### PR TITLE
Remove connect deploy key from CI workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,6 @@ jobs:
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: |
-            ${{ secrets.CONNECT_DEPLOY_KEY }}
             ${{ secrets.CONNECT_WEB_DEPLOY_KEY }}
             ${{ secrets.PROTOBUF_ES_DEPLOY_KEY }}
       - name: Cache


### PR DESCRIPTION
Now that connect-go is public, we no longer need the deploy key
for our Github Actions CI workflows.
