### PR TITLE
V2: Load test cases from embedded test suite data

### DIFF
--- a/internal/app/connectconformance/test_case_library.go
+++ b/internal/app/connectconformance/test_case_library.go
@@ -1,0 +1,228 @@
+// Copyright 2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connectconformance
+
+import (
+	"errors"
+	"fmt"
+	"path"
+	"sort"
+
+	conformancev1alpha1 "connectrpc.com/conformance/internal/gen/proto/go/connectrpc/conformance/v1alpha1"
+	"github.com/bufbuild/protoyaml-go"
+	"google.golang.org/protobuf/proto"
+)
+
+//nolint:gochecknoglobals
+var (
+	allProtocols    = allValues[conformancev1alpha1.Protocol](conformancev1alpha1.Protocol_name)
+	allHTTPVersions = allValues[conformancev1alpha1.HTTPVersion](conformancev1alpha1.HTTPVersion_name)
+	allCodecs       = allValues[conformancev1alpha1.Codec](conformancev1alpha1.Codec_name)
+	allCompressions = allValues[conformancev1alpha1.Compression](conformancev1alpha1.Compression_name)
+	allStreamTypes  = allValues[conformancev1alpha1.StreamType](conformancev1alpha1.StreamType_name)
+)
+
+// testCaseLibrary is the set of all applicable test cases for a run
+// of the conformance tests.
+type testCaseLibrary struct {
+	testCases     map[string]*conformancev1alpha1.TestCase
+	casesByServer map[serverInstance][]*conformancev1alpha1.TestCase
+}
+
+// loadTestCases applies the given test suite configuration to the given
+// config cases that are applicable to the current run of conformance tests.
+func loadTestCases(
+	allSuites map[string]*conformancev1alpha1.TestSuite,
+	configCases []configCase,
+	mode conformancev1alpha1.TestSuite_TestMode,
+) (*testCaseLibrary, error) {
+	configCaseSet := make(map[configCase]struct{}, len(configCases))
+	for _, c := range configCases {
+		configCaseSet[c] = struct{}{}
+	}
+	lib := &testCaseLibrary{
+		testCases: map[string]*conformancev1alpha1.TestCase{},
+	}
+	suitesIndex := make(map[string]string, len(allSuites))
+	for file, suite := range allSuites {
+		if suite.Name == "" {
+			return nil, fmt.Errorf("%s defines a suite with no name", file)
+		}
+		if len(suite.TestCases) == 0 {
+			return nil, fmt.Errorf("%s defines a suite %s that has no test cases", file, suite.Name)
+		}
+		if existingFile, exists := suitesIndex[suite.Name]; exists {
+			return nil, fmt.Errorf("both %s and %s define a suite named %s", file, existingFile, suite.Name)
+		}
+		suitesIndex[suite.Name] = file
+		if suite.Mode != conformancev1alpha1.TestSuite_TEST_MODE_UNSPECIFIED && suite.Mode != mode {
+			continue // skip it
+		}
+		if err := lib.expandSuite(suite, configCaseSet); err != nil {
+			return nil, err
+		}
+	}
+
+	if len(lib.testCases) == 0 {
+		return nil, errors.New("no test cases apply to current configuration")
+	}
+	lib.groupTestCases()
+	return lib, nil
+}
+
+func (lib *testCaseLibrary) expandSuite(suite *conformancev1alpha1.TestSuite, configCases map[configCase]struct{}) error {
+	protocols := suite.RelevantProtocols
+	if len(protocols) == 0 {
+		protocols = allProtocols
+	}
+	for _, protocol := range protocols {
+		httpVersions := suite.RelevantHttpVersions
+		if len(httpVersions) == 0 {
+			httpVersions = allHTTPVersions
+		}
+		for _, httpVersion := range httpVersions {
+			codecs := suite.RelevantCodecs
+			if len(codecs) == 0 {
+				codecs = allCodecs
+			}
+			for _, codec := range codecs {
+				compressions := suite.RelevantCompressions
+				if len(compressions) == 0 {
+					compressions = allCompressions
+				}
+				for _, compression := range compressions {
+					for _, streamType := range allStreamTypes {
+						cfgCase := configCase{
+							Version:            httpVersion,
+							Protocol:           protocol,
+							Codec:              codec,
+							Compression:        compression,
+							StreamType:         streamType,
+							UseTLS:             suite.ReliesOnTls,
+							UseConnectGET:      suite.ReliesOnConnectGet,
+							ConnectVersionMode: suite.ConnectVersionMode,
+						}
+						if _, ok := configCases[cfgCase]; ok {
+							namePrefix := generateTestCasePrefix(suite, cfgCase)
+							if err := lib.expandCases(cfgCase, namePrefix, suite.TestCases); err != nil {
+								return err
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (lib *testCaseLibrary) expandCases(cfgCase configCase, namePrefix []string, testCases []*conformancev1alpha1.TestCase) error {
+	for _, testCase := range testCases {
+		if testCase.Request.StreamType != cfgCase.StreamType {
+			continue
+		}
+		name := path.Join(append(namePrefix, testCase.Request.TestName)...)
+		if _, exists := lib.testCases[name]; exists {
+			return fmt.Errorf("test case library includes duplicate definition for %v", name)
+		}
+		testCase := proto.Clone(testCase).(*conformancev1alpha1.TestCase) //nolint:errcheck,forcetypeassert
+		testCase.Request.TestName = name
+		if cfgCase.UseTLS {
+			// to be replaced with actual cert provided by server
+			testCase.Request.ServerTlsCert = []byte("PLACEHOLDER")
+		}
+		testCase.Request.HttpVersion = cfgCase.Version
+		testCase.Request.Protocol = cfgCase.Protocol
+		testCase.Request.Codec = cfgCase.Codec
+		testCase.Request.Compression = cfgCase.Compression
+		lib.testCases[name] = testCase
+	}
+	return nil
+}
+
+func (lib *testCaseLibrary) groupTestCases() {
+	lib.casesByServer = map[serverInstance][]*conformancev1alpha1.TestCase{}
+	for _, testCase := range lib.testCases {
+		svr := serverInstanceForCase(testCase)
+		lib.casesByServer[svr] = append(lib.casesByServer[svr], testCase)
+	}
+}
+
+// serverInstance identifies the properties of a server process, so tests
+// can be grouped by target server process.
+type serverInstance struct {
+	protocol    conformancev1alpha1.Protocol
+	httpVersion conformancev1alpha1.HTTPVersion
+	useTLS      bool
+}
+
+func serverInstanceForCase(testCase *conformancev1alpha1.TestCase) serverInstance {
+	return serverInstance{
+		protocol:    testCase.Request.Protocol,
+		httpVersion: testCase.Request.HttpVersion,
+		useTLS:      len(testCase.Request.ServerTlsCert) > 0,
+	}
+}
+
+// parseTestSuites processes the given file contents. The given map is keyed
+// by test file name. Each entry's value is the contents of the named file.
+// The given argument often represents the embedded test suite data. Also
+// see testsuites.LoadTestSuites.
+func parseTestSuites(testFileData map[string][]byte) (map[string]*conformancev1alpha1.TestSuite, error) {
+	allSuites := make(map[string]*conformancev1alpha1.TestSuite, len(testFileData))
+	for testFilePath, data := range testFileData {
+		opts := protoyaml.UnmarshalOptions{
+			Path: testFilePath,
+		}
+		suite := &conformancev1alpha1.TestSuite{}
+		if err := opts.Unmarshal(data, suite); err != nil {
+			return nil, err
+		}
+		allSuites[testFilePath] = suite
+	}
+	return allSuites, nil
+}
+
+func generateTestCasePrefix(suite *conformancev1alpha1.TestSuite, cfgCase configCase) []string {
+	components := make([]string, 1, 5)
+	components = append(components, suite.Name)
+	if len(suite.RelevantHttpVersions) != 1 {
+		components = append(components, fmt.Sprintf("HTTPVersion:%d", cfgCase.Version))
+	}
+	if len(suite.RelevantProtocols) != 1 {
+		components = append(components, fmt.Sprintf("Protocol:%s", cfgCase.Protocol))
+	}
+	if len(suite.RelevantCodecs) != 1 {
+		components = append(components, fmt.Sprintf("Codec:%s", cfgCase.Codec))
+	}
+	if len(suite.RelevantCompressions) != 1 {
+		components = append(components, fmt.Sprintf("Compression:%s", cfgCase.Compression))
+	}
+	return components
+}
+
+func allValues[T ~int32](m map[int32]string) []T {
+	vals := make([]T, 0, len(m))
+	for k := range m {
+		if k == 0 {
+			continue
+		}
+		vals = append(vals, T(k))
+	}
+	sort.Slice(vals, func(i, j int) bool {
+		return vals[i] < vals[j]
+	})
+	return vals
+}

--- a/internal/app/connectconformance/test_case_library_test.go
+++ b/internal/app/connectconformance/test_case_library_test.go
@@ -1,0 +1,292 @@
+// Copyright 2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connectconformance
+
+import (
+	"sort"
+	"testing"
+
+	"connectrpc.com/conformance/internal/app/connectconformance/testsuites"
+	conformancev1alpha1 "connectrpc.com/conformance/internal/gen/proto/go/connectrpc/conformance/v1alpha1"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadTestCases(t *testing.T) {
+	t.Parallel()
+
+	testData := map[string]string{
+		"basic.yaml": `
+                    name: Basic
+                    testCases:
+                      - request:
+                            testName: basic-unary
+                            streamType: STREAM_TYPE_UNARY
+                      - request:
+                            testName: basic-client-stream
+                            streamType: STREAM_TYPE_CLIENT_STREAM
+                      - request:
+                            testName: basic-server-stream
+                            streamType: STREAM_TYPE_SERVER_STREAM
+                      - request:
+                            testName: basic-bidi-stream
+                            streamType: STREAM_TYPE_FULL_DUPLEX_BIDI_STREAM`,
+		"tls.yaml": `
+                    name: TLS
+                    reliesOnTls: true
+                    testCases:
+                      - request:
+                            testName: tls-unary
+                            streamType: STREAM_TYPE_UNARY
+                      - request:
+                            testName: tls-client-stream
+                            streamType: STREAM_TYPE_CLIENT_STREAM
+                      - request:
+                            testName: tls-server-stream
+                            streamType: STREAM_TYPE_SERVER_STREAM
+                      - request:
+                            testName: tls-bidi-stream
+                            streamType: STREAM_TYPE_FULL_DUPLEX_BIDI_STREAM`,
+		"connect-get.yaml": `
+                    name: Connect GET
+                    relevantProtocols: [PROTOCOL_CONNECT]
+                    reliesOnConnectGet: true
+                    testCases:
+                      - request:
+                            testName: connect-get-unary
+                            streamType: STREAM_TYPE_UNARY`,
+		"connect-version-client-required.yaml": `
+                    name: Connect Version Required (client)
+                    mode: TEST_MODE_CLIENT
+                    relevantProtocols: [PROTOCOL_CONNECT]
+                    connectVersionMode: CONNECT_VERSION_MODE_REQUIRE
+                    testCases:
+                      - request:
+                            testName: unary-without-connect-version-header
+                            streamType: STREAM_TYPE_UNARY`,
+		"connect-version-server-required.yaml": `
+                    name: Connect Version Required (server)
+                    mode: TEST_MODE_SERVER
+                    relevantProtocols: [PROTOCOL_CONNECT]
+                    connectVersionMode: CONNECT_VERSION_MODE_REQUIRE
+                    testCases:
+                      - request:
+                            testName: unary-without-connect-version-header
+                            streamType: STREAM_TYPE_UNARY`,
+		"connect-version-client-not-required.yaml": `
+                    name: Connect Version Optional (client)
+                    mode: TEST_MODE_CLIENT
+                    relevantProtocols: [PROTOCOL_CONNECT]
+                    connectVersionMode: CONNECT_VERSION_MODE_IGNORE
+                    testCases:
+                      - request:
+                            testName: unary-without-connect-version-header
+                            streamType: STREAM_TYPE_UNARY`,
+		"connect-version-server-not-required.yaml": `
+                    name: Connect Version Optional (server)
+                    mode: TEST_MODE_SERVER
+                    relevantProtocols: [PROTOCOL_CONNECT]
+                    connectVersionMode: CONNECT_VERSION_MODE_IGNORE
+                    testCases:
+                      - request:
+                            testName: unary-without-connect-version-header
+                            streamType: STREAM_TYPE_UNARY`,
+	}
+	testSuiteData := make(map[string][]byte, len(testData))
+	for k, v := range testData {
+		testSuiteData[k] = []byte(v)
+	}
+	testSuites, err := parseTestSuites(testSuiteData)
+	require.NoError(t, err)
+
+	// there is some repetition, but we want them to be able to
+	// vary and evolve independently, so we won't consolidate
+	//nolint:dupl
+	testCases := []struct {
+		name   string
+		config []configCase
+		mode   conformancev1alpha1.TestSuite_TestMode
+		cases  map[serverInstance][]string
+	}{
+		{
+			name: "client mode",
+			config: []configCase{
+				{
+					Version:     conformancev1alpha1.HTTPVersion_HTTP_VERSION_1,
+					Protocol:    conformancev1alpha1.Protocol_PROTOCOL_CONNECT,
+					Codec:       conformancev1alpha1.Codec_CODEC_PROTO,
+					Compression: conformancev1alpha1.Compression_COMPRESSION_IDENTITY,
+					StreamType:  conformancev1alpha1.StreamType_STREAM_TYPE_UNARY,
+				},
+				{
+					Version:     conformancev1alpha1.HTTPVersion_HTTP_VERSION_1,
+					Protocol:    conformancev1alpha1.Protocol_PROTOCOL_CONNECT,
+					Codec:       conformancev1alpha1.Codec_CODEC_PROTO,
+					Compression: conformancev1alpha1.Compression_COMPRESSION_IDENTITY,
+					StreamType:  conformancev1alpha1.StreamType_STREAM_TYPE_UNARY,
+					UseTLS:      true,
+				},
+				{
+					Version:       conformancev1alpha1.HTTPVersion_HTTP_VERSION_1,
+					Protocol:      conformancev1alpha1.Protocol_PROTOCOL_CONNECT,
+					Codec:         conformancev1alpha1.Codec_CODEC_PROTO,
+					Compression:   conformancev1alpha1.Compression_COMPRESSION_IDENTITY,
+					StreamType:    conformancev1alpha1.StreamType_STREAM_TYPE_UNARY,
+					UseConnectGET: true,
+				},
+				{
+					Version:            conformancev1alpha1.HTTPVersion_HTTP_VERSION_1,
+					Protocol:           conformancev1alpha1.Protocol_PROTOCOL_CONNECT,
+					Codec:              conformancev1alpha1.Codec_CODEC_PROTO,
+					Compression:        conformancev1alpha1.Compression_COMPRESSION_IDENTITY,
+					StreamType:         conformancev1alpha1.StreamType_STREAM_TYPE_UNARY,
+					ConnectVersionMode: conformancev1alpha1.TestSuite_CONNECT_VERSION_MODE_REQUIRE,
+				},
+				{
+					Version:     conformancev1alpha1.HTTPVersion_HTTP_VERSION_2,
+					Protocol:    conformancev1alpha1.Protocol_PROTOCOL_GRPC,
+					Codec:       conformancev1alpha1.Codec_CODEC_PROTO,
+					Compression: conformancev1alpha1.Compression_COMPRESSION_IDENTITY,
+					StreamType:  conformancev1alpha1.StreamType_STREAM_TYPE_FULL_DUPLEX_BIDI_STREAM,
+				},
+			},
+			mode: conformancev1alpha1.TestSuite_TEST_MODE_CLIENT,
+			cases: map[serverInstance][]string{
+				{
+					protocol:    conformancev1alpha1.Protocol_PROTOCOL_CONNECT,
+					httpVersion: conformancev1alpha1.HTTPVersion_HTTP_VERSION_1,
+					useTLS:      false,
+				}: {
+					"Basic/HTTPVersion:1/Protocol:PROTOCOL_CONNECT/Codec:CODEC_PROTO/Compression:COMPRESSION_IDENTITY/basic-unary",
+					"Connect GET/HTTPVersion:1/Codec:CODEC_PROTO/Compression:COMPRESSION_IDENTITY/connect-get-unary",
+					"Connect Version Required (client)/HTTPVersion:1/Codec:CODEC_PROTO/Compression:COMPRESSION_IDENTITY/unary-without-connect-version-header",
+				},
+				{
+					protocol:    conformancev1alpha1.Protocol_PROTOCOL_CONNECT,
+					httpVersion: conformancev1alpha1.HTTPVersion_HTTP_VERSION_1,
+					useTLS:      true,
+				}: {
+					"TLS/HTTPVersion:1/Protocol:PROTOCOL_CONNECT/Codec:CODEC_PROTO/Compression:COMPRESSION_IDENTITY/tls-unary",
+				},
+				{
+					protocol:    conformancev1alpha1.Protocol_PROTOCOL_GRPC,
+					httpVersion: conformancev1alpha1.HTTPVersion_HTTP_VERSION_2,
+					useTLS:      false,
+				}: {
+					"Basic/HTTPVersion:2/Protocol:PROTOCOL_GRPC/Codec:CODEC_PROTO/Compression:COMPRESSION_IDENTITY/basic-bidi-stream",
+				},
+			},
+		},
+
+		{
+			name: "server mode",
+			config: []configCase{
+				{
+					Version:     conformancev1alpha1.HTTPVersion_HTTP_VERSION_1,
+					Protocol:    conformancev1alpha1.Protocol_PROTOCOL_CONNECT,
+					Codec:       conformancev1alpha1.Codec_CODEC_PROTO,
+					Compression: conformancev1alpha1.Compression_COMPRESSION_IDENTITY,
+					StreamType:  conformancev1alpha1.StreamType_STREAM_TYPE_UNARY,
+				},
+				{
+					Version:     conformancev1alpha1.HTTPVersion_HTTP_VERSION_1,
+					Protocol:    conformancev1alpha1.Protocol_PROTOCOL_CONNECT,
+					Codec:       conformancev1alpha1.Codec_CODEC_PROTO,
+					Compression: conformancev1alpha1.Compression_COMPRESSION_IDENTITY,
+					StreamType:  conformancev1alpha1.StreamType_STREAM_TYPE_UNARY,
+					UseTLS:      true,
+				},
+				{
+					Version:       conformancev1alpha1.HTTPVersion_HTTP_VERSION_1,
+					Protocol:      conformancev1alpha1.Protocol_PROTOCOL_CONNECT,
+					Codec:         conformancev1alpha1.Codec_CODEC_PROTO,
+					Compression:   conformancev1alpha1.Compression_COMPRESSION_IDENTITY,
+					StreamType:    conformancev1alpha1.StreamType_STREAM_TYPE_UNARY,
+					UseConnectGET: true,
+				},
+				{
+					Version:            conformancev1alpha1.HTTPVersion_HTTP_VERSION_1,
+					Protocol:           conformancev1alpha1.Protocol_PROTOCOL_CONNECT,
+					Codec:              conformancev1alpha1.Codec_CODEC_PROTO,
+					Compression:        conformancev1alpha1.Compression_COMPRESSION_IDENTITY,
+					StreamType:         conformancev1alpha1.StreamType_STREAM_TYPE_UNARY,
+					ConnectVersionMode: conformancev1alpha1.TestSuite_CONNECT_VERSION_MODE_IGNORE,
+				},
+				{
+					Version:     conformancev1alpha1.HTTPVersion_HTTP_VERSION_2,
+					Protocol:    conformancev1alpha1.Protocol_PROTOCOL_GRPC,
+					Codec:       conformancev1alpha1.Codec_CODEC_PROTO,
+					Compression: conformancev1alpha1.Compression_COMPRESSION_IDENTITY,
+					StreamType:  conformancev1alpha1.StreamType_STREAM_TYPE_FULL_DUPLEX_BIDI_STREAM,
+				},
+			},
+			mode: conformancev1alpha1.TestSuite_TEST_MODE_SERVER,
+			cases: map[serverInstance][]string{
+				{
+					protocol:    conformancev1alpha1.Protocol_PROTOCOL_CONNECT,
+					httpVersion: conformancev1alpha1.HTTPVersion_HTTP_VERSION_1,
+					useTLS:      false,
+				}: {
+					"Basic/HTTPVersion:1/Protocol:PROTOCOL_CONNECT/Codec:CODEC_PROTO/Compression:COMPRESSION_IDENTITY/basic-unary",
+					"Connect GET/HTTPVersion:1/Codec:CODEC_PROTO/Compression:COMPRESSION_IDENTITY/connect-get-unary",
+					"Connect Version Optional (server)/HTTPVersion:1/Codec:CODEC_PROTO/Compression:COMPRESSION_IDENTITY/unary-without-connect-version-header",
+				},
+				{
+					protocol:    conformancev1alpha1.Protocol_PROTOCOL_CONNECT,
+					httpVersion: conformancev1alpha1.HTTPVersion_HTTP_VERSION_1,
+					useTLS:      true,
+				}: {
+					"TLS/HTTPVersion:1/Protocol:PROTOCOL_CONNECT/Codec:CODEC_PROTO/Compression:COMPRESSION_IDENTITY/tls-unary",
+				},
+				{
+					protocol:    conformancev1alpha1.Protocol_PROTOCOL_GRPC,
+					httpVersion: conformancev1alpha1.HTTPVersion_HTTP_VERSION_2,
+					useTLS:      false,
+				}: {
+					"Basic/HTTPVersion:2/Protocol:PROTOCOL_GRPC/Codec:CODEC_PROTO/Compression:COMPRESSION_IDENTITY/basic-bidi-stream",
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			testCaseLib, err := loadTestCases(testSuites, testCase.config, testCase.mode)
+			require.NoError(t, err)
+			results := make(map[serverInstance][]string, len(testCaseLib.casesByServer))
+			for svrKey, testCaseProtos := range testCaseLib.casesByServer {
+				names := make([]string, len(testCaseProtos))
+				for i, testCaseProto := range testCaseProtos {
+					names[i] = testCaseProto.Request.TestName
+				}
+				sort.Strings(names)
+				results[svrKey] = names
+			}
+			require.Empty(t, cmp.Diff(testCase.cases, results), "- wanted; + got")
+		})
+	}
+}
+
+func TestParseTestSuites_EmbeddedTestSuites(t *testing.T) {
+	t.Parallel()
+	testSuiteData, err := testsuites.LoadTestSuites()
+	require.NoError(t, err)
+	allSuites, err := parseTestSuites(testSuiteData)
+	require.NoError(t, err)
+	_ = allSuites
+	// TODO: basic assertions about the embedded test suites
+}

--- a/internal/app/connectconformance/testsuites/basic.yaml
+++ b/internal/app/connectconformance/testsuites/basic.yaml
@@ -1,0 +1,3 @@
+name: Basic
+# TODO: define test cases
+testCases: []

--- a/internal/app/connectconformance/testsuites/testsuites.go
+++ b/internal/app/connectconformance/testsuites/testsuites.go
@@ -1,0 +1,56 @@
+// Copyright 2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package testsuites contains embedded test suite data used when running
+// conformance tests. While it is possible to point the test runner at
+// other files, by default, it will use the test cases embedded in this
+// package. This package embeds all *.yaml files in this folder.
+package testsuites
+
+import (
+	"embed"
+	"fmt"
+	"io/fs"
+	"path"
+	"strings"
+)
+
+//go:embed *.yaml
+var testSuiteFS embed.FS
+
+// LoadTestSuites returns a file system and a slice of file names that
+// represent the embedded corpus of test suites. The file name are the
+// names of test suite YAML files, and the returned file system can be
+// used to read their contents.
+func LoadTestSuites() (map[string][]byte, error) {
+	testSuites := map[string][]byte{}
+	err := fs.WalkDir(testSuiteFS, ".", func(currentPath string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() || strings.ToLower(path.Ext(entry.Name())) != ".yaml" {
+			return nil
+		}
+		data, err := testSuiteFS.ReadFile(currentPath)
+		if err != nil {
+			return fmt.Errorf("failed to load test suite date file %s: %w", currentPath, err)
+		}
+		testSuites[currentPath] = data
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return testSuites, nil
+}

--- a/internal/app/connectconformance/testsuites/testsuites.go
+++ b/internal/app/connectconformance/testsuites/testsuites.go
@@ -44,7 +44,7 @@ func LoadTestSuites() (map[string][]byte, error) {
 		}
 		data, err := testSuiteFS.ReadFile(currentPath)
 		if err != nil {
-			return fmt.Errorf("failed to load test suite date file %s: %w", currentPath, err)
+			return fmt.Errorf("failed to load test suite data file %s: %w", currentPath, err)
 		}
 		testSuites[currentPath] = data
 		return nil


### PR DESCRIPTION
This PR adds the logic for embedding test suite data and for loading the data, filtering it according to active config cases, and then grouping by server process. In this case, a "server process" identifies a `ServerCompatRequest` and thus a single server process that will be started by the test runner.