### PR TITLE
add compression test

### DIFF
--- a/cmd/server/servergrpc/main.go
+++ b/cmd/server/servergrpc/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	_ "google.golang.org/grpc/encoding/gzip" // this register the gzip compressor to the grpc server
 	"google.golang.org/protobuf/encoding/protojson"
 )
 

--- a/internal/interop/grpc/test_cases.go
+++ b/internal/interop/grpc/test_cases.go
@@ -407,16 +407,16 @@ func DoSpecialStatusMessage(t testing.TB, client testpb.TestServiceClient, args 
 }
 
 // DoUnimplementedService attempts to call a method from an unimplemented service.
-func DoUnimplementedService(t testing.TB, client testpb.UnimplementedServiceClient) {
-	_, err := client.UnimplementedCall(context.Background(), &testpb.Empty{})
+func DoUnimplementedService(t testing.TB, client testpb.UnimplementedServiceClient, args ...grpc.CallOption) {
+	_, err := client.UnimplementedCall(context.Background(), &testpb.Empty{}, args...)
 	assert.Equal(t, status.Code(err), codes.Unimplemented)
 	t.Successf("successful unimplemented service")
 }
 
 // DoUnimplementedMethod attempts to call an unimplemented method.
-func DoUnimplementedMethod(t testing.TB, cc *grpc.ClientConn) {
+func DoUnimplementedMethod(t testing.TB, cc *grpc.ClientConn, args ...grpc.CallOption) {
 	var req, reply proto.Message
-	err := cc.Invoke(context.Background(), "/grpc.testing.TestService/UnimplementedCall", req, reply)
+	err := cc.Invoke(context.Background(), "/grpc.testing.TestService/UnimplementedCall", req, reply, args...)
 	assert.Error(t, err)
 	assert.Equal(t, status.Code(err), codes.Unimplemented)
 	t.Successf("successful unimplemented method")
@@ -428,6 +428,7 @@ func DoFailWithNonASCIIError(t testing.TB, client testpb.TestServiceClient, args
 		&testpb.SimpleRequest{
 			ResponseType: testpb.PayloadType_COMPRESSABLE,
 		},
+		args...,
 	)
 	assert.Nil(t, reply)
 	assert.Error(t, err)


### PR DESCRIPTION
Fixes TCN-89

this add the compression test using `gzip`

we didn't implement the compression test in the interop test (e.g. `client_compressed_unary`) as `grpc-go` didn't expose `grpc-encoding` or other method/ field for application to determine if the request is compressed (although you can with `connect-go` by looking for the `grpc-encoding` header), therefore we duplicated the tests with compress option instead