### PR TITLE
Exclude soak tests from crosstest cron

### DIFF
--- a/.github/workflows/crosstest.yaml
+++ b/.github/workflows/crosstest.yaml
@@ -33,7 +33,8 @@ jobs:
           restore-keys: ${{ runner.os }}-connect-crosstest-ci-
           # upgrades all dependencies to latest version
       - name: Upgrade and Test
-        run: make upgrade && make test
+        # we don't need the soak tests for this job, we only need the base interop functionality
+        run: make upgrade && make shorttest
         env:
           GOPRIVATE: github.com/bufbuild
       - name: Open Issue on Fail


### PR DESCRIPTION
We want to test the interop functionality for the latest version of `connect-go` on a regular basis,
but we don't need to run the soak tests, which behave more like benchmarks. We should exclude
them from the regular run of crosstest.

Fixes #46