### PR TITLE
Upgrade actions/cache from v2 to v3.0.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.CONNECT_DEPLOY_KEY }}
       - name: Cache
-        uses: actions/cache@v3.0.1
+        uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-connect-crosstest-ci-${{ hashFiles('**/go.sum') }}


### PR DESCRIPTION
The Github Action for configuring private repo access does not seem to like Dependabot, which makes sense since Dependabot is likely not a bufbuild org user.

This supercedes: https://github.com/bufbuild/connect-crosstest/pull/16