### PR TITLE
add unresolvable host test in connect-h2 and grpc-go

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ a range of expected behaviours and functionality for gRPC and Connect.
 | `duplicated_custom_metadata` | :ballot_box_with_check: | |
 | `status_code_and_message` | :ballot_box_with_check: | :ballot_box_with_check: |
 | `special_status_message` | :ballot_box_with_check: | :ballot_box_with_check: |
-| `unimplemented_method` | :ballot_box_with_check: |
+| `unimplemented_method` | :ballot_box_with_check: | :ballot_box_with_check: |
 | `unimplemented_service` | :ballot_box_with_check: | :ballot_box_with_check: |
+| `unresolvable_host` | :ballot_box_with_check: | |
 
 ### Test Descriptions
 
@@ -166,6 +167,11 @@ RPC: N/A
 
 Client calls an unimplemented service and expects an error with the status `UNIMPLEMENTED`.
 
+**unresolvable_host**:
+
+RPC: N/A
+
+Client calls an unresolvable host and expects an error with the status `UNAVAILABLE`.
 
 ## Requirements and Running the Tests
 

--- a/internal/interop/connect/test_cases.go
+++ b/internal/interop/connect/test_cases.go
@@ -462,6 +462,18 @@ func DoFailWithNonASCIIError(t testing.TB, client connectpb.TestServiceClient, a
 	t.Successf("successful fail call with non-ASCII error")
 }
 
+// DoUnresolvableHost attempts to call a method to an unresolvable host.
+func DoUnresolvableHost(t testing.TB, client connectpb.TestServiceClient, args ...grpc.CallOption) {
+	reply, err := client.EmptyCall(
+		context.Background(),
+		connect.NewRequest(&testpb.Empty{}),
+	)
+	assert.Nil(t, reply)
+	assert.Error(t, err)
+	assert.Equal(t, connect.CodeOf(err), connect.CodeUnavailable)
+	t.Successf("successful fail call with unresolvable call")
+}
+
 func doOneSoakIteration(ctx context.Context, t testing.TB, tc connectpb.TestServiceClient, resetChannel bool, serverAddr string) (latency time.Duration, err error) {
 	start := time.Now()
 	client := tc

--- a/internal/interop/grpc/test_cases.go
+++ b/internal/interop/grpc/test_cases.go
@@ -438,6 +438,15 @@ func DoFailWithNonASCIIError(t testing.TB, client testpb.TestServiceClient, args
 	t.Successf("successful fail call with non-ASCII error")
 }
 
+// DoUnresolvableHost attempts to call a method to an unresolvable host.
+func DoUnresolvableHost(t testing.TB, client testpb.TestServiceClient, args ...grpc.CallOption) {
+	reply, err := client.EmptyCall(context.Background(), &testpb.Empty{}, args...)
+	assert.Nil(t, reply)
+	assert.Error(t, err)
+	assert.Equal(t, status.Code(err), codes.Unavailable)
+	t.Successf("successful fail call with unresolvable call")
+}
+
 func doOneSoakIteration(ctx context.Context, t testing.TB, tc testpb.TestServiceClient, resetChannel bool, serverAddr string, dopts []grpc.DialOption) (latency time.Duration, err error) {
 	start := time.Now()
 	client := tc


### PR DESCRIPTION
fixes TCN-85

grpc-web doesn't handle this case, so I think it makes sense to just skip this test for connect-web and grpc-web