### PR TITLE
Use Active LTS version of Node

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # We would like to manage this manually and use the Active LTS for Node.
+      - dependency-name: "node"
+        versions: ["17.x", "18.x"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/Dockerfile.crosstestweb
+++ b/Dockerfile.crosstestweb
@@ -1,4 +1,4 @@
-FROM node:17-alpine
+FROM node:16-alpine
 
 WORKDIR /workspace
 


### PR DESCRIPTION
We want to stick with the Active LTS version of node, so we're going to ignore versions greater than that and manage this manually.