### PR TITLE
V2: Smarter assertions about whether the client response matches the expected response

### DIFF
--- a/internal/app/connectconformance/results.go
+++ b/internal/app/connectconformance/results.go
@@ -15,16 +15,23 @@
 package connectconformance
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 
 	conformancev1alpha1 "connectrpc.com/conformance/internal/gen/proto/go/connectrpc/conformance/v1alpha1"
+	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/anypb"
 )
+
+const timeoutCheckGracePeriodMillis = 500
 
 // testResults represents the results of running conformance tests. It accumulates
 // the state of passed and failed test cases and also reports failures to a given
@@ -99,16 +106,41 @@ func (r *testResults) failed(testCase string, err *conformancev1alpha1.ClientErr
 // assert will examine the actual and expected RPC result and mark the test
 // case as successful or failed accordingly.
 func (r *testResults) assert(testCase string, expected, actual *conformancev1alpha1.ClientResponseResult) {
-	// TODO: Need to do smart processing of expected and actual to make sure
-	//       actual *complies* with expected (doesn't necessarily have to match
-	//       exactly; for example extra response headers are fine...)
-	//       Also, more bespoke checks will also result in better error messages
-	//       for users, so they know what went wrong.
-	var err error
-	if !proto.Equal(expected, actual) {
-		err = &expectationFailedError{expected: expected, actual: actual}
+	var errs multiErrors
+
+	if len(expected.Payloads) == 0 && expected.Error != nil && (len(actual.ResponseHeaders) == 0 || len(actual.ResponseTrailers) == 0) {
+		// When there are no messages in the body, only an error, the server may send a
+		// trailers-only response. In that case, it is acceptable for the client the
+		// expected headers and trailers to be merged into one set, and it is acceptable
+		// for the client to interpret them as either headers or trailers.
+		merged := mergeHeaders(expected.ResponseHeaders, expected.ResponseTrailers)
+		var actualHeaders []*conformancev1alpha1.Header
+		if len(actual.ResponseHeaders) == 0 {
+			actualHeaders = actual.ResponseTrailers
+		} else {
+			actualHeaders = actual.ResponseHeaders
+		}
+		errs = append(errs, checkHeaders("response metadata", merged, actualHeaders)...)
+	} else {
+		errs = append(errs, checkHeaders("response headers", expected.ResponseHeaders, actual.ResponseHeaders)...)
+		errs = append(errs, checkHeaders("response trailers", expected.ResponseTrailers, actual.ResponseTrailers)...)
 	}
-	r.setOutcome(testCase, false, err)
+
+	errs = append(errs, checkPayloads(expected.Payloads, actual.Payloads)...)
+
+	if diff := cmp.Diff(expected.Error, actual.Error, protocmp.Transform()); diff != "" {
+		errs = append(errs, fmt.Errorf("actual error does not match expected error: - wanted, + got\n%s", diff))
+	}
+
+	// If client didn't provide actual raw error, we skip this check.
+	if expected.ConnectErrorRaw != nil && actual.ConnectErrorRaw != nil {
+		diff := cmp.Diff(expected.ConnectErrorRaw, actual.ConnectErrorRaw, protocmp.Transform())
+		if diff != "" {
+			errs = append(errs, fmt.Errorf("raw Connect error does not match: - wanted, + got\n%s", diff))
+		}
+	}
+
+	r.setOutcome(testCase, false, errs.Result())
 }
 
 // recordServerSideband accepts an error message for a test that was sent
@@ -183,10 +215,138 @@ type testOutcome struct {
 	knownFailing bool
 }
 
-type expectationFailedError struct {
-	expected, actual *conformancev1alpha1.ClientResponseResult
+type multiErrors []error
+
+func (e multiErrors) Error() string {
+	var buf bytes.Buffer
+	for i, err := range e {
+		if i > 0 {
+			buf.WriteByte('\n')
+		}
+		buf.WriteString(err.Error())
+	}
+	return buf.String()
 }
 
-func (e *expectationFailedError) Error() string {
-	return "actual result did not match expected result"
+func (e multiErrors) Result() error {
+	switch len(e) {
+	case 0:
+		return nil
+	case 1:
+		return e[0]
+	default:
+		return e
+	}
+}
+
+func mergeHeaders(a, b []*conformancev1alpha1.Header) []*conformancev1alpha1.Header {
+	mergedMap := map[string][]string{}
+	for _, hdr := range a {
+		mergedMap[strings.ToLower(hdr.Name)] = hdr.Value
+	}
+	for _, hdr := range b {
+		mergedMap[strings.ToLower(hdr.Name)] = append(mergedMap[strings.ToLower(hdr.Name)], hdr.Value...)
+	}
+	results := make([]*conformancev1alpha1.Header, 0, len(mergedMap))
+	for k, v := range mergedMap {
+		results = append(results, &conformancev1alpha1.Header{Name: k, Value: v})
+	}
+	return results
+}
+
+func checkHeaders(what string, expected, actual []*conformancev1alpha1.Header) multiErrors {
+	var errs multiErrors
+	actualHeaders := map[string][]string{}
+	for _, hdr := range actual {
+		actualHeaders[strings.ToLower(hdr.Name)] = hdr.Value
+	}
+	for _, hdr := range expected {
+		name := strings.ToLower(hdr.Name)
+		actualVals, ok := actualHeaders[name]
+		if !ok {
+			errs = append(errs, fmt.Errorf("actual %s missing %q", what, name))
+			continue
+		}
+		actualStr := headerValsToString(actualVals)
+		expectedStr := headerValsToString(hdr.Value)
+		if actualStr != expectedStr {
+			errs = append(errs, fmt.Errorf("%s has incorrect values for %q: expected [%s], got [%s]", what, name, expectedStr, actualStr))
+		}
+	}
+	return errs
+}
+
+func headerValsToString(vals []string) string {
+	var buf bytes.Buffer
+	for i, val := range vals {
+		if i > 0 {
+			buf.WriteString(", ")
+		}
+		buf.WriteString(strconv.Quote(val))
+	}
+	return buf.String()
+}
+
+func checkPayloads(expected, actual []*conformancev1alpha1.ConformancePayload) multiErrors {
+	var errs multiErrors
+	if len(actual) != len(expected) {
+		errs = append(errs, fmt.Errorf("expecting %d response messages but instead got %d", len(expected), len(actual)))
+	}
+	reqNum := 0
+	for i := 0; i < len(actual) && i < len(expected); i++ {
+		actualPayload := actual[i]
+		expectedPayload := expected[i]
+		if !bytes.Equal(actualPayload.Data, expectedPayload.Data) {
+			errs = append(errs, fmt.Errorf("response #%d: expecting data %x, got %x", i+1, expectedPayload.Data, actualPayload.Data))
+		}
+		actualReq := actualPayload.GetRequestInfo()
+		expectedReq := expectedPayload.GetRequestInfo()
+
+		if i == 0 { //nolint:nestif
+			// Validate headers, timeout, and query params. We only need to do this once, for first payload.
+			errs = append(errs, checkHeaders("request headers", expectedReq.GetRequestHeaders(), actualReq.GetRequestHeaders())...)
+			if expectedReq != nil && expectedReq.TimeoutMs != nil {
+				if actualReq == nil || actualReq.TimeoutMs == nil {
+					errs = append(errs, fmt.Errorf("server did not echo back a timeout but one was expected (%d ms)", expectedReq.GetTimeoutMs()))
+				} else {
+					max := expectedReq.GetTimeoutMs()
+					min := max - timeoutCheckGracePeriodMillis
+					if min < 0 {
+						min = 0
+					}
+					if actualReq.GetTimeoutMs() > max || actualReq.GetTimeoutMs() < min {
+						errs = append(errs, fmt.Errorf("server echoed back a timeout (%d ms) that did not match expected (%d ms)", actualReq.GetTimeoutMs(), expectedReq.GetTimeoutMs()))
+					}
+				}
+			} else if actualReq != nil && actualReq.TimeoutMs != nil {
+				errs = append(errs, fmt.Errorf("server echoed back a timeout (%d ms) but none was expected", actualReq.GetTimeoutMs()))
+			}
+			if len(expectedReq.GetConnectGetInfo().GetQueryParams()) > 0 && len(actualReq.GetConnectGetInfo().GetQueryParams()) > 0 {
+				errs = append(errs, checkHeaders("request query params", expectedReq.GetConnectGetInfo().GetQueryParams(), actualReq.GetConnectGetInfo().GetQueryParams())...)
+			}
+		}
+
+		if len(actualReq.GetRequests()) != len(expectedReq.GetRequests()) {
+			errs = append(errs, fmt.Errorf("response #%d: expecting %d request messages to be described but instead got %d", i+1, len(expectedReq.GetRequests()), len(actualReq.GetRequests())))
+		}
+		for i := 0; i < len(actualReq.GetRequests()) && i < len(expectedReq.GetRequests()); i++ {
+			reqNum++
+			actualMsg, err := anypb.UnmarshalNew(actualReq.GetRequests()[i], proto.UnmarshalOptions{})
+			if err != nil {
+				errs = append(errs, fmt.Errorf("request #%d: failed to unmarshal actual message: %w", reqNum, err))
+				continue
+			}
+			expectedMsg, err := anypb.UnmarshalNew(expectedReq.GetRequests()[i], proto.UnmarshalOptions{})
+			if err != nil {
+				errs = append(errs, fmt.Errorf("request #%d: failed to unmarshal expected message: %w", reqNum, err))
+				continue
+			}
+			diff := cmp.Diff(expectedMsg, actualMsg, protocmp.Transform())
+			if diff != "" {
+				errs = append(errs, fmt.Errorf("request #%d: did not survive round-trip: - wanted, + got\n%s", reqNum, diff))
+			}
+		}
+	}
+
+	return errs
 }

--- a/internal/app/connectconformance/results_test.go
+++ b/internal/app/connectconformance/results_test.go
@@ -17,6 +17,7 @@ package connectconformance
 import (
 	"bytes"
 	"errors"
+	"strings"
 	"testing"
 
 	conformancev1alpha1 "connectrpc.com/conformance/internal/gen/proto/go/connectrpc/conformance/v1alpha1"
@@ -123,13 +124,20 @@ func TestResults_Assert(t *testing.T) {
 	logger := &lineWriter{}
 	err := results.report(logger)
 	require.NoError(t, err)
-	require.Len(t, logger.lines, 6)
-	require.Contains(t, logger.lines[0], "FAILED: foo/bar/1: ")
-	require.Contains(t, logger.lines[1], "FAILED: foo/bar/2: ")
-	require.Contains(t, logger.lines[2], "INFO: known-to-fail/1 failed (as expected): ")
-	require.Contains(t, logger.lines[3], "INFO: known-to-fail/2 failed (as expected): ")
-	require.Equal(t, logger.lines[4], "FAILED: known-to-fail/3 was expected to fail but did not\n")
-	require.Equal(t, logger.lines[5], "FAILED: known-to-fail/4 was expected to fail but did not\n")
+	// only keep the summary lines:
+	var lines []string
+	for _, line := range logger.lines {
+		if strings.HasPrefix(line, "FAILED: ") || strings.HasPrefix(line, "INFO: ") {
+			lines = append(lines, line)
+		}
+	}
+	require.Len(t, lines, 6)
+	require.Contains(t, lines[0], "FAILED: foo/bar/1: ")
+	require.Contains(t, lines[1], "FAILED: foo/bar/2: ")
+	require.Contains(t, lines[2], "INFO: known-to-fail/1 failed (as expected): ")
+	require.Contains(t, lines[3], "INFO: known-to-fail/2 failed (as expected): ")
+	require.Equal(t, lines[4], "FAILED: known-to-fail/3 was expected to fail but did not\n")
+	require.Equal(t, lines[5], "FAILED: known-to-fail/4 was expected to fail but did not\n")
 }
 
 func TestResults_ServerSideband(t *testing.T) {


### PR DESCRIPTION
This addresses the TODO about how comparing the actual response to expected needed to be more sophisticated.

In particular:
1. It is acceptable for the actual headers/trailers to contain more than what's in the test expectation. Not only is it common for some HTTP client/server frameworks to add add'l headers (like "Date", "User-Agent", etc.), but we also don't want to hard-code all of the protocol-specific headers into the test case data (e.g. "Content-Type").
2. It is acceptable for a client or server to merge headers and trailers for responses that have empty response streams and an error. These can be conveyed via "trailers-only responses" in the gRPC protocol, in which case it is not possible to separate headers and trailers. Furthermore, such responses are actually "headers-only" on the wire, so we allow the sets to be merged into either headers or trailers under these specific conditions.
3. It is acceptable for the server to omit the Connect GET query params in its response.
4. It is acceptable for the client to omit the raw Connect error details.
5. `Any` messages need smarter treatment than just `proto.Equal` since two semantically equivalent messages could be serialized differently, which means the `value` byte slices in two messages may differ and cause `proto.Equal` to consider them unequal.

This adds new test cases to hopefully verify that the checks are working as expected.

Sorry the diff is kinda big. It's nearly all in the second commit and due to response data in the test cases.