### PR TITLE
V2: Add remaining compression algorithms

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,9 @@ go 1.20
 
 require (
 	connectrpc.com/connect v1.11.1
+	github.com/andybalholm/brotli v1.0.6
 	github.com/bufbuild/protoyaml-go v0.1.4
+	github.com/golang/snappy v0.0.4
 	github.com/google/go-cmp v0.5.9
 	github.com/klauspost/compress v1.17.2
 	github.com/rs/cors v1.10.1

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.31.0-2023091417185
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.31.0-20230914171853-63dfe56cc2c4.1/go.mod h1:xafc+XIsTxTy76GJQ1TKgvJWsSugFBqMaN27WhUblew=
 connectrpc.com/connect v1.11.1 h1:dqRwblixqkVh+OFBOOL1yIf1jS/yP0MSJLijRj29bFg=
 connectrpc.com/connect v1.11.1/go.mod h1:3AGaO6RRGMx5IKFfqbe3hvK1NqLosFNP2BxDYTPmNPo=
+github.com/andybalholm/brotli v1.0.6 h1:Yf9fFpf49Zrxb9NlQaluyE92/+X7UVHlhMNJN2sxfOI=
+github.com/andybalholm/brotli v1.0.6/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230512164433-5d1fd1a340c9 h1:goHVqTbFX3AIo0tzGr14pgfAW2ZfPChKO21Z9MGf/gk=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230512164433-5d1fd1a340c9/go.mod h1:pSwJ0fSY5KhvocuWSx4fz3BA8OrA1bQn+K1Eli3BRwM=
 github.com/bufbuild/protovalidate-go v0.3.2 h1:7sG1R83PkCzOZb3P187gAchWFLHY6LQ8aVoUw6Wp9es=
@@ -13,6 +15,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/envoyproxy/protoc-gen-validate v1.0.2 h1:QkIBuU5k+x7/QXPvPPnWXWlCdaBFApVqftFV6k087DA=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
+github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
+github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/cel-go v0.18.1 h1:V/lAXKq4C3BYLDy/ARzMtpkEEYfHQpZzVyzy69nEUjs=
 github.com/google/cel-go v0.18.1/go.mod h1:PVAybmSnWkNMUZR/tEWFUiJ1Np4Hz0MHsZJcgC4zln4=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=

--- a/internal/app/client/client.go
+++ b/internal/app/client/client.go
@@ -152,8 +152,8 @@ func invoke(ctx context.Context, req *v1alpha1.ClientCompatRequest) (*v1alpha1.C
 				compression.NewBrotliDecompressor,
 				compression.NewBrotliCompressor,
 			),
+			connect.WithSendCompression(compression.Brotli),
 		)
-		clientOptions = append(clientOptions, connect.WithSendCompression(compression.Brotli))
 	case v1alpha1.Compression_COMPRESSION_DEFLATE:
 		clientOptions = append(
 			clientOptions,
@@ -162,8 +162,8 @@ func invoke(ctx context.Context, req *v1alpha1.ClientCompatRequest) (*v1alpha1.C
 				compression.NewDeflateDecompressor,
 				compression.NewDeflateCompressor,
 			),
+			connect.WithSendCompression(compression.Deflate),
 		)
-		clientOptions = append(clientOptions, connect.WithSendCompression(compression.Deflate))
 	case v1alpha1.Compression_COMPRESSION_GZIP:
 		// Connect clients send uncompressed requests and ask for gzipped responses by default
 		// As a result, specifying a compression of gzip for a client indicates it should also
@@ -177,8 +177,8 @@ func invoke(ctx context.Context, req *v1alpha1.ClientCompatRequest) (*v1alpha1.C
 				compression.NewSnappyDecompressor,
 				compression.NewSnappyCompressor,
 			),
+			connect.WithSendCompression(compression.Snappy),
 		)
-		clientOptions = append(clientOptions, connect.WithSendCompression(compression.Snappy))
 	case v1alpha1.Compression_COMPRESSION_ZSTD:
 		clientOptions = append(
 			clientOptions,
@@ -187,8 +187,8 @@ func invoke(ctx context.Context, req *v1alpha1.ClientCompatRequest) (*v1alpha1.C
 				compression.NewZstdDecompressor,
 				compression.NewZstdCompressor,
 			),
+			connect.WithSendCompression(compression.Zstd),
 		)
-		clientOptions = append(clientOptions, connect.WithSendCompression(compression.Zstd))
 	case v1alpha1.Compression_COMPRESSION_IDENTITY, v1alpha1.Compression_COMPRESSION_UNSPECIFIED:
 		// Do nothing
 	}

--- a/internal/app/client/client.go
+++ b/internal/app/client/client.go
@@ -143,13 +143,42 @@ func invoke(ctx context.Context, req *v1alpha1.ClientCompatRequest) (*v1alpha1.C
 		clientOptions = append(clientOptions, connect.WithProtoJSON())
 	}
 
