### PR TITLE
fix docker build platform

### DIFF
--- a/Dockerfile.crosstest
+++ b/Dockerfile.crosstest
@@ -1,4 +1,4 @@
-FROM golang:1.18.2-alpine3.15 as builder
+FROM --platform=${BUILDPLATFORM} golang:1.18.2-alpine3.15 as builder
 
 WORKDIR /workspace
 


### PR DESCRIPTION
reproduced locally and this should fix the failed CI build. This is missed as we didn't need it by the time we added the dockerfile.