### PR TITLE
V2: Add test result handler

### DIFF
--- a/internal/app/connectconformance/known_failing.go
+++ b/internal/app/connectconformance/known_failing.go
@@ -1,0 +1,125 @@
+// Copyright 2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connectconformance
+
+import (
+	"bytes"
+	"strings"
+	"sync/atomic"
+)
+
+// knownFailingTrie is a trie (aka prefix tree) of patterns of test case
+// names that are known to fail.
+type knownFailingTrie struct {
+	// If true, this node represents a path that was inserted into the trie.
+	// If false, this node is an intermediate component of a path.
+	present  bool
+	children map[string]*knownFailingTrie
+
+	// matched is used to verify that all paths in the trie are valid
+	// and correspond to at least one test case
+	matched atomic.Int32
+}
+
+// parseKnownFailing creates a knownFailingTrie from the given configuration
+// data for known failing test cases.
+func parseKnownFailing(data []byte) *knownFailingTrie {
+	lines := bytes.Split(data, []byte{'\n'})
+	var knownFailing knownFailingTrie
+	for _, line := range lines {
+		line := bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+		if line[0] == '#' {
+			// comment line
+			continue
+		}
+		knownFailing.add(strings.Split(string(line), "/"))
+	}
+	return &knownFailing
+}
+
+func (k *knownFailingTrie) add(components []string) {
+	if len(components) == 0 {
+		k.present = true
+		return
+	}
+	if k.children == nil {
+		k.children = map[string]*knownFailingTrie{}
+	}
+	first, rest := components[0], components[1:]
+	child := k.children[first]
+	if child == nil {
+		child = &knownFailingTrie{}
+		k.children[first] = child
+	}
+	child.add(rest)
+}
+
+func (k *knownFailingTrie) match(components []string) bool {
+	if len(components) == 0 {
+		if k.present {
+			k.matched.Add(1)
+			return true
+		}
+		// See if there's a double-wildcard that may match the empty remaining components.
+		child := k.children["**"]
+		if child != nil && child.present {
+			child.matched.Add(1)
+			return true
+		}
+		return false
+	}
+	first, rest := components[0], components[1:]
+	child := k.children[first]
+	if child != nil && child.match(rest) {
+		return true
+	}
+	child = k.children["*"]
+	if child != nil && child.match(rest) {
+		return true
+	}
+
+	// ** can match zero or more components
+	child = k.children["**"]
+	if child == nil {
+		return false
+	}
+	for {
+		if child.match(components) {
+			return true
+		}
+		if len(components) == 0 {
+			return child.present
+		}
+		components = components[1:]
+	}
+}
+
+func (k *knownFailingTrie) findUnmatched(prefix string, unmatched map[string]struct{}) {
+	if k.present && k.matched.Load() == 0 {
+		unmatched[prefix] = struct{}{}
+	}
+	for next, child := range k.children {
+		var childPrefix string
+		if prefix == "" {
+			childPrefix = next
+		} else {
+			childPrefix = prefix + "/" + next
+		}
+		child.findUnmatched(childPrefix, unmatched)
+	}
+}