-	// TODO - Add support for other compression algos
 	switch req.Compression {
+	case v1alpha1.Compression_COMPRESSION_BR:
+		clientOptions = append(
+			clientOptions,
+			connect.WithAcceptCompression(
+				compression.Brotli,
+				compression.NewBrotliDecompressor,
+				compression.NewBrotliCompressor,
+			),
+		)
+		clientOptions = append(clientOptions, connect.WithSendCompression(compression.Brotli))
+	case v1alpha1.Compression_COMPRESSION_DEFLATE:
+		clientOptions = append(
+			clientOptions,
+			connect.WithAcceptCompression(
+				compression.Deflate,
+				compression.NewDeflateDecompressor,
+				compression.NewDeflateCompressor,
+			),
+		)
+		clientOptions = append(clientOptions, connect.WithSendCompression(compression.Deflate))
 	case v1alpha1.Compression_COMPRESSION_GZIP:
+		// Connect clients send uncompressed requests and ask for gzipped responses by default
+		// As a result, specifying a compression of gzip for a client indicates it should also
+		// send gzipped requests
 		clientOptions = append(clientOptions, connect.WithSendGzip())
-	case v1alpha1.Compression_COMPRESSION_SNAPPY, v1alpha1.Compression_COMPRESSION_DEFLATE,
-		v1alpha1.Compression_COMPRESSION_BR:
-		return nil, errors.New(req.Compression.String() + " is not yet supported")
+	case v1alpha1.Compression_COMPRESSION_SNAPPY:
+		clientOptions = append(
+			clientOptions,
+			connect.WithAcceptCompression(
+				compression.Snappy,
+				compression.NewSnappyDecompressor,
+				compression.NewSnappyCompressor,
+			),
+		)
+		clientOptions = append(clientOptions, connect.WithSendCompression(compression.Snappy))
 	case v1alpha1.Compression_COMPRESSION_ZSTD:
 		clientOptions = append(
 			clientOptions,

--- a/internal/app/server/server.go
+++ b/internal/app/server/server.go
@@ -105,6 +105,9 @@ func createServer(req *v1alpha1.ServerCompatRequest) (*http.Server, error) {
 	mux := http.NewServeMux()
 	mux.Handle(conformancev1alpha1connect.NewConformanceServiceHandler(
 		&conformanceServer{},
+		connect.WithCompression(compression.Brotli, compression.NewBrotliDecompressor, compression.NewBrotliCompressor),
+		connect.WithCompression(compression.Deflate, compression.NewDeflateDecompressor, compression.NewDeflateCompressor),
+		connect.WithCompression(compression.Snappy, compression.NewSnappyDecompressor, compression.NewSnappyCompressor),
 		connect.WithCompression(compression.Zstd, compression.NewZstdDecompressor, compression.NewZstdCompressor),
 	))
 	// The server needs a lenient cors setup so that it can handle testing

--- a/internal/compression/brotli.go
+++ b/internal/compression/brotli.go
@@ -33,6 +33,7 @@ func (c *brotliDecompressor) Reset(rdr io.Reader) error {
 	return c.reader.Reset(rdr)
 }
 func (c *brotliDecompressor) Close() error {
+	// brotli's Reader does not expose a Close function
 	return nil
 }
 
@@ -41,11 +42,6 @@ func NewBrotliDecompressor() connect.Decompressor {
 	return &brotliDecompressor{
 		reader: brotli.NewReader(nil),
 	}
-}
-
-// BrotliCompressor is a thin wrapper around a brotli Writer.
-type BrotliCompressor struct {
-	*brotli.Writer
 }
 
 // NewBrotliCompressor returns a new Brotli Compressor.

--- a/internal/compression/brotli.go
+++ b/internal/compression/brotli.go
@@ -1,0 +1,54 @@
+// Copyright 2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compression
+
+import (
+	"io"
+
+	"connectrpc.com/connect"
+	"github.com/andybalholm/brotli"
+)
+
+// brotliDecompressor is a thin wrapper around a brotli Reader.
+type brotliDecompressor struct {
+	reader *brotli.Reader
+}
+
+func (c *brotliDecompressor) Read(bytes []byte) (int, error) {
+	return c.reader.Read(bytes)
+}
+func (c *brotliDecompressor) Reset(rdr io.Reader) error {
+	return c.reader.Reset(rdr)
+}
+func (c *brotliDecompressor) Close() error {
+	return nil
+}
+
+// NewBrotliDecompressor returns a new Brotli Decompressor.
+func NewBrotliDecompressor() connect.Decompressor {
+	return &brotliDecompressor{
+		reader: brotli.NewReader(nil),
+	}
+}
+
+// BrotliCompressor is a thin wrapper around a brotli Writer.
+type BrotliCompressor struct {
+	*brotli.Writer
+}
+
+// NewBrotliCompressor returns a new Brotli Compressor.
+func NewBrotliCompressor() connect.Compressor {
+	return brotli.NewWriter(nil)
+}

--- a/internal/compression/compression.go
+++ b/internal/compression/compression.go
@@ -16,5 +16,8 @@ package compression
 
 // The IANA names for supported compression algorithms.
 const (
-	Zstd = "zstd"
+	Brotli  = "br"
+	Deflate = "deflate"
+	Snappy  = "snappy"
+	Zstd    = "zstd"
 )

--- a/internal/compression/deflate.go
+++ b/internal/compression/deflate.go
@@ -22,7 +22,7 @@ import (
 	"connectrpc.com/connect"
 )
 
-// deflateDecompressor is a thin wrapper around a deflate Reader.
+// deflateDecompressor is a thin wrapper around a flate Reader.
 type deflateDecompressor struct {
 	reader io.ReadCloser
 }

--- a/internal/compression/deflate.go
+++ b/internal/compression/deflate.go
@@ -1,0 +1,60 @@
+// Copyright 2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compression
+
+import (
+	"compress/flate"
+	"errors"
+	"io"
+
+	"connectrpc.com/connect"
+)
+
+// deflateDecompressor is a thin wrapper around a deflate Reader.
+type deflateDecompressor struct {
+	reader io.ReadCloser
+}
+
+func (c *deflateDecompressor) Read(bytes []byte) (int, error) {
+	return c.reader.Read(bytes)
+}
+func (c *deflateDecompressor) Reset(rdr io.Reader) error {
+	r, ok := c.reader.(flate.Resetter)
+	if !ok {
+		return errors.New("deflate reader is not able to be used as a resetter")
+	}
+	// Mimics NewReader internal logic, which initializes the internal dict to nil
+	return r.Reset(rdr, nil)
+}
+func (c *deflateDecompressor) Close() error {
+	return c.reader.Close()
+}
+
+// NewDeflateDecompressor returns a new deflate Decompressor.
+func NewDeflateDecompressor() connect.Decompressor {
+	return &deflateDecompressor{
+		reader: flate.NewReader(nil),
+	}
+}
+
+// NewDeflateCompressor returns a new deflate Compressor.
+func NewDeflateCompressor() connect.Compressor {
+	// Construct a new flate Writer with default compression level
+	w, err := flate.NewWriter(nil, 1)
+	if err != nil {
+		return &errorCompressor{err: err}
+	}
+	return w
+}

--- a/internal/compression/deflate.go
+++ b/internal/compression/deflate.go
@@ -31,12 +31,15 @@ func (c *deflateDecompressor) Read(bytes []byte) (int, error) {
 	return c.reader.Read(bytes)
 }
 func (c *deflateDecompressor) Reset(rdr io.Reader) error {
-	r, ok := c.reader.(flate.Resetter)
+	resetter, ok := c.reader.(flate.Resetter)
 	if !ok {
+		// This should never happen as the returned type from flate should always
+		// implement Resetter, but the check is here as a safeguard just in case.
+		// This error would be a very exceptional / unexpected occurrence.
 		return errors.New("deflate reader is not able to be used as a resetter")
 	}
 	// Mimics NewReader internal logic, which initializes the internal dict to nil
-	return r.Reset(rdr, nil)
+	return resetter.Reset(rdr, nil)
 }
 func (c *deflateDecompressor) Close() error {
 	return c.reader.Close()

--- a/internal/compression/snappy.go
+++ b/internal/compression/snappy.go
@@ -1,0 +1,52 @@
+// Copyright 2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compression
+
+import (
+	"io"
+
+	"connectrpc.com/connect"
+	"github.com/golang/snappy"
+)
+
+// snappyDecompressor is a thin wrapper around a snappy Reader.
+type snappyDecompressor struct {
+	reader *snappy.Reader
+}
+
+func (c *snappyDecompressor) Read(bytes []byte) (int, error) {
+	return c.reader.Read(bytes)
+}
+func (c *snappyDecompressor) Reset(rdr io.Reader) error {
+	c.reader.Reset(rdr)
+	// snappy's Reader does not return an error on Reset
+	return nil
+}
+func (c *snappyDecompressor) Close() error {
+	// snappy's Reader does not expose a Close function
+	return nil
+}
+
+// NewSnappyDecompressor returns a new snappy Decompressor.
+func NewSnappyDecompressor() connect.Decompressor {
+	return &snappyDecompressor{
+		reader: snappy.NewReader(nil),
+	}
+}
+
+// NewSnappyCompressor returns a new snappy Compressor.
+func NewSnappyCompressor() connect.Compressor {
+	return snappy.NewBufferedWriter(nil)
+}

--- a/internal/compression/zstd.go
+++ b/internal/compression/zstd.go
@@ -48,11 +48,6 @@ func NewZstdDecompressor() connect.Decompressor {
 	}
 }
 
-// ZstdCompressor is a thin wrapper around a zstd Encoder.
-type ZstdCompressor struct {
-	*zstd.Encoder
-}
-
 // NewZstdCompressor returns a new Zstd Compressor.
 func NewZstdCompressor() connect.Compressor {
 	w, err := zstd.NewWriter(nil)


### PR DESCRIPTION
This adds the remaining compression algorithms to the client and server as specified in the `Compression` enum. So, rounding out the list, conformance tests support:

* brotli
* deflate
* gzip
* snappy
* zstd