### PR TITLE
Fix flakiness from DoTimeoutOnSleepingServer

### DIFF
--- a/internal/interop/connect/test_cases.go
+++ b/internal/interop/connect/test_cases.go
@@ -196,6 +196,7 @@ func DoTimeoutOnSleepingServer(t testing.TB, client connectpb.TestServiceClient)
 		// the stream has already timed out before the `Send` and so this would
 		// return a EOF.
 		assert.True(t, errors.Is(err, io.EOF))
+		return
 	}
 	require.NoError(t, err)
 	_, err = stream.Receive()


### PR DESCRIPTION
This adds a check similar to the check for the `grpc-go` test case, where the stream could have timed out before `Send`, in which case, we would be expecting a `EOF` error in the case of `connect-go`.