### PR TITLE
Fix c++ conformance run

### DIFF
--- a/Dockerfile.conformancecc
+++ b/Dockerfile.conformancecc
@@ -1,9 +1,5 @@
 FROM --platform=arm64 gcr.io/bazel-public/bazel
 
-ARG PORT
-ARG HOST
-ARG CERT_FILE
-ARG KEY_FILE
 WORKDIR /workspace
 COPY WORKSPACE.bazel .bazelrc /workspace/
 COPY cc /workspace/cc

--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,8 @@ dockercomposetestweb: dockercomposeclean
 .PHONY: dockercomposetestcc
 dockercomposetestcc: dockercomposeclean
 	docker-compose run client-cc-grpc-to-server-connect-go-h2-no-tls
+	@# TLS does not seem to be working with current certs
+	@# docker-compose run client-cc-grpc-to-server-connect-go-h2-with-tls
 	$(MAKE) dockercomposeclean
 
 .PHONY: dockercomposetest

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,6 @@ dockercomposetestweb: dockercomposeclean
 
 .PHONY: dockercomposetestcc
 dockercomposetestcc: dockercomposeclean
-	docker-compose run client-cc-grpc-to-server-connect-go-h2-no-tls
 	docker-compose run client-cc-grpc-to-server-connect-go-h2-with-tls
 	$(MAKE) dockercomposeclean
 

--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,7 @@ dockercomposetestweb: dockercomposeclean
 .PHONY: dockercomposetestcc
 dockercomposetestcc: dockercomposeclean
 	docker-compose run client-cc-grpc-to-server-connect-go-h2-no-tls
+	docker-compose run client-cc-grpc-to-server-connect-node-fastify-h2-no-tls
 	@# TLS does not seem to be working with current certs
 	@# docker-compose run client-cc-grpc-to-server-connect-go-h2-with-tls
 	$(MAKE) dockercomposeclean

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ dockercomposetestweb: dockercomposeclean
 
 .PHONY: dockercomposetestcc
 dockercomposetestcc: dockercomposeclean
-	docker-compose run client-cc-grpc-to-server-connect-go-h2-no-tls
+	docker-compose run client-cc-grpc-to-server-connect-go-h2-with-tls
 	$(MAKE) dockercomposeclean
 
 .PHONY: dockercomposetest

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ dockercomposetestweb: dockercomposeclean
 
 .PHONY: dockercomposetestcc
 dockercomposetestcc: dockercomposeclean
-	docker-compose run client-cc-grpc-to-server-connect-go-h2-with-tls
+	docker-compose run client-cc-grpc-to-server-connect-go-h2-no-tls
 	$(MAKE) dockercomposeclean
 
 .PHONY: dockercomposetest

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,6 @@ dockercomposetestweb: dockercomposeclean
 .PHONY: dockercomposetestcc
 dockercomposetestcc: dockercomposeclean
 	docker-compose run client-cc-grpc-to-server-connect-go-h2-no-tls
-	docker-compose run client-cc-grpc-to-server-connect-node-fastify-h2-no-tls
 	@# TLS does not seem to be working with current certs
 	@# docker-compose run client-cc-grpc-to-server-connect-go-h2-with-tls
 	$(MAKE) dockercomposeclean

--- a/cc/BUILD.bazel
+++ b/cc/BUILD.bazel
@@ -23,6 +23,7 @@ cc_test(
         "@com_google_googleapis//google/rpc:status_cc_proto",
         "@com_google_googletest//:gtest_main",
     ],
