### PR TITLE
Move CI workflows to use docker-compose for crosstests and fix Makefile

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,11 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
+      - name: Setup Docker Buildx # Docker Buildkit required for docker-compose
+        uses: docker/setup-buildx-action@v1
+        with:
+          driver: docker
+          install: true
       # TODO: Remove when connect-web is public.
       - name: Configure Private Repo Access
         uses: webfactory/ssh-agent@v0.5.4
@@ -40,11 +45,13 @@ jobs:
           key: ${{ runner.os }}-connect-crosstest-ci-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-connect-crosstest-ci-
       - name: Test
-        run: make test && make checkgenerate
+        run: make test-docker-compose # Make target includes clean-up
         env:
           GOPRIVATE: github.com/bufbuild
+          DOCKER_BUILDKIT: 1
+          COMPOSE_DOCKER_CLI_BUILD: 1
       - name: Lint
         # Often, lint & gofmt guidelines depend on the Go version. To prevent
         # conflicting guidance, run only on the most recent supported version.
         if: matrix.latest
-        run: make lint
+        run: make lint && make checkgenerate

--- a/.github/workflows/crosstest.yaml
+++ b/.github/workflows/crosstest.yaml
@@ -18,6 +18,11 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: '1.18.1'
+      - name: Setup Docker Buildx # Docker Buildkit required for docker-compose
+        uses: docker/setup-buildx-action@v1
+        with:
+          driver: docker
+          install: true
       # TODO: Remove when connect-web is public.
       - name: Configure Private Repo Access
         uses: webfactory/ssh-agent@v0.5.4
@@ -34,9 +39,11 @@ jobs:
           # upgrades all dependencies to latest version
       - name: Upgrade and Test
         # we don't need the soak tests for this job, we only need the base interop functionality
-        run: make upgrade && make shorttest
+        run: make upgrade && make test-docker-compose # Make target includes clean-up
         env:
           GOPRIVATE: github.com/bufbuild
+          DOCKER_BUILDKIT: 1
+          COMPOSE_DOCKER_CLI_BUILD: 1
       - name: Open Issue on Fail
         uses: dblock/create-a-github-issue@v3
         if: failure()

--- a/Makefile
+++ b/Makefile
@@ -116,11 +116,11 @@ docker-compose-clean:
 	docker-compose down --rmi local --remove-orphans
 
 test-docker-compose: docker-compose-clean
-	docker-compose run client-connect-to-connect
-	docker-compose run client-connect-to-grpc
-	docker-compose run client-grpc-to-connect
-	docker-compose run client-grpc-to-grpc
-	docker-compose run client-grpc-web-to-connect-h1
-	docker-compose run client-grpc-web-to-envoy-connect
-	docker-compose run client-grpc-web-to-envoy-grpc
+	docker-compose run client-connect-to-server-connect
+	docker-compose run client-connect-to-server-grpc
+	docker-compose run client-grpc-to-server-connect
+	docker-compose run client-grpc-to-server-grpc
+	docker-compose run client-grpc-web-to-server-connect-h1
+	docker-compose run client-grpc-web-to-envoy-server-connect
+	docker-compose run client-grpc-web-to-envoy-server-grpc
 	$(MAKE) docker-compose-clean


### PR DESCRIPTION
This uses our `docker-compose` workflow for both our CI and nightly crosstests.