### PR TITLE
Add Access-Control-Expose-Headers preflight response header

### DIFF
--- a/web/src/test-case.tsx
+++ b/web/src/test-case.tsx
@@ -32,7 +32,7 @@ const TestCase: React.FC<TestCaseProps> = (props: TestCaseProps) => {
       setData("fail");
       console.log(`Test ${name} failed: ${e}`);
     });
-  });
+  }, []);
   return (
     <tr>
       <td>{name}</td>


### PR DESCRIPTION
Otherwise, connect-web cannot read the Grpc-Status-Details-Bin response header.