### PR TITLE
add empty stream tests in connect-web and grpc-web

### DIFF
--- a/web/spec/connect-web.callback.spec.ts
+++ b/web/spec/connect-web.callback.spec.ts
@@ -101,6 +101,21 @@ describe("connect_web_callback_client", function () {
       }
     );
   });
+  // TODO: enable this test when we have a fix on connect-web
+  xit("empty_stream", function (done) {
+    client.streamingOutputCall(
+      {
+        responseParameters: [],
+      },
+      () => {
+        fail("expecting no response in the empty stream");
+      },
+      (err) => {
+        expect(err).toBeUndefined();
+        done();
+      }
+    );
+  });
   it("custom_metadata", function (done) {
     const doneFn = multiDone(done, 3);
     // TODO: adjust this test once we land on the API for reading response headers and trailers

--- a/web/spec/connect-web.promise.spec.ts
+++ b/web/spec/connect-web.promise.spec.ts
@@ -72,6 +72,18 @@ describe("connect_web_promise_client", function () {
     }
     expect(responseCount).toEqual(sizes.length);
   });
+  // TODO: enable this test when we have a fix on connect-web
+  xit("empty_stream", async function () {
+    try {
+      for await (const response of await client.streamingOutputCall({
+        responseParameters: [],
+      })) {
+        fail(`expecting no response in the empty stream, got: ${response}`);
+      }
+    } catch (e) {
+      fail(`expecting no error in the empty stream, got: ${e}`);
+    }
+  });
   it("custom_metadata", async function () {
     // TODO: adjust this test once we land on the API for reading response headers and trailers
     const size = 314159;

--- a/web/spec/grpc-web.spec.ts
+++ b/web/spec/grpc-web.spec.ts
@@ -107,6 +107,19 @@ describe("grpc_web", function () {
       doneFn();
     });
   });
+  it("empty_stream", function (done) {
+    const req = new StreamingOutputCallRequest();
+    const call = client.streamingOutputCall(req, {});
+    call.on("data", (data) => {
+      fail(`expecting no response in the empty stream, got: ${data}`);
+    });
+    call.on("error", (err) => {
+      fail(`expecting no error in the empty stream, got: ${err}`);
+    });
+    call.on("end", () => {
+      done();
+    });
+  });
   it("custom_metadata", function (done) {
     const doneFn = multiDone(done, 3);
     const size = 314159;
@@ -215,12 +228,12 @@ describe("grpc_web", function () {
     });
   });
   it("fail_unary", function (done) {
-    client.failUnaryCall(new SimpleRequest(), null, (err)=>{
+    client.failUnaryCall(new SimpleRequest(), null, (err) => {
       expect(err).toBeDefined();
       expect("code" in err).toBeTrue();
       expect(err.code).toEqual(8);
       expect(err.message).toEqual("soirée 🎉");
       done();
-    })
+    });
   });
 });


### PR DESCRIPTION
fixes TCN-56
with connect-web tests excluded with `xit`