### PR TITLE
Update copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 Buf Technologies, Inc.
+   Copyright 2022 The Connect Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ MAKEFLAGS += --warn-undefined-variables
 MAKEFLAGS += --no-builtin-rules
 MAKEFLAGS += --no-print-directory
 BIN := .tmp/bin
-COPYRIGHT_YEARS := 2022
+COPYRIGHT_YEARS := 2022-2023
 LICENSE_IGNORE := -e proto/grpc -e internal/interopgrpc -e web/spec/grpc-web.spec.ts -e web/server/fastify/program.ts
 # Set to use a different compiler. For example, `GO=go1.18rc1 make test`.
 GO ?= go
@@ -68,7 +68,7 @@ generate: $(BIN)/buf $(BIN)/protoc-gen-go $(BIN)/protoc-gen-connect-go $(BIN)/pr
 		<(git ls-files --deleted | sort -u) | \
 		xargs $(BIN)/license-header \
 			--license-type apache \
-			--copyright-holder "Buf Technologies, Inc." \
+			--copyright-holder "The Connect Authors" \
 			--year-range "$(COPYRIGHT_YEARS)"
 
 .PHONY: upgrade

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -1,4 +1,4 @@
-# Copyright 2022 Buf Technologies, Inc.
+# Copyright 2022-2023 The Connect Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cc/BUILD.bazel
+++ b/cc/BUILD.bazel
@@ -1,4 +1,4 @@
-# Copyright 2022 Buf Technologies, Inc.
+# Copyright 2022-2023 The Connect Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cc/gen/connectrpc/conformance/v1/messages.grpc.pb.cc
+++ b/cc/gen/connectrpc/conformance/v1/messages.grpc.pb.cc
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cc/gen/connectrpc/conformance/v1/messages.grpc.pb.h
+++ b/cc/gen/connectrpc/conformance/v1/messages.grpc.pb.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cc/gen/connectrpc/conformance/v1/messages.pb.cc
+++ b/cc/gen/connectrpc/conformance/v1/messages.pb.cc
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cc/gen/connectrpc/conformance/v1/messages.pb.h
+++ b/cc/gen/connectrpc/conformance/v1/messages.pb.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cc/gen/connectrpc/conformance/v1/test.grpc.pb.cc
+++ b/cc/gen/connectrpc/conformance/v1/test.grpc.pb.cc
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cc/gen/connectrpc/conformance/v1/test.grpc.pb.h
+++ b/cc/gen/connectrpc/conformance/v1/test.grpc.pb.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cc/gen/connectrpc/conformance/v1/test.pb.cc
+++ b/cc/gen/connectrpc/conformance/v1/test.pb.cc
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cc/gen/connectrpc/conformance/v1/test.pb.h
+++ b/cc/gen/connectrpc/conformance/v1/test.pb.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cc/gen/server/v1/server.grpc.pb.cc
+++ b/cc/gen/server/v1/server.grpc.pb.cc
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cc/gen/server/v1/server.grpc.pb.h
+++ b/cc/gen/server/v1/server.grpc.pb.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cc/gen/server/v1/server.pb.cc
+++ b/cc/gen/server/v1/server.pb.cc
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cc/gen/server/v1/server.pb.h
+++ b/cc/gen/server/v1/server.pb.h
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cc/grpc_client_test.cc
+++ b/cc/grpc_client_test.cc
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cert/BUILD.bazel
+++ b/cert/BUILD.bazel
@@ -1,3 +1,17 @@
+# Copyright 2022-2023 The Connect Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 filegroup(
     name = "client_certs",
     srcs = ["client.crt", "client.key"],

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/serverconnect/main.go
+++ b/cmd/serverconnect/main.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/servergrpc/main.go
+++ b/cmd/servergrpc/main.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/conformancetesting/conformancetesting.go
+++ b/internal/conformancetesting/conformancetesting.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/conformancetesting/tb.go
+++ b/internal/conformancetesting/tb.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/console/console.go
+++ b/internal/console/console.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/gen/proto/connect/connectrpc/conformance/v1/conformancev1connect/test.connect.go
+++ b/internal/gen/proto/connect/connectrpc/conformance/v1/conformancev1connect/test.connect.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/gen/proto/go/connectrpc/conformance/v1/messages.pb.go
+++ b/internal/gen/proto/go/connectrpc/conformance/v1/messages.pb.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/gen/proto/go/connectrpc/conformance/v1/test.pb.go
+++ b/internal/gen/proto/go/connectrpc/conformance/v1/test.pb.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/gen/proto/go/connectrpc/conformance/v1/test_grpc.pb.go
+++ b/internal/gen/proto/go/connectrpc/conformance/v1/test_grpc.pb.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/gen/proto/go/server/v1/server.pb.go
+++ b/internal/gen/proto/go/server/v1/server.pb.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/interop/interop.go
+++ b/internal/interop/interop.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/interop/interopconnect/test_cases.go
+++ b/internal/interop/interopconnect/test_cases.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/interop/interopconnect/test_server.go
+++ b/internal/interop/interopconnect/test_server.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/interop/interopconnect/trailers.go
+++ b/internal/interop/interopconnect/trailers.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/interop/interopgrpc/test_cases.go
+++ b/internal/interop/interopgrpc/test_cases.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/interop/interopgrpc/test_server.go
+++ b/internal/interop/interopgrpc/test_server.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/proto/connectrpc/conformance/v1/BUILD.bazel
+++ b/proto/connectrpc/conformance/v1/BUILD.bazel
@@ -1,4 +1,4 @@
-# Copyright 2022 Buf Technologies, Inc.
+# Copyright 2022-2023 The Connect Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/proto/connectrpc/conformance/v1/messages.proto
+++ b/proto/connectrpc/conformance/v1/messages.proto
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/proto/connectrpc/conformance/v1/test.proto
+++ b/proto/connectrpc/conformance/v1/test.proto
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/proto/server/v1/server.proto
+++ b/proto/server/v1/server.proto
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/web/gen/proto/connect-web/connectrpc/conformance/v1/messages_pb.ts
+++ b/web/gen/proto/connect-web/connectrpc/conformance/v1/messages_pb.ts
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/web/gen/proto/connect-web/connectrpc/conformance/v1/test_connect.ts
+++ b/web/gen/proto/connect-web/connectrpc/conformance/v1/test_connect.ts
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/web/gen/proto/connect-web/server/v1/server_pb.ts
+++ b/web/gen/proto/connect-web/server/v1/server_pb.ts
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/web/karma.conf.js
+++ b/web/karma.conf.js
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/web/server/fastify/server.ts
+++ b/web/server/fastify/server.ts
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/web/server/interop.ts
+++ b/web/server/interop.ts
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/web/server/routes.ts
+++ b/web/server/routes.ts
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/web/spec/connect-web.callback.spec.ts
+++ b/web/spec/connect-web.callback.spec.ts
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/web/spec/connect-web.promise.spec.ts
+++ b/web/spec/connect-web.promise.spec.ts
@@ -1,4 +1,4 @@
-// Copyright 2022 Buf Technologies, Inc.
+// Copyright 2022-2023 The Connect Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
- Update to use "The Connect Authors" instead of "Buf Technologies, Inc."
- Update copyright years from 2022 to 2022-2023