--- a/internal/app/connectconformance/known_failing_test.go
+++ b/internal/app/connectconformance/known_failing_test.go
@@ -1,0 +1,149 @@
+// Copyright 2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connectconformance
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseKnownFailing(t *testing.T) {
+	t.Parallel()
+	trie := parseKnownFailing([]byte(`
+		# This is a comment
+		This is a test pattern/foo/bar/baz/test-case-name
+		All tests in this suite/**
+		**/all-test-cases-with-this-name
+		Another suite/*/*/*/another-test-case
+		A suite with interior double wildcard/**/foo/bar
+
+		# Another comment`))
+
+	testCases := []struct {
+		testName string
+		matched  bool
+	}{
+		{
+			testName: "This is a test pattern/foo/bar/baz/test-case-name",
+			matched:  true,
+		},
+		{
+			testName: "Some test that is not match",
+			matched:  false,
+		},
+		{
+			testName: "All tests in this suite",
+			matched:  true,
+		},
+		{
+			testName: "All tests in this suite/abc/xyz",
+			matched:  true,
+		},
+		{
+			testName: "All tests in this suite/a/b/c/d/e/f/g/h/i/j/k",
+			matched:  true,
+		},
+		{
+			testName: "all-test-cases-with-this-name",
+			matched:  true,
+		},
+		{
+			testName: "Abc/xyz/all-test-cases-with-this-name",
+			matched:  true,
+		},
+		{
+			testName: "Abc/1/2/3/4/5/6/7/8/9/0/all-test-cases-with-this-name",
+			matched:  true,
+		},
+		{
+			testName: "Another suite/foo/bar/baz/another-test-case",
+			matched:  true,
+		},
+		{
+			testName: "Another suite/foo/bar/baz/buzz/another-test-case",
+			matched:  false, // too many path components
+		},
+		{
+			testName: "Another suite/foo/bar/another-test-case",
+			matched:  false, // too few path components
+		},
+		{
+			testName: "A suite with interior double wildcard/foo/bar",
+			matched:  true,
+		},
+		{
+			testName: "A suite with interior double wildcard/a/1/b/2/c/3/d/4/e/5/foo/bar",
+			matched:  true,
+		},
+		{
+			testName: "A suite with interior double wildcard/a/1/b/2/c/3/d/4/e/5/foo",
+			matched:  false, // wrong suffix
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.testName, func(t *testing.T) {
+			t.Parallel()
+			matched := trie.match(strings.Split(testCase.testName, "/"))
+			require.Equal(t, testCase.matched, matched)
+		})
+	}
+}
+
+func TestKnownFailingTrie_FindUnmatched(t *testing.T) {
+	t.Parallel()
+	trie := parseKnownFailing([]byte(`
+		Unmatched test suite/**
+		Simple test suite/that/has/no/wildcards
+		All tests in this suite/**
+		**/all-test-cases-with-this-name
+		**/unmatched-test-case
+		Another suite/*/*/*/another-test-case
+		A suite with interior double wildcard/**/test-case
+		Another unmatched/test/*/with/*/wildcards`))
+
+	testCaseNames := []string{
+		"Simple test suite/that/has/no/wildcards",
+		"All tests in this suite/foo/bar/case123",
+		"All tests in this suite/foo/bar/case456",
+		"All tests in this suite/foo/baz/case123",
+		"All tests in this suite/foo/baz/case456",
+		"Some other test suite/foo/bar/all-test-cases-with-this-name",
+		"And another test suite/foo/bar/all-test-cases-with-this-name",
+		"Another suite/abc/xyz/123/another-test-case",
+		"A suite with interior double wildcard/test-case",
+	}
+	for _, testCaseName := range testCaseNames {
+		require.True(t, trie.match(strings.Split(testCaseName, "/")))
+	}
+
+	unmatched := map[string]struct{}{}
+	trie.findUnmatched("", unmatched)
+	unmatchedSlice := make([]string, 0, len(unmatched))
+	for unmatchedName := range unmatched {
+		unmatchedSlice = append(unmatchedSlice, unmatchedName)
+	}
+	sort.Strings(unmatchedSlice)
+
+	require.Equal(t, []string{
+		"**/unmatched-test-case",
+		"Another unmatched/test/*/with/*/wildcards",
+		"Unmatched test suite/**",
+	}, unmatchedSlice)
+}

