### PR TITLE
Check context error on all Connect server streaming RPCs

### DIFF
--- a/internal/interop/connect/server.go
+++ b/internal/interop/connect/server.go
@@ -115,6 +115,9 @@ func (s *testServer) StreamingOutputCall(ctx context.Context, args *connect.Requ
 func (s *testServer) StreamingInputCall(ctx context.Context, stream *connect.ClientStream[testpb.StreamingInputCallRequest, testpb.StreamingInputCallResponse]) error {
 	var sum int
 	for stream.Receive() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		p := stream.Msg().GetPayload().GetBody()
 		sum += len(p)
 	}
@@ -179,6 +182,9 @@ func (s *testServer) FullDuplexCall(ctx context.Context, stream *connect.BidiStr
 func (s *testServer) HalfDuplexCall(ctx context.Context, stream *connect.BidiStream[testpb.StreamingOutputCallRequest, testpb.StreamingOutputCallResponse]) error {
 	var msgBuf []*testpb.StreamingOutputCallRequest
 	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		req, err := stream.Receive()
 		if errors.Is(err, io.EOF) {
 			// read done.


### PR DESCRIPTION
Currently we are not checking the context error
in all of our streaming APIs. And while this has worked
with our test cases so far, this is not a realistic implementation
for the test server.
This adds context error checks in all of our streaming RPCs
for the Connect server implementation. It does not change
any of the test case implementation nor should it affect any
test cases.
