### PR TITLE
Upgrade `connect-go` and use new client streaming API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/bufbuild/connect-crosstest
 go 1.18
 
 require (
-	github.com/bufbuild/connect-go v0.0.0-20220520175512-2b3d3442ffb8
+	github.com/bufbuild/connect-go v0.0.0-20220527041454-159c8011dfbb
 	github.com/golang/protobuf v1.5.2
 	github.com/lucas-clemente/quic-go v0.27.0
 	github.com/rs/cors v1.8.2

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/bufbuild/connect-go v0.0.0-20220520175512-2b3d3442ffb8 h1:ZaD9cVYESl0sBAvcpmSO4wRbOSwS32F5wNPrnDw1XdE=
 github.com/bufbuild/connect-go v0.0.0-20220520175512-2b3d3442ffb8/go.mod h1:BajZGyRXK+Oq6Ddkm7atQ1Tu4W92OMpam7vyhFIf0ww=
+github.com/bufbuild/connect-go v0.0.0-20220527041454-159c8011dfbb h1:zC8B/lIdSoTEyMrkRFXB5iIeTgYp+dYQkOBkPNxXMxw=
+github.com/bufbuild/connect-go v0.0.0-20220527041454-159c8011dfbb/go.mod h1:BajZGyRXK+Oq6Ddkm7atQ1Tu4W92OMpam7vyhFIf0ww=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=

--- a/internal/gen/proto/connect/grpc/testing/testingconnect/test.connect.go
+++ b/internal/gen/proto/connect/grpc/testing/testingconnect/test.connect.go
@@ -215,7 +215,7 @@ type TestServiceHandler interface {
 	StreamingOutputCall(context.Context, *connect_go.Request[testing.StreamingOutputCallRequest], *connect_go.ServerStream[testing.StreamingOutputCallResponse]) error
 	// A sequence of requests followed by one response (streamed upload).
 	// The server returns the aggregated size of client payload as the result.
-	StreamingInputCall(context.Context, *connect_go.ClientStream[testing.StreamingInputCallRequest, testing.StreamingInputCallResponse]) error
+	StreamingInputCall(context.Context, *connect_go.ClientStream[testing.StreamingInputCallRequest]) (*connect_go.Response[testing.StreamingInputCallResponse], error)
 	// A sequence of requests with each request served by the server immediately.
 	// As one request could lead to multiple responses, this interface
 	// demonstrates the idea of full duplexing.
@@ -308,8 +308,8 @@ func (UnimplementedTestServiceHandler) StreamingOutputCall(context.Context, *con
 	return connect_go.NewError(connect_go.CodeUnimplemented, errors.New("grpc.testing.TestService.StreamingOutputCall is not implemented"))
 }
 
-func (UnimplementedTestServiceHandler) StreamingInputCall(context.Context, *connect_go.ClientStream[testing.StreamingInputCallRequest, testing.StreamingInputCallResponse]) error {
-	return connect_go.NewError(connect_go.CodeUnimplemented, errors.New("grpc.testing.TestService.StreamingInputCall is not implemented"))
+func (UnimplementedTestServiceHandler) StreamingInputCall(context.Context, *connect_go.ClientStream[testing.StreamingInputCallRequest]) (*connect_go.Response[testing.StreamingInputCallResponse], error) {
+	return nil, connect_go.NewError(connect_go.CodeUnimplemented, errors.New("grpc.testing.TestService.StreamingInputCall is not implemented"))
 }
 
 func (UnimplementedTestServiceHandler) FullDuplexCall(context.Context, *connect_go.BidiStream[testing.StreamingOutputCallRequest, testing.StreamingOutputCallResponse]) error {

--- a/internal/interop/connect/server.go
+++ b/internal/interop/connect/server.go
@@ -112,23 +112,23 @@ func (s *testServer) StreamingOutputCall(ctx context.Context, args *connect.Requ
 	return nil
 }
 
-func (s *testServer) StreamingInputCall(ctx context.Context, stream *connect.ClientStream[testpb.StreamingInputCallRequest, testpb.StreamingInputCallResponse]) error {
+func (s *testServer) StreamingInputCall(ctx context.Context, stream *connect.ClientStream[testpb.StreamingInputCallRequest]) (*connect.Response[testpb.StreamingInputCallResponse], error) {
 	var sum int
 	for stream.Receive() {
 		if err := ctx.Err(); err != nil {
-			return err
+			return nil, err
 		}
 		p := stream.Msg().GetPayload().GetBody()
 		sum += len(p)
 	}
 	if err := stream.Err(); err != nil {
-		return err
+		return nil, err
 	}
-	return stream.SendAndClose(connect.NewResponse(
+	return connect.NewResponse(
 		&testpb.StreamingInputCallResponse{
 			AggregatedPayloadSize: int32(sum),
 		},
-	))
+	), nil
 }
 
 func (s *testServer) FullDuplexCall(ctx context.Context, stream *connect.BidiStream[testpb.StreamingOutputCallRequest, testpb.StreamingOutputCallResponse]) error {


### PR DESCRIPTION
There was an update to `connect-go`'s client streaming API, so
this pulls in the `connect-go` update and makes the necessary
changes to the Connect server implementation.
Fixes #124