--- a/internal/app/connectconformance/results.go
+++ b/internal/app/connectconformance/results.go
@@ -1,0 +1,192 @@
+// Copyright 2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connectconformance
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"sync"
+
+	conformancev1alpha1 "connectrpc.com/conformance/internal/gen/proto/go/connectrpc/conformance/v1alpha1"
+	"google.golang.org/protobuf/proto"
+)
+
+// testResults represents the results of running conformance tests. It accumulates
+// the state of passed and failed test cases and also reports failures to a given
+// log writer. It can also incorporate data provided out-of-band by a reference
+// server, when testing a client implementation.
+type testResults struct {
+	knownFailing *knownFailingTrie
+
+	mu             sync.Mutex
+	outcomes       map[string]testOutcome
+	serverSideband map[string]string
+}
+
+func newResults(knownFailing *knownFailingTrie) *testResults {
+	return &testResults{
+		knownFailing:   knownFailing,
+		outcomes:       map[string]testOutcome{},
+		serverSideband: map[string]string{},
+	}
+}
+
+// setOutcome sets the outcome for the named test case. If setupError is true,
+// then err occurred before the test case could actually be run. Otherwise, err
+// represents the result of issuing the RPC, which may be nil to indicate
+// the test case passed.
+func (r *testResults) setOutcome(testCase string, setupError bool, err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.setOutcomeLocked(testCase, setupError, err)
+}
+
+func (r *testResults) setOutcomeLocked(testCase string, setupError bool, err error) {
+	r.outcomes[testCase] = testOutcome{
+		actualFailure: err,
+		setupError:    setupError,
+		knownFailing:  r.knownFailing.match(strings.Split(testCase, "/")),
+	}
+}
+
+// failedToStart marks all the given test cases with the given setup error.
+// This convenience method is to mark many tests in a batch when the relevant
+// server process could not be started.
+func (r *testResults) failedToStart(testCases []*conformancev1alpha1.TestCase, err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, testCase := range testCases {
+		r.setOutcomeLocked(testCase.Request.TestName, true, err)
+	}
+}
+
+// failRemaining marks any of the given test cases that do not yet have an outcome
+// as failing with the given error. This is typically called when the server or client
+// process fails, so we can mark any pending test.
+func (r *testResults) failRemaining(testCases []*conformancev1alpha1.TestCase, err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, testCase := range testCases {
+		name := testCase.Request.TestName
+		if _, outcomeExists := r.outcomes[name]; outcomeExists {
+			continue
+		}
+		r.setOutcomeLocked(testCase.Request.TestName, true, err)
+	}
+}
+
+// failed marks the given test case as having failed with the given error
+// message received from the client.
+func (r *testResults) failed(testCase string, err *conformancev1alpha1.ClientErrorResult) {
+	r.setOutcome(testCase, false, errors.New(err.Message))
+}
+
+// assert will examine the actual and expected RPC result and mark the test
+// case as successful or failed accordingly.
+func (r *testResults) assert(testCase string, expected, actual *conformancev1alpha1.ClientResponseResult) {
+	// TODO: Need to do smart processing of expected and actual to make sure
+	//       actual *complies* with expected (doesn't necessarily have to match
+	//       exactly; for example extra response headers are fine...)
+	//       Also, more bespoke checks will also result in better error messages
+	//       for users, so they know what went wrong.
+	var err error
+	if !proto.Equal(expected, actual) {
+		err = &expectationFailedError{expected: expected, actual: actual}
+	}
+	r.setOutcome(testCase, false, err)
+}
+
+// recordServerSideband accepts an error message for a test that was sent
+// out-of-band by a reference server.
+func (r *testResults) recordServerSideband(testCase string, errMsg string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.serverSideband[testCase] = errMsg
+}
+
+// processServerSidebandInfoLocked merges the data recorded during calls
+// to recordServerSideband into the outcomes. This is done when a report
+// is created.
+func (r *testResults) processServerSidebandInfoLocked() {
+	for name, msg := range r.serverSideband {
+		outcome, ok := r.outcomes[name]
+		if ok {
+			// Update outcome to include reference server's feedback
+			if outcome.actualFailure == nil {
+				outcome.actualFailure = errors.New(msg)
+			} else {
+				outcome.actualFailure = fmt.Errorf("%s; %w", msg, outcome.actualFailure)
+			}
+			r.outcomes[name] = outcome
+		} else {
+			r.setOutcomeLocked(name, false, errors.New(msg))
+		}
+	}
+}
+
+func (r *testResults) report(writer io.Writer) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.serverSideband) > 0 {
+		r.processServerSidebandInfoLocked()
+		r.serverSideband = map[string]string{}
+	}
+	testCaseNames := make([]string, 0, len(r.outcomes))
+	for testCaseName := range r.outcomes {
+		testCaseNames = append(testCaseNames, testCaseName)
+	}
+	sort.Strings(testCaseNames)
+	for _, name := range testCaseNames {
+		outcome := r.outcomes[name]
+		expectError := outcome.knownFailing && !outcome.setupError
+		var err error
+		switch {
+		case !expectError && outcome.actualFailure != nil:
+			_, err = fmt.Fprintf(writer, "FAILED: %s: %v\n", name, outcome.actualFailure)
+		case expectError && outcome.actualFailure == nil:
+			_, err = fmt.Fprintf(writer, "FAILED: %s was expected to fail but did not\n", name)
+		case expectError && outcome.actualFailure != nil:
+			_, err = fmt.Fprintf(writer, "INFO: %s failed (as expected): %v\n", name, outcome.actualFailure)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type testOutcome struct {
+	// nil if the test case executed successfully, otherwise an error that
+	// represents why the test case failed, such as an error returned by the
+	// client or an "expectation failure", when the client's result does not
+	// match the expected result.
+	actualFailure error
+	// if actualFailure != nil and setupError is true, the error occurred while
+	// setting up the test, not as an outcome of running the test.
+	setupError bool
+	// true if this test case is known to fail
+	knownFailing bool
+}
+
+type expectationFailedError struct {
+	expected, actual *conformancev1alpha1.ClientResponseResult
+}
+
+func (e *expectationFailedError) Error() string {
+	return "actual result did not match expected result"
+}

--- a/internal/app/connectconformance/results_test.go
+++ b/internal/app/connectconformance/results_test.go
@@ -1,0 +1,188 @@
+// Copyright 2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connectconformance
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	conformancev1alpha1 "connectrpc.com/conformance/internal/gen/proto/go/connectrpc/conformance/v1alpha1"
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResults_SetOutcome(t *testing.T) {
+	t.Parallel()
+	results := newResults(makeKnownFailing())
+	results.setOutcome("foo/bar/1", false, nil)
+	results.setOutcome("foo/bar/2", true, errors.New("fail"))
+	results.setOutcome("foo/bar/3", false, errors.New("fail"))
+	results.setOutcome("known-to-fail/1", false, nil)
+	results.setOutcome("known-to-fail/2", true, errors.New("fail"))
+	results.setOutcome("known-to-fail/3", false, errors.New("fail"))
+
+	logger := &lineWriter{}
+	err := results.report(logger)
+	require.NoError(t, err)
+	require.Len(t, logger.lines, 5)
+	require.Equal(t, logger.lines[0], "FAILED: foo/bar/2: fail\n")
+	require.Equal(t, logger.lines[1], "FAILED: foo/bar/3: fail\n")
+	require.Equal(t, logger.lines[2], "FAILED: known-to-fail/1 was expected to fail but did not\n")
+	require.Equal(t, logger.lines[3], "FAILED: known-to-fail/2: fail\n")
+	require.Equal(t, logger.lines[4], "INFO: known-to-fail/3 failed (as expected): fail\n")
+}
+
+func TestResults_FailedToStart(t *testing.T) {
+	t.Parallel()
+	results := newResults(makeKnownFailing())
+	results.failedToStart([]*conformancev1alpha1.TestCase{
+		{Request: &conformancev1alpha1.ClientCompatRequest{TestName: "foo/bar/1"}},
+		{Request: &conformancev1alpha1.ClientCompatRequest{TestName: "known-to-fail/1"}},
+	}, errors.New("fail"))
+
+	logger := &lineWriter{}
+	err := results.report(logger)
+	require.NoError(t, err)
+	require.Len(t, logger.lines, 2)
+	require.Equal(t, logger.lines[0], "FAILED: foo/bar/1: fail\n")
+	// Marked as failure even though expected to fail because it failed to start.
+	require.Equal(t, logger.lines[1], "FAILED: known-to-fail/1: fail\n")
+}
+
+func TestResults_FailRemaining(t *testing.T) {
+	t.Parallel()
+	results := newResults(makeKnownFailing())
+	results.setOutcome("foo/bar/1", false, nil)
+	results.setOutcome("known-to-fail/1", false, errors.New("fail"))
+	results.failRemaining([]*conformancev1alpha1.TestCase{
+		{Request: &conformancev1alpha1.ClientCompatRequest{TestName: "foo/bar/1"}},
+		{Request: &conformancev1alpha1.ClientCompatRequest{TestName: "foo/bar/2"}},
+		{Request: &conformancev1alpha1.ClientCompatRequest{TestName: "known-to-fail/1"}},
+		{Request: &conformancev1alpha1.ClientCompatRequest{TestName: "known-to-fail/2"}},
+	}, errors.New("something went wrong"))
+
+	logger := &lineWriter{}
+	err := results.report(logger)
+	require.NoError(t, err)
+	require.Len(t, logger.lines, 3)
+	require.Equal(t, logger.lines[0], "FAILED: foo/bar/2: something went wrong\n")
+	require.Equal(t, logger.lines[1], "INFO: known-to-fail/1 failed (as expected): fail\n")
+	// Marked as failure even though expected to fail because failRemaining is
+	// used when a process under test dies (so this error is not due to lack of
+	// conformance).
+	require.Equal(t, logger.lines[2], "FAILED: known-to-fail/2: something went wrong\n")
+}
+
+func TestResults_Failed(t *testing.T) {
+	t.Parallel()
+	results := newResults(makeKnownFailing())
+	results.failed("foo/bar/1", &conformancev1alpha1.ClientErrorResult{Message: "fail"})
+	results.failed("known-to-fail/1", &conformancev1alpha1.ClientErrorResult{Message: "fail"})
+
+	logger := &lineWriter{}
+	err := results.report(logger)
+	require.NoError(t, err)
+	require.Len(t, logger.lines, 2)
+	require.Equal(t, logger.lines[0], "FAILED: foo/bar/1: fail\n")
+	require.Equal(t, logger.lines[1], "INFO: known-to-fail/1 failed (as expected): fail\n")
+}
+
+func TestResults_Assert(t *testing.T) {
+	t.Parallel()
+	results := newResults(makeKnownFailing())
+	payload1 := &conformancev1alpha1.ClientResponseResult{
+		Payloads: []*conformancev1alpha1.ConformancePayload{
+			{Data: []byte{0, 1, 2, 3, 4}},
+		},
+	}
+	payload2 := &conformancev1alpha1.ClientResponseResult{
+		Error: &conformancev1alpha1.Error{Code: int32(connect.CodeAborted), Message: "oops"},
+	}
+	results.assert("foo/bar/1", payload1, payload2)
+	results.assert("foo/bar/2", payload2, payload1)
+	results.assert("foo/bar/3", payload1, payload1)
+	results.assert("foo/bar/4", payload2, payload2)
+	results.assert("known-to-fail/1", payload1, payload2)
+	results.assert("known-to-fail/2", payload2, payload1)
+	results.assert("known-to-fail/3", payload1, payload1)
+	results.assert("known-to-fail/4", payload2, payload2)
+
+	logger := &lineWriter{}
+	err := results.report(logger)
+	require.NoError(t, err)
+	require.Len(t, logger.lines, 6)
+	require.Contains(t, logger.lines[0], "FAILED: foo/bar/1: ")
+	require.Contains(t, logger.lines[1], "FAILED: foo/bar/2: ")
+	require.Contains(t, logger.lines[2], "INFO: known-to-fail/1 failed (as expected): ")
+	require.Contains(t, logger.lines[3], "INFO: known-to-fail/2 failed (as expected): ")
+	require.Equal(t, logger.lines[4], "FAILED: known-to-fail/3 was expected to fail but did not\n")
+	require.Equal(t, logger.lines[5], "FAILED: known-to-fail/4 was expected to fail but did not\n")
+}
+
+func TestResults_ServerSideband(t *testing.T) {
+	t.Parallel()
+	results := newResults(makeKnownFailing())
+	results.setOutcome("foo/bar/1", false, nil)
+	results.setOutcome("foo/bar/2", false, errors.New("fail"))
+	results.setOutcome("foo/bar/3", false, nil)
+	results.setOutcome("known-to-fail/1", false, nil)
+	results.setOutcome("known-to-fail/2", false, errors.New("fail"))
+	results.recordServerSideband("foo/bar/2", "something awkward in wire format")
+	results.recordServerSideband("foo/bar/3", "something awkward in wire format")
+	results.recordServerSideband("known-to-fail/1", "something awkward in wire format")
+
+	logger := &lineWriter{}
+	err := results.report(logger)
+	require.NoError(t, err)
+	require.Len(t, logger.lines, 4)
+	require.Equal(t, logger.lines[0], "FAILED: foo/bar/2: something awkward in wire format; fail\n")
+	require.Equal(t, logger.lines[1], "FAILED: foo/bar/3: something awkward in wire format\n")
+	require.Equal(t, logger.lines[2], "INFO: known-to-fail/1 failed (as expected): something awkward in wire format\n")
+	require.Equal(t, logger.lines[3], "INFO: known-to-fail/2 failed (as expected): fail\n")
+}
+
+func makeKnownFailing() *knownFailingTrie {
+	var trie knownFailingTrie
+	trie.add([]string{"known-to-fail", "**"})
+	return &trie
+}
+
+type lineWriter struct {
+	current []byte
+	lines   []string
+}
+
+func (l *lineWriter) Write(data []byte) (n int, err error) {
+	for {
+		if len(data) == 0 {
+			return n, nil
+		}
+		var hasLF bool
+		pos := bytes.IndexByte(data, '\n')
+		if pos == -1 {
+			pos = len(data)
+		} else {
+			pos++ // include LF
+			hasLF = true
+		}
+		l.current = append(l.current, data[:pos]...)
+		if hasLF {
+			l.lines = append(l.lines, string(l.current))
+			l.current = nil
+		}
+		data = data[pos:]
+	}
+}


### PR DESCRIPTION
This adds a `testResults` type that accumulates the results of a conformance test run and can report the results at the end. This also adds a `knownFailingTrie`, which is a prefix tree that is an index of all known-failing test cases. This is used to invert the expectation of a test: if a test case is configured as known-failing, the conformance test runner accepts when the case results in an error but will complain if the test case actually passes (since it means the known-failing config is stale).