### PR TITLE
Small clean-up

### DIFF
--- a/internal/console/console.go
+++ b/internal/console/console.go
@@ -17,6 +17,7 @@ package console
 
 import (
 	"log"
+	"os"
 )
 
 type TB struct{}
@@ -37,4 +38,8 @@ func (t *TB) Fatalf(format string, args ...any) {
 
 func (t *TB) Successf(format string, args ...any) {
 	log.Printf("SUCCESS: "+format, args...)
+}
+
+func (t *TB) FailNow() {
+	os.Exit(1)
 }

--- a/internal/testing/cross.go
+++ b/internal/testing/cross.go
@@ -41,3 +41,7 @@ func (t *t) Fatalf(format string, args ...any) {
 func (t *t) Successf(format string, args ...any) {
 	t.internal.Logf(format, args...)
 }
+
+func (t *t) FailNow() {
+	t.internal.FailNow()
+}

--- a/internal/testing/testing.go
+++ b/internal/testing/testing.go
@@ -22,4 +22,5 @@ type TB interface {
 	Errorf(string, ...any)
 	Fatalf(string, ...any)
 	Successf(string, ...any)
+	FailNow()
 }


### PR DESCRIPTION
- Do not panic/log.Fatalf on test failures.
- Add back context deadline for timeout on sleeping server.
