### PR TITLE
Clean-up flakey timeout test case

### DIFF
--- a/internal/interop/connect/test_cases.go
+++ b/internal/interop/connect/test_cases.go
@@ -192,10 +192,10 @@ func DoTimeoutOnSleepingServer(t testing.TB, client connectpb.TestServiceClient)
 	}
 	err = stream.Send(req)
 	if err != nil {
-		// This emulates the original test case, where due to network issues,
+		// This emulates the gRPC test case, where due to network issues,
 		// the stream has already timed out before the `Send` and so this would
 		// return a EOF.
-		assert.True(t, errors.Is(err, io.EOF))
+		assert.True(t, errors.Is(err, io.EOF) || connect.CodeOf(err) == connect.CodeDeadlineExceeded)
 		t.Successf("successful timeout on sleep")
 		return
 	}

--- a/internal/interop/grpc/test_cases.go
+++ b/internal/interop/grpc/test_cases.go
@@ -196,8 +196,9 @@ func DoTimeoutOnSleepingServer(t testing.TB, client testpb.TestServiceClient, ar
 	defer cancel()
 	stream, err := client.FullDuplexCall(ctx, args...)
 	if err != nil {
+		// This checks if the stream has already timed out before the `Send`, so we would
+		// receive a DeadlineExceeded error from the initial call to the bidi streaming RPC.
 		if status.Code(err) == codes.DeadlineExceeded {
-			// This emulates the original test case.
 			return
 		}
 	}


### PR DESCRIPTION
This adds an extra check for a deadline exceeded error
if the context in the timeout test times out _before_ `Send`.
This should reduce the flakiness of the timeout test.
