### PR TITLE
Add Docker Compose V2 instructions to README and Contribution guide

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,13 +16,16 @@ you to accept the CLA when you open your pull request.
 
 ## Setup
 
+Install Docker on your machine and ensure that [Docker Compose V2 is
+enabled][docker-compose-v2].
+
 [Fork][fork], then clone the repository:
 
 ```
 mkdir -p $GOPATH/src/github.com/bufbuild
 cd $GOPATH/src/github.com/bufbuild
 git clone git@github.com:your_github_username/connect-crosstest.git
-cd connect
+cd connect-crosstest
 git remote add upstream https://github.com/bufbuild/connect-crosstest.git
 git fetch upstream
 ```
@@ -72,3 +75,4 @@ We're much more likely to approve your changes if you:
 [open-issue]: https://github.com/bufbuild/connect-crosstest/issues/new
 [cla]: TODO
 [commit-message]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
+[docker-compose-v2]: https://www.docker.com/blog/announcing-compose-v2-general-availability/#still-using-compose-v1

--- a/README.md
+++ b/README.md
@@ -188,6 +188,9 @@ test against a development branch of any of these packages.
 ### Locally
 
 To run these locally tests, you'll need Docker. The test suite uses Docker Compose.
+Please note, that if you are running the tests on MacOS, you'll need to [enable Docker
+Compose V2][docker-compose-v2].
+
 You can run the tests using `make test-docker-compose`.
 
 To run the tests against the latest commits of `connect-go` and `connect-web` (instead of the
@@ -231,3 +234,4 @@ Offered under the [Apache 2 license][license].
 [license]: https://github.com/bufbuild/connect-crosstest/blob/main/LICENSE.txt
 [test.proto]: https://github.com/bufbuild/connect-crosstest/blob/main/internal/proto/grpc/testing/test.proto
 [github-action]: https://github.com/bufbuild/connect-crosstest/actions/workflows/crosstest.yaml
+[docker-compose-v2]: https://www.docker.com/blog/announcing-compose-v2-general-availability/#still-using-compose-v1


### PR DESCRIPTION
This adds instructions from the Docker docs to enable Docker Compose V2
for running crosstests locally.
