### PR TITLE
Add a bit of styling to connect-web tests

### DIFF
--- a/web/src/test-case.module.css
+++ b/web/src/test-case.module.css
@@ -1,0 +1,4 @@
+.td {
+  padding: 0.75rem; /* p-3 */
+  border: 1px solid black;
+}

--- a/web/src/test-case.tsx
+++ b/web/src/test-case.tsx
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import * as React from "react";
+import classes from "./test-case.module.css";
 
 interface TestCaseProps {
   name: string;
@@ -35,8 +36,8 @@ const TestCase: React.FC<TestCaseProps> = (props: TestCaseProps) => {
   }, []);
   return (
     <tr>
-      <td>{name}</td>
-      <td>{data}</td>
+      <td className={classes.td}>{name}</td>
+      <td className={classes.td}>{data}</td>
     </tr>
   );
 };

--- a/web/src/test-cases.module.css
+++ b/web/src/test-cases.module.css
@@ -1,0 +1,10 @@
+.table {
+  margin: 1.25rem; /* m-5 */
+  border-collapse: collapse;
+  border-style: hidden;
+}
+
+.th {
+  text-align: left;
+  padding: 0.75rem; /* p-3 */
+}

--- a/web/src/test-cases.tsx
+++ b/web/src/test-cases.tsx
@@ -26,6 +26,7 @@ import {
 import { SimpleRequest } from "../gen/proto/connect-web/grpc/testing/messages_pb";
 import * as React from "react";
 import { ClientInterceptor } from "@bufbuild/connect-web/dist/types/client-interceptor";
+import classes from "./test-cases.module.css";
 
 interface TestCasesProps {
   host: string;
@@ -39,7 +40,11 @@ const TestCases: React.FC<TestCasesProps> = (props: TestCasesProps) => {
   });
   const client = makePromiseClient(TestService, transport);
   return (
-    <table>
+    <table className={classes.table}>
+      <tr>
+        <th className={classes.th}>Test Case</th>
+        <th className={classes.th}>Result</th>
+      </tr>
       <TestCase
         name="empty_unary"
         testFunc={async () => {


### PR DESCRIPTION
This adds the bare minimum amount of styling to make the `connect-web` tests.

<img width="369" alt="Screen Shot 2022-04-25 at 16 15 30" src="https://user-images.githubusercontent.com/9167065/165168041-9d86d412-60a4-4bbd-8d33-69c195f9e2bf.png">

