### PR TITLE
V2: Add process-handling helpers and the client runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.19.x, 1.20.x, 1.21.x]
+        go-version: [1.20.x, 1.21.x]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,7 @@ linters-settings:
       - i int
       - wg sync.WaitGroup
       - ok bool
+      - in io.Reader
 linters:
   enable-all: true
   disable:

--- a/internal/app/connectconformance/client_runner.go
+++ b/internal/app/connectconformance/client_runner.go
@@ -1,0 +1,207 @@
+// Copyright 2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connectconformance
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	conformancev1alpha1 "connectrpc.com/conformance/internal/gen/proto/go/connectrpc/conformance/v1alpha1"
+)
+
+const testCaseTimeout = 20 * time.Second
+
+var errClosed = errors.New("send-to-client is closed")
+var errDuplicate = errors.New("duplicate test case")
+
+type clientRunner interface {
+	sendRequest(req *conformancev1alpha1.ClientCompatRequest, whenDone func(string, *conformancev1alpha1.ClientCompatResponse, error)) error
+	closeSend()
+	waitForResponses() error
+}
+
+func runClient(ctx context.Context, start processStarter) (clientRunner, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	proc, err := start(ctx, false)
+	if err != nil {
+		cancel() // prevent any context-related leak
+		return nil, err
+	}
+	proc.whenDone(func(_ error) { cancel() })
+	result := &clientProcessRunner{
+		proc:       proc,
+		cancel:     cancel,
+		done:       make(chan struct{}),
+		pendingOps: map[string]func(string, *conformancev1alpha1.ClientCompatResponse, error){},
+	}
+	go result.consumeOutput()
+	return result, nil
+}
+
+type clientProcessRunner struct {
+	proc   *process
+	cancel context.CancelFunc
+
+	err  atomic.Pointer[error]
+	done chan struct{}
+
+	sendMu     sync.Mutex // serialize calls to sendRequest
+	closedSend bool
+
+	// pendingMu needs to be separate so that consumeOutput function can acquire
+	// it without being blocked by another goroutine writing a request (which can
+	// trivially lead to deadlock).
+	// If acquiring both sendMu and pendingMu, *always* acquire sendMu first.
+	pendingMu  sync.Mutex
+	pendingOps map[string]func(string, *conformancev1alpha1.ClientCompatResponse, error)
+}
+
+func (c *clientProcessRunner) sendRequest(req *conformancev1alpha1.ClientCompatRequest, whenDone func(string, *conformancev1alpha1.ClientCompatResponse, error)) (err error) {
+	if err := c.err.Load(); err != nil && *err != nil {
+		return *err
+	}
+
+	c.sendMu.Lock()
+	defer c.sendMu.Unlock()
+
+	if c.closedSend {
+		return errClosed
+	}
+
+	// We have to eagerly add to pending set. If we waited until after
+	// a successful write, it's possible that process could process the
+	// request and reply to it and consumeOutput goroutine could read
+	// the response, all concurrently before we've gotten a chance to
+	// add it. That would result in consumeOutput failing due to receiving
+	// a response for an unknown test case.
+	c.pendingMu.Lock()
+	_, exists := c.pendingOps[req.TestName]
+	if !exists {
+		c.pendingOps[req.TestName] = whenDone
+	}
+	c.pendingMu.Unlock()
+	if exists {
+		return fmt.Errorf("%w: %q", errDuplicate, req.TestName)
+	}
+
+	if err := writeDelimitedMessage(c.proc.stdin, req); err != nil {
+		// Since we eagerly added to pending set but failed to write,
+		// we now need to remove it to clean up.
+		c.pendingMu.Lock()
+		_, exists := c.pendingOps[req.TestName]
+		if exists {
+			delete(c.pendingOps, req.TestName)
+		}
+		c.pendingMu.Unlock()
+
+		if !exists {
+			// It was concurrently removed, which means the client *did* get the
+			// request and already replied, and consumeOutput already handled it.
+			return nil
+		}
+
+		if errors.Is(err, io.ErrClosedPipe) {
+			err = errors.New("could not write request: client closed stdin")
+		}
+		c.err.CompareAndSwap(nil, &err)
+		c.cancel()
+		return err
+	}
+
+	return nil
+}
+
+func (c *clientProcessRunner) closeSend() {
+	c.sendMu.Lock()
+	_ = c.proc.stdin.Close()
+	c.closedSend = true
+	c.sendMu.Unlock()
+}
+
+func (c *clientProcessRunner) waitForResponses() error {
+	<-c.done
+	procErr := c.proc.result()
+	err := c.err.Load()
+	if err != nil {
+		return *err
+	}
+	return procErr
+}
+
+func (c *clientProcessRunner) consumeOutput() {
+	defer close(c.done)
+	var reasonForReturn error
+	defer func() {
+		if reasonForReturn != nil && !errors.Is(reasonForReturn, io.EOF) {
+			c.err.CompareAndSwap(nil, &reasonForReturn)
+		}
+		c.closeSend() // stop the send side now that we're done with receive side
+
+		c.pendingMu.Lock()
+		defer c.pendingMu.Unlock()
+		for key, action := range c.pendingOps {
+			err := reasonForReturn
+			if err == nil || errors.Is(err, io.EOF) {
+				err = fmt.Errorf("client never provided response for test case %q", key)
+			}
+			action(key, nil, err)
+			delete(c.pendingOps, key)
+		}
+	}()
+
+	testCaseNames := map[string]struct{}{}
+	for {
+		resp := &conformancev1alpha1.ClientCompatResponse{}
+		var readErr error
+		readDone := make(chan struct{})
+		go func() {
+			defer close(readDone)
+			readErr = readDelimitedMessage(c.proc.stdout, resp)
+		}()
+
+		select {
+		case <-readDone:
+			if readErr != nil {
+				reasonForReturn = readErr
+				return
+			}
+		case <-time.After(testCaseTimeout):
+			reasonForReturn = errors.New("timed out waiting for result from client")
+		}
+
+		c.pendingMu.Lock()
+		action, ok := c.pendingOps[resp.TestName]
+		if ok {
+			delete(c.pendingOps, resp.TestName)
+		}
+		c.pendingMu.Unlock()
+		if !ok {
+			if _, ok := testCaseNames[resp.TestName]; ok {
+				// already processed this one
+				reasonForReturn = fmt.Errorf("duplicate response received for test case name %q", resp.TestName)
+			} else {
+				reasonForReturn = fmt.Errorf("received response for unrecognized test case name %q", resp.TestName)
+			}
+			return
+		}
+		testCaseNames[resp.TestName] = struct{}{}
+		action(resp.TestName, resp, nil)
+	}
+}

