### PR TITLE
Remove npm and docker from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,22 +1,10 @@
 version: 2
 updates:
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    ignore:
-      # We would like to manage this manually and use the Active LTS for Node.
-      - dependency-name: "node"
-        versions: ["17.x", "18.x"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
   - package-ecosystem: "gomod"
     directory: "/"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "npm"
-    directory: "/web"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
This updates the dependabot yaml to remove NPM and Docker.