+    data = ["//cert:client_certs"],
 )
 
 cc_library(

--- a/cc/grpc_client_test.cc
+++ b/cc/grpc_client_test.cc
@@ -93,7 +93,7 @@ class GrpcClientTest : public ::testing::Test {
       channel = grpc::CreateChannel(
           uri,
           grpc::SslCredentials(grpc::SslCredentialsOptions{
-              .pem_root_certs = certFile.str(),
+              .pem_root_certs = certBuffer.str(),
               .pem_private_key = keyBuffer.str(),
           }));
     } else {

--- a/cc/grpc_client_test.cc
+++ b/cc/grpc_client_test.cc
@@ -97,8 +97,8 @@ class GrpcClientTest : public ::testing::Test {
       channel = grpc::CreateChannel(
           host + ":" + port,
           grpc::SslCredentials(grpc::SslCredentialsOptions{
-              .pem_cert_chain = certBuffer.str(),
               .pem_private_key = keyBuffer.str(),
+              .pem_cert_chain = certBuffer.str(),
           }));
     } else {
       channel = grpc::CreateChannel(host + ":" + port, grpc::InsecureChannelCredentials());

--- a/cc/grpc_client_test.cc
+++ b/cc/grpc_client_test.cc
@@ -97,7 +97,7 @@ class GrpcClientTest : public ::testing::Test {
       channel = grpc::CreateChannel(
           host + ":" + port,
           grpc::SslCredentials(grpc::SslCredentialsOptions{
-              .pem_root_certs = certBuffer.str(),
+              .pem_cert_chain = certBuffer.str(),
               .pem_private_key = keyBuffer.str(),
           }));
     } else {

--- a/cc/grpc_client_test.cc
+++ b/cc/grpc_client_test.cc
@@ -68,13 +68,15 @@ class GrpcClientTest : public ::testing::Test {
     // Get the port from the env
     std::string port = getEnvStr("PORT");
     if (port.empty()) {
-      port = "8081";
+      port = "3001";
     }
     // Get the host from the env
     std::string host = getEnvStr("HOST", "127.0.0.1");
     // Get the insecure cert from the env
     std::string certFile = getEnvStr("CERT_FILE");
     std::string keyFile = getEnvStr("KEY_FILE");
+
+    std::cout << certFile;
     if (!certFile.empty() || !keyFile.empty()) {
       channel = grpc::CreateChannel(
           host + ":" + port,

--- a/cc/grpc_client_test.cc
+++ b/cc/grpc_client_test.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <fstream>
 #include <memory>
 #include <string>
 
@@ -68,21 +69,36 @@ class GrpcClientTest : public ::testing::Test {
     // Get the port from the env
     std::string port = getEnvStr("PORT");
     if (port.empty()) {
-      port = "3001";
+      port = "8081";
     }
     // Get the host from the env
     std::string host = getEnvStr("HOST", "127.0.0.1");
+
+    std::cout << "Connect to host " << host << "and port " << port;
     // Get the insecure cert from the env
     std::string certFile = getEnvStr("CERT_FILE");
     std::string keyFile = getEnvStr("KEY_FILE");
 
-    std::cout << certFile;
-    if (!certFile.empty() || !keyFile.empty()) {
+
+    if (!certFile.empty() && !keyFile.empty()) {
+      std::cout << "Reading certs";
+      std::ifstream c(certFile);
+      std::ifstream k(keyFile);
+      std::stringstream certBuffer;
+      std::stringstream keyBuffer;
+
+      certBuffer << c.rdbuf();
+      keyBuffer << k.rdbuf();
+      std::cout << "Cert Buffer is \n";
+      std::cout << certBuffer.str();
+      std::cout << "Key Buffer is \n";
+      std::cout << keyBuffer.str();
+      std::cout << "Fini";
       channel = grpc::CreateChannel(
           host + ":" + port,
           grpc::SslCredentials(grpc::SslCredentialsOptions{
-              .pem_root_certs = certFile,
-              .pem_private_key = keyFile,
+              .pem_root_certs = certBuffer.str(),
+              .pem_private_key = keyBuffer.str(),
           }));
     } else {
       channel = grpc::CreateChannel(host + ":" + port, grpc::InsecureChannelCredentials());

--- a/cert/BUILD.bazel
+++ b/cert/BUILD.bazel
@@ -1,0 +1,5 @@
+filegroup(
+    name = "client_certs",
+    srcs = ["client.crt", "client.key"],
+    visibility = ["//visibility:public"],
+)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
       dockerfile: Dockerfile.conformancego
       args:
         TEST_CONNECT_GO_BRANCH: "${TEST_CONNECT_GO_BRANCH:-}"
-    entrypoint: /usr/local/bin/serverconnect --h1port "8080" --h2port "8081" --h3port "8082" --insecure
+    entrypoint: /usr/local/bin/serverconnect --h1port "8080" --h2port "8081" --insecure
     ports:
       - "8080:8080"
       - "8081:8081"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,10 +7,6 @@ services:
       args:
         TEST_CONNECT_GO_BRANCH: "${TEST_CONNECT_GO_BRANCH:-}"
     entrypoint: /usr/local/bin/serverconnect --h1port "8080" --h2port "8081" --h3port "8082" --cert "cert/server-connect.crt" --key "cert/server-connect.key"
-    healthcheck:
-      test: [ "CMD", "nc", "-z", "localhost", "8081" ]
-      interval: 3s
-      timeout: 10s
     ports:
       - "8080:8080"
       - "8081:8081"
@@ -385,9 +381,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.conformancecc
-      args:
-        PORT: 8081
-        HOST: server-connect-insecure
     entrypoint: bazel test //cc:grpc_client_test --test_output=errors --action_env=HOST=server-connect-insecure --action_env=PORT=8081
     depends_on:
       - server-connect-insecure
@@ -395,11 +388,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.conformancecc
-      args:
-        PORT: 8081
-        HOST: server-connect
-        CERT_FILE: cert/client.crt
-        KEY_FILE: cert/client.key
-    entrypoint: bazel test //cc:grpc_client_test --test_output=errors --action_env=HOST=server-connect  --action_env=PORT=8081 --action_env=CERT_FILE=cert/client.crt --action_env=KEY_FILE=cert/client.key --action_env=GRPC_DNS_RESOLVER=native
+    entrypoint: bazel test //cc:grpc_client_test --test_output=errors --action_env=HOST=server-connect  --action_env=PORT=8081 --action_env=CERT_FILE=cert/client.crt --action_env=KEY_FILE=cert/client.key
     depends_on:
       - server-connect

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -388,7 +388,7 @@ services:
       args:
         PORT: 8081
         HOST: server-connect-insecure
-    entrypoint: bazel test //cc:grpc_client_test --test_output=errors
+    entrypoint: bazel test //cc:grpc_client_test --test_output=errors --action_env=HOST  --action_env=PORT
     depends_on:
       - server-connect-insecure
   client-cc-grpc-to-server-connect-go-h2-with-tls:
@@ -400,6 +400,6 @@ services:
         HOST: server-connect
         CERT_FILE: cert/client.crt
         KEY_FILE: cert/client.key
-    entrypoint: bazel test //cc:grpc_client_test --test_output=errors
+    entrypoint: bazel test //cc:grpc_client_test --test_output=errors --action_env=HOST  --action_env=PORT --action_env=CERT_FILE --action_env=KEY_FILE
     depends_on:
       - server-connect

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -388,7 +388,7 @@ services:
       args:
         PORT: 8081
         HOST: server-connect-insecure
-    entrypoint: bazel test //cc:grpc_client_test --test_output=errors --action_env=HOST=server-connect-insecure  --action_env=PORT=8081
+    entrypoint: bazel test //cc:grpc_client_test --test_output=errors --action_env=HOST=server-connect-insecure --action_env=PORT=8081 --action_env=GRPC_DNS_RESOLVER=native
     depends_on:
       - server-connect-insecure
   client-cc-grpc-to-server-connect-go-h2-with-tls:
@@ -400,6 +400,6 @@ services:
         HOST: server-connect
         CERT_FILE: cert/client.crt
         KEY_FILE: cert/client.key
-    entrypoint: bazel test //cc:grpc_client_test --test_output=errors --action_env=HOST=server-connect  --action_env=PORT=8081 --action_env=CERT_FILE=cert/client.crt --action_env=KEY_FILE=cert/client.key
+    entrypoint: bazel test //cc:grpc_client_test --test_output=errors --action_env=HOST=server-connect  --action_env=PORT=8081 --action_env=CERT_FILE=cert/client.crt --action_env=KEY_FILE=cert/client.key --action_env=GRPC_DNS_RESOLVER=native
     depends_on:
       - server-connect

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,6 +15,17 @@ services:
       - "8080:8080"
       - "8081:8081"
       - "8082:8082"
+  server-connect-insecure:
+    build:
+      context: .
+      dockerfile: Dockerfile.conformancego
+      args:
+        TEST_CONNECT_GO_BRANCH: "${TEST_CONNECT_GO_BRANCH:-}"
+    entrypoint: /usr/local/bin/serverconnect --h1port "8080" --h2port "8081" --h3port "8082" --insecure
+    ports:
+      - "8080:8080"
+      - "8081:8081"
+      - "8082:8082"
   server-grpc:
     build:
       context: .
@@ -376,10 +387,10 @@ services:
       dockerfile: Dockerfile.conformancecc
       args:
         PORT: 8081
-        HOST: server-connect
+        HOST: server-connect-insecure
     entrypoint: bazel test //cc:grpc_client_test --test_output=errors
     depends_on:
-      - server-connect
+      - server-connect-insecure
   client-cc-grpc-to-server-connect-go-h2-with-tls:
     build:
       context: .
@@ -391,5 +402,4 @@ services:
         KEY_FILE: cert/client.key
     entrypoint: bazel test //cc:grpc_client_test --test_output=errors
     depends_on:
-      server-connect:
-        condition: service_healthy
+      - server-connect

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -391,11 +391,3 @@ services:
     entrypoint: bazel test //cc:grpc_client_test --test_output=errors --action_env=HOST=server-connect  --action_env=PORT=8081 --action_env=CERT_FILE=cert/client.crt --action_env=KEY_FILE=cert/client.key
     depends_on:
       - server-connect
-  client-cc-grpc-to-server-connect-node-fastify-h2-no-tls:
-    build:
-      context: .
-      dockerfile: Dockerfile.conformancecc
-    entrypoint: bazel test //cc:grpc_client_test --test_output=errors --action_env=HOST=server-connect-node-fastify  --action_env=PORT=8087
-    depends_on:
-      server-connect-node-fastify:
-        condition: service_healthy

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -391,3 +391,11 @@ services:
     entrypoint: bazel test //cc:grpc_client_test --test_output=errors --action_env=HOST=server-connect  --action_env=PORT=8081 --action_env=CERT_FILE=cert/client.crt --action_env=KEY_FILE=cert/client.key
     depends_on:
       - server-connect
+  client-cc-grpc-to-server-connect-node-fastify-h2-no-tls:
+    build:
+      context: .
+      dockerfile: Dockerfile.conformancecc
+    entrypoint: bazel test //cc:grpc_client_test --test_output=errors --action_env=HOST=server-connect-node-fastify  --action_env=PORT=8087
+    depends_on:
+      server-connect-node-fastify:
+        condition: service_healthy

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,6 +7,10 @@ services:
       args:
         TEST_CONNECT_GO_BRANCH: "${TEST_CONNECT_GO_BRANCH:-}"
     entrypoint: /usr/local/bin/serverconnect --h1port "8080" --h2port "8081" --h3port "8082" --cert "cert/server-connect.crt" --key "cert/server-connect.key"
+    healthcheck:
+      test: [ "CMD", "nc", "-z", "localhost", "8081" ]
+      interval: 3s
+      timeout: 10s
     ports:
       - "8080:8080"
       - "8081:8081"
@@ -387,4 +391,5 @@ services:
         KEY_FILE: cert/client.key
     entrypoint: bazel test //cc:grpc_client_test --test_output=errors
     depends_on:
-      - server-connect
+      server-connect:
+        condition: service_healthy

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -388,7 +388,7 @@ services:
       args:
         PORT: 8081
         HOST: server-connect-insecure
-    entrypoint: bazel test //cc:grpc_client_test --test_output=errors --action_env=HOST=server-connect-insecure --action_env=PORT=8081 --action_env=GRPC_DNS_RESOLVER=native
+    entrypoint: bazel test //cc:grpc_client_test --test_output=errors --action_env=HOST=server-connect-insecure --action_env=PORT=8081
     depends_on:
       - server-connect-insecure
   client-cc-grpc-to-server-connect-go-h2-with-tls:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -388,7 +388,7 @@ services:
       args:
         PORT: 8081
         HOST: server-connect-insecure
-    entrypoint: bazel test //cc:grpc_client_test --test_output=errors --action_env=HOST  --action_env=PORT
+    entrypoint: bazel test //cc:grpc_client_test --test_output=errors --action_env=HOST=server-connect-insecure  --action_env=PORT=8081
     depends_on:
       - server-connect-insecure
   client-cc-grpc-to-server-connect-go-h2-with-tls:
@@ -400,6 +400,6 @@ services:
         HOST: server-connect
         CERT_FILE: cert/client.crt
         KEY_FILE: cert/client.key
-    entrypoint: bazel test //cc:grpc_client_test --test_output=errors --action_env=HOST  --action_env=PORT --action_env=CERT_FILE --action_env=KEY_FILE
+    entrypoint: bazel test //cc:grpc_client_test --test_output=errors --action_env=HOST=server-connect  --action_env=PORT=8081 --action_env=CERT_FILE=cert/client.crt --action_env=KEY_FILE=cert/client.key
     depends_on:
       - server-connect

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -373,7 +373,7 @@ services:
       args:
         PORT: 8081
         HOST: server-connect
-    entrypoint: bazel test //cc:grpc_client_test
+    entrypoint: bazel test //cc:grpc_client_test --test_output=errors
     depends_on:
       - server-connect
   client-cc-grpc-to-server-connect-go-h2-with-tls:
@@ -385,6 +385,6 @@ services:
         HOST: server-connect
         CERT_FILE: cert/client.crt
         KEY_FILE: cert/client.key
-    entrypoint: bazel test //cc:grpc_client_test
+    entrypoint: bazel test //cc:grpc_client_test --test_output=errors
     depends_on:
       - server-connect


### PR DESCRIPTION
This makes some fixes to the C++ conformance test run. Namely:

* Stands up an insecure Connect-Go server so that the path without TLS can be tested properly. Now, the 'no TLS' test will use the insecure server.
* Pass env vars via Bazel rather than Docker since the bazel command is being run in the container. The previous command invocation was not making those env vars accessible to Bazel.
* Use the `CERT_FILE` and `KEY_FILE` values to read the cert file contents and pass those to the gRPC channel. 

Note though that the certs do not seem to be working and are showing the following error, so they have been temporarily commented out.

```
E0908 22:52:33.431680247   10972 ssl_transport_security.cc:1420]       Handshake failed with fatal error SSL_ERROR_SSL: error:1000007d:SSL routines:OPENSSL_internal:CERTIFICATE_VERIFY_FAILED.
```