--- a/internal/app/connectconformance/client_runner_test.go
+++ b/internal/app/connectconformance/client_runner_test.go
@@ -1,0 +1,216 @@
+// Copyright 2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connectconformance
+
+import (
+	"context"
+	"errors"
+	"io"
+	"math/rand"
+	"sort"
+	"testing"
+
+	conformancev1alpha1 "connectrpc.com/conformance/internal/gen/proto/go/connectrpc/conformance/v1alpha1"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunClient(t *testing.T) {
+	t.Parallel()
+
+	testReqs := []*conformancev1alpha1.ClientCompatRequest{
+		{
+			TestName: "TestSuite1/testcase1",
+		},
+		{
+			TestName: "TestSuite1/testcase2",
+		},
+		{
+			TestName: "TestSuite2/testcase1",
+		},
+		{
+			TestName: "TestSuite2/testcase2",
+		},
+	}
+
+	testCases := []struct {
+		name            string
+		clientFunc      func(_ context.Context, _ []string, in io.ReadCloser, out, _ io.WriteCloser) error
+		expectErr       string
+		failToSend      int
+		expectedResults map[string]bool
+	}{
+		{
+			name:       "simple",
+			clientFunc: (&testClientProcess{}).run,
+			expectedResults: map[string]bool{
+				"TestSuite1/testcase1": true,
+				"TestSuite1/testcase2": true,
+				"TestSuite2/testcase1": true,
+				"TestSuite2/testcase2": true,
+			},
+		},
+		{
+			name:       "client fails",
+			clientFunc: (&testClientProcess{failAfter: 2}).run,
+			failToSend: 2,
+			expectErr:  "could not write request: client closed stdin",
+			expectedResults: map[string]bool{
+				"TestSuite1/testcase1": true,
+				"TestSuite1/testcase2": true,
+			},
+		},
+		{
+			name:       "random order",
+			clientFunc: testClientProcessRand,
+			expectedResults: map[string]bool{
+				"TestSuite1/testcase1": true,
+				"TestSuite1/testcase2": true,
+				"TestSuite2/testcase1": true,
+				"TestSuite2/testcase2": true,
+			},
+		},
+		{
+			name:       "broken",
+			clientFunc: testClientProcessBroken,
+			expectErr:  "broken",
+			expectedResults: map[string]bool{
+				"TestSuite1/testcase1": false,
+				"TestSuite1/testcase2": false,
+				"TestSuite2/testcase1": false,
+				"TestSuite2/testcase2": false,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			start := runInProcess(testCase.clientFunc)
+			runner, err := runClient(context.Background(), start)
+			require.NoError(t, err)
+
+			actualResults := make(map[string]bool, len(testReqs))
+			var actualFailedToSend int
+			for i, req := range testReqs {
+				err := runner.sendRequest(req, func(name string, _ *conformancev1alpha1.ClientCompatResponse, err error) {
+					actualResults[name] = err == nil
+				})
+				if err != nil {
+					actualFailedToSend = len(testReqs) - i
+					break
+				}
+			}
+			runner.closeSend()
+
+			err = runner.waitForResponses()
+			if testCase.expectErr != "" {
+				assert.ErrorContains(t, err, testCase.expectErr)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, testCase.failToSend, actualFailedToSend)
+			assert.Empty(t, cmp.Diff(testCase.expectedResults, actualResults))
+		})
+	}
+}
+
+// testClientProcess reads requests from in and immediately writes a corresponding response to out.
+type testClientProcess struct {
+	failAfter int
+}
+
+func (c *testClientProcess) run(_ context.Context, _ []string, in io.ReadCloser, out, _ io.WriteCloser) error {
+	var count int
+	for {
+		req := &conformancev1alpha1.ClientCompatRequest{}
+		if err := readDelimitedMessage(in, req); err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		}
+		resp := &conformancev1alpha1.ClientCompatResponse{
+			TestName: req.TestName,
+			Result: &conformancev1alpha1.ClientCompatResponse_Response{
+				Response: &conformancev1alpha1.ClientResponseResult{
+					Payloads: []*conformancev1alpha1.ConformancePayload{
+						{Data: []byte{0, 1, 2, 3, 4}},
+					},
+				},
+			},
+		}
+		if err := writeDelimitedMessage(out, resp); err != nil {
+			return err
+		}
+		count++
+		if c.failAfter > 0 && count >= c.failAfter {
+			return errors.New("failed")
+		}
+	}
+}
+
+func testClientProcessRand(_ context.Context, _ []string, in io.ReadCloser, out, _ io.WriteCloser) error {
+	var allCases []string
+	for {
+		req := &conformancev1alpha1.ClientCompatRequest{}
+		if err := readDelimitedMessage(in, req); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return err
+		}
+		allCases = append(allCases, req.TestName)
+	}
+
+	for {
+		rand.Shuffle(len(allCases), func(i, j int) {
+
+		})
+		// just make sure we didn't shuffle to a non-random permutation
+		isSorted := !sort.SliceIsSorted(allCases, func(i, j int) bool {
+			return allCases[i] < allCases[j]
+		})
+		if isSorted {
+			continue // try again
+		}
+		break
+	}
+
+	for _, name := range allCases {
+		resp := &conformancev1alpha1.ClientCompatResponse{
+			TestName: name,
+			Result: &conformancev1alpha1.ClientCompatResponse_Response{
+				Response: &conformancev1alpha1.ClientResponseResult{
+					Payloads: []*conformancev1alpha1.ConformancePayload{
+						{Data: []byte{0, 1, 2, 3, 4}},
+					},
+				},
+			},
+		}
+		if err := writeDelimitedMessage(out, resp); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func testClientProcessBroken(_ context.Context, _ []string, in io.ReadCloser, _, _ io.WriteCloser) error {
+	_, _ = io.Copy(io.Discard, in)
+	return errors.New("broken")
+}

--- a/internal/app/connectconformance/delimited.go
+++ b/internal/app/connectconformance/delimited.go
@@ -1,0 +1,58 @@
+// Copyright 2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connectconformance
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+
+	"google.golang.org/protobuf/proto"
+)
+
+func readDelimitedMessage[T proto.Message](in io.Reader, msg T) error {
+	var lenBuffer [4]byte
+	if _, err := io.ReadFull(in, lenBuffer[:]); err != nil {
+		return err
+	}
+	data := make([]byte, binary.BigEndian.Uint32(lenBuffer[:]))
+	if _, err := io.ReadFull(in, data); err != nil {
+		if errors.Is(err, io.EOF) {
+			err = io.ErrUnexpectedEOF
+		}
+		return err
+	}
+	if err := proto.Unmarshal(data, msg); err != nil {
+		return fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+	return nil
+}
+
+func writeDelimitedMessage[T proto.Message](out io.Writer, msg T) error {
+	data, err := proto.Marshal(msg)
+	if err != nil {
+		return err
+	}
+	var lenBuffer [4]byte
+	binary.BigEndian.PutUint32(lenBuffer[:], uint32(len(data)))
+	if _, err := out.Write(lenBuffer[:]); err != nil {
+		return err
+	}
+	if _, err := out.Write(data); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/app/connectconformance/process.go
+++ b/internal/app/connectconformance/process.go
@@ -1,0 +1,186 @@
+// Copyright 2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//nolint:unused // some stuff is currently unused but will be used by future changes
+package connectconformance
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"time"
+)
+
+const (
+	gracefulShutdownPeriod = 5 * time.Second
+)
+
+// process represents some asynchronous execution unit. It may be in another
+// OS process or it may actually be another goroutine in the current OS process.
+type process struct {
+	processController
+
+	stdin  io.WriteCloser
+	stdout io.Reader
+	stderr io.Reader
+}
+
+type processController interface {
+	// result returns nil if the process exits normally and an error otherwise.
+	// If the process is a separate OS process that exits with a non-zero code,
+	// this will return an instance of *[exec.ExitError].
+	result() error
+	abort()
+	whenDone(func(error))
+}
+
+type processStarter func(ctx context.Context, pipeStderr bool) (*process, error)
+
+// runCommand returns a process starter that invokes the given command-line in
+// a separate OS process.
+func runCommand(command []string) processStarter {
+	return makeProcess(func(ctx context.Context, stdin io.ReadCloser, stdout, stderr io.WriteCloser) (processController, error) {
+		cmd := exec.CommandContext(ctx, command[0], command[1:]...) //nolint:gosec
+		cmd.Stdin = stdin
+		cmd.Stdout = stdout
+		cmd.Stderr = stderr
+		cmd.Cancel = func() error {
+			err := cmd.Process.Signal(os.Interrupt)
+			if err != nil {
+				// Interrupt not supported on Windows. If interrupt fails, try sending kill.
+				err = cmd.Process.Signal(os.Kill)
+			}
+			return err
+		}
+		cmd.WaitDelay = gracefulShutdownPeriod
+		if err := cmd.Start(); err != nil {
+			return nil, err
+		}
+		return (*cmdProcess)(cmd), nil
+	})
+}
+
+// runInProcess returns a process starter that invokes the given function
+// in another goroutine.
+func runInProcess(impl func(ctx context.Context, args []string, in io.ReadCloser, out, err io.WriteCloser) error) processStarter {
+	return makeProcess(func(ctx context.Context, stdin io.ReadCloser, stdout, stderr io.WriteCloser) (processController, error) {
+		ctx, cancel := context.WithCancel(ctx)
+		proc := &localProcess{
+			cancel: cancel,
+			done:   make(chan struct{}),
+		}
+		if stdin == nil {
+			stdin = os.Stdin
+		}
+		if stdout == nil {
+			stdout = os.Stdout
+		}
+		if stderr == nil {
+			stderr = os.Stderr
+		}
+		go func() {
+			defer close(proc.done)
+			defer func() {
+				if stdin != os.Stdin {
+					_ = stdin.Close()
+				}
+				if stdout != os.Stdout {
+					_ = stdout.Close()
+				}
+				if stderr != os.Stderr {
+					_ = stderr.Close()
+				}
+			}()
+			proc.err = impl(ctx, nil, stdin, stdout, stderr)
+		}()
+		return proc, nil
+	})
+}
+
+func makeProcess(procFunc func(ctx context.Context, stdin io.ReadCloser, stdout, stderr io.WriteCloser) (processController, error)) processStarter {
+	return func(ctx context.Context, pipeStderr bool) (*process, error) {
+		stdinReader, stdinWriter := io.Pipe()
+		stdoutReader, stdoutWriter := io.Pipe()
+		var stderrReader io.ReadCloser
+		var stderrWriter io.WriteCloser
+		if pipeStderr {
+			stderrReader, stderrWriter = io.Pipe()
+		} else {
+			stderrReader = io.NopCloser(bytes.NewReader(nil)) // empty
+			stderrWriter = os.Stderr
+		}
+		proc, err := procFunc(ctx, stdinReader, stdoutWriter, stderrWriter)
+		if err != nil {
+			return nil, err
+		}
+		return &process{
+			processController: proc,
+			stdin:             stdinWriter,
+			stdout:            stdoutReader,
+			stderr:            stderrReader,
+		}, nil
+	}
+}
+
+type cmdProcess exec.Cmd
+
+func (c *cmdProcess) result() error {
+	return (*exec.Cmd)(c).Wait()
+}
+
+func (c *cmdProcess) abort() {
+	cmd := (*exec.Cmd)(c)
+	err := cmd.Cancel()
+	if err == nil || errors.Is(err, os.ErrProcessDone) {
+		// done
+		return
+	}
+	// Failed to cancel? Try to kill the process.
+	_ = cmd.Process.Kill()
+}
+
+func (c *cmdProcess) whenDone(action func(error)) {
+	go func() {
+		action(c.result())
+	}()
+}
+
+type localProcess struct {
+	cancel context.CancelFunc
+	done   chan struct{}
+	err    error
+}
+
+func (l *localProcess) result() error {
+	select {
+	case <-l.done:
+		return l.err
+	case <-time.After(gracefulShutdownPeriod):
+		return context.DeadlineExceeded
+	}
+}
+
+func (l *localProcess) abort() {
+	l.cancel()
+}
+
+func (l *localProcess) whenDone(action func(error)) {
+	go func() {
+		<-l.done
+		action(l.err)
+	}()
+}


### PR DESCRIPTION
This defines some process-related types, for modeling client and server processes.

It also includes a "client runner", which is a wrapper around a client-under-test or reference client process that handles the serialization of requests to the process's stdin and the de-serialization of responses from the process's stdout.

It also adds helpers for reading/writing streams of delimited messages -- where each message is delimited by a four-byte preface that indicates the message's size.