### PR TITLE
V2: Add the test runner: cmd/connectconformance

### DIFF
--- a/cmd/connectconformance/main.go
+++ b/cmd/connectconformance/main.go
@@ -27,14 +27,12 @@ const (
 	modeFlagName         = "mode"
 	configFlagName       = "conf"
 	knownFailingFlagName = "known-failing"
-	maxServersFlagName   = "max-servers"
 )
 
 type flags struct {
 	mode             string
 	configFile       string
 	knownFailingFile string
-	maxServers       uint
 }
 
 func main() {
@@ -88,7 +86,6 @@ func bind(cmd *cobra.Command, flags *flags) {
 	cmd.Flags().StringVar(&flags.mode, modeFlagName, "", "required: the mode of the test to run; must be 'client' or 'server'")
 	cmd.Flags().StringVar(&flags.configFile, configFlagName, "", "a config file in YAML format with supported features")
 	cmd.Flags().StringVar(&flags.knownFailingFile, knownFailingFlagName, "", "a file with a list of known-failing test cases")
-	cmd.Flags().UintVar(&flags.maxServers, maxServersFlagName, 4, "the maximum number of server processes to run concurrently")
 }
 
 func run(flags *flags, command []string) {
@@ -108,7 +105,6 @@ func run(flags *flags, command []string) {
 			Mode:             mode,
 			ConfigFile:       flags.configFile,
 			KnownFailingFile: flags.knownFailingFile,
-			MaxServers:       flags.maxServers,
 		},
 		command,
 		os.Stdout,

--- a/cmd/connectconformance/main.go
+++ b/cmd/connectconformance/main.go
@@ -1,0 +1,119 @@
+// Copyright 2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"log"
+	"os"
+
+	"connectrpc.com/conformance/internal/app/connectconformance"
+	conformancev1alpha1 "connectrpc.com/conformance/internal/gen/proto/go/connectrpc/conformance/v1alpha1"
+	"github.com/spf13/cobra"
+)
+
+const (
+	modeFlagName         = "mode"
+	configFlagName       = "conf"
+	knownFailingFlagName = "known-failing"
+	maxServersFlagName   = "max-servers"
+)
+
+type flags struct {
+	mode             string
+	configFile       string
+	knownFailingFile string
+	maxServers       uint
+}
+
+func main() {
+	flagset := &flags{}
+	rootCmd := &cobra.Command{
+		Use:   "connectconformance --mode [client|server] command...",
+		Short: "Runs conformance tests against the given command.",
+		Long: `Runs conformance tests against a Connect implementation. Depending on the mode,
+the given command must be either a conformance client or a conformance server.
+
+A conformance client tests a client implementation: the command reads test cases
+from stdin. Each test case describes an RPC to make. The command then records
+the result of each operation to stdout. The input is a sequence of binary-encoded
+Protobuf messages of type connectrpc.conformance.v1alpha1.ClientCompatRequest,
+each prefixed with a varint-encoded length. The output is expected to be similar:
+a sequence of varint-encoded-length-prefixed messages, but the results are of
+type connectrpc.conformance.v1alpha1.ClientCompatResponse. The command should exit
+when it has read all test cases (i.e reached EOF of stdin) and then issued RPCs
+and recorded all results to stdout. The command should also exit and abort any
+in-progress RPCs if it receives a SIGTERM signal.
+
+A conformance server tests a server implementation: the command reads the required
+server properties from stdin. This comes in the form of a binary-encoded Protobuf
+message of type connectrpc.conformance.v1alpha1.ServerCompatRequest. The command
+should then start a server process and write its properties to stdout in the form
+of a binary-encoded connectrpc.conformance.v1alpha1.ServerCompatResponse message.
+The server process should provide an implementation of the test service defined
+by connectrpc.conformance.v1alpha1.ConformanceService. The command should exit
+upon receiving a SIGTERM signal. The command maybe invoked repeatedly, to start
+and test servers with different properties.
+
+A configuration file may be provided which specifies what features the client
+or server under test supports. This is used to filter the set of test cases
+that will be executed. If no config file is indicated, all tests will be run.
+
+A file with a list of known-failing test cases may also be provided. For these
+cases, the test runner reverses its assertions: it considers the test case
+failing to be successful; if the test case succeeds, it is considered a failure.
+(The latter aspect makes sure that the file doesn't is up-to-date and does not
+include test cases which have actually been fixed.)
+`,
+		Run: func(cmd *cobra.Command, args []string) {
+			run(flagset, args)
+		},
+	}
+	bind(rootCmd, flagset)
+	_ = rootCmd.Execute()
+}
+
+func bind(cmd *cobra.Command, flags *flags) {
+	cmd.Flags().StringVar(&flags.mode, modeFlagName, "", "required: the mode of the test to run; must be 'client' or 'server'")
+	cmd.Flags().StringVar(&flags.configFile, configFlagName, "", "a config file in YAML format with supported features")
+	cmd.Flags().StringVar(&flags.knownFailingFile, knownFailingFlagName, "", "a file with a list of known-failing test cases")
+	cmd.Flags().UintVar(&flags.maxServers, maxServersFlagName, 4, "the maximum number of server processes to run concurrently")
+}
+
+func run(flags *flags, command []string) {
+	var mode conformancev1alpha1.TestSuite_TestMode
+	switch flags.mode {
+	case "client":
+		mode = conformancev1alpha1.TestSuite_TEST_MODE_CLIENT
+	case "server":
+		mode = conformancev1alpha1.TestSuite_TEST_MODE_SERVER
+	default:
+		// TODO: support mode "both", which would allow the caller to supply both the
+		//       client and server commands, instead of using a reference impl?
+		log.Fatalf(`invalid mode: expecting "client" or "server""; got %q`, flags.mode)
+	}
+	err := connectconformance.Run(
+		&connectconformance.Flags{
+			Mode:             mode,
+			ConfigFile:       flags.configFile,
+			KnownFailingFile: flags.knownFailingFile,
+			MaxServers:       flags.maxServers,
+		},
+		command,
+		os.Stdout,
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/klauspost/compress v1.17.2
 	github.com/rs/cors v1.10.1
+	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/net v0.15.0
 	google.golang.org/protobuf v1.31.0
@@ -21,7 +22,9 @@ require (
 	github.com/bufbuild/protovalidate-go v0.3.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/cel-go v0.18.1 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
 	golang.org/x/text v0.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,7 @@ github.com/bufbuild/protovalidate-go v0.3.2 h1:7sG1R83PkCzOZb3P187gAchWFLHY6LQ8a
 github.com/bufbuild/protovalidate-go v0.3.2/go.mod h1:ywZqKUjMhQA8fmhsc+0DUlMfan8/umJ+5mKvjdxAD3M=
 github.com/bufbuild/protoyaml-go v0.1.4 h1:wPSKIb/DkHwUK71Dqw5cUkLpohWD7JY+TeLBbrlN8nM=
 github.com/bufbuild/protoyaml-go v0.1.4/go.mod h1:6G7eGacFmps/ilH7uyfjv18HQ74Feri8I5dZi7XMs1o=
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -22,6 +23,8 @@ github.com/google/cel-go v0.18.1/go.mod h1:PVAybmSnWkNMUZR/tEWFUiJ1Np4Hz0MHsZJcg
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/klauspost/compress v1.17.2 h1:RlWWUY/Dr4fL8qk9YG7DTZ7PDgME2V4csBXA8L/ixi4=
 github.com/klauspost/compress v1.17.2/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
@@ -30,6 +33,11 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rs/cors v1.10.1 h1:L0uuZVXIKlI1SShY2nhFfo44TYvDPQ1w4oFkUJNfhyo=
 github.com/rs/cors v1.10.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
+github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stoewer/go-strcase v1.3.0 h1:g0eASXYtp+yvN9fK8sH94oCIk0fau9uV1/ZdJ0AVEzs=
 github.com/stoewer/go-strcase v1.3.0/go.mod h1:fAH5hQ5pehh+j3nZfvwdk2RgEgQjAoM8wodgtPmh1xo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/internal/app/connectconformance/connectconformance.go
+++ b/internal/app/connectconformance/connectconformance.go
@@ -32,7 +32,6 @@ type Flags struct {
 	Mode             conformancev1alpha1.TestSuite_TestMode
 	ConfigFile       string
 	KnownFailingFile string
-	MaxServers       uint
 }
 
 func Run(flags *Flags, command []string, logOut io.Writer) error {

--- a/internal/app/connectconformance/connectconformance.go
+++ b/internal/app/connectconformance/connectconformance.go
@@ -1,0 +1,132 @@
+// Copyright 2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connectconformance
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+
+	"connectrpc.com/conformance/internal/app/client"
+	"connectrpc.com/conformance/internal/app/connectconformance/testsuites"
+	"connectrpc.com/conformance/internal/app/server"
+	conformancev1alpha1 "connectrpc.com/conformance/internal/gen/proto/go/connectrpc/conformance/v1alpha1"
+)
+
+type Flags struct {
+	Mode             conformancev1alpha1.TestSuite_TestMode
+	ConfigFile       string
+	KnownFailingFile string
+	MaxServers       uint
+}
+
+func Run(flags *Flags, command []string, logOut io.Writer) error {
+	var configData []byte
+	if flags.ConfigFile != "" {
+		var err error
+		if configData, err = os.ReadFile(flags.ConfigFile); err != nil {
+			return ensureFileName(err, flags.ConfigFile)
+		}
+	}
+	configCases, err := parseConfig(flags.ConfigFile, configData)
+	if err != nil {
+		return err
+	}
+
+	var knownFailingData []byte
+	if flags.KnownFailingFile != "" {
+		var err error
+		if knownFailingData, err = os.ReadFile(flags.KnownFailingFile); err != nil {
+			return ensureFileName(err, flags.KnownFailingFile)
+		}
+	}
+	knownFailing := parseKnownFailing(knownFailingData)
+	if err != nil {
+		return err
+	}
+
+	// TODO: allow test suite files to indicate on command-line to override use
+	//       of built-in, embedded test suite data
+	testSuiteData, err := testsuites.LoadTestSuites()
+	if err != nil {
+		return fmt.Errorf("failed to load embedded test suite data: %w", err)
+	}
+	allSuites, err := parseTestSuites(testSuiteData)
+	if err != nil {
+		return fmt.Errorf("embedded test suite: %w", err)
+	}
+	testCaseLib, err := newTestCaseLibrary(allSuites, configCases, flags.Mode)
+	if err != nil {
+		return err
+	}
+
+	// Validate keys in knownFailing, to make sure they match actual test names
+	// (to prevent accidental typos and inadvertently ignored entries)
+	for name := range testCaseLib.testCases {
+		knownFailing.match(strings.Split(name, "/"))
+	}
+	unmatched := map[string]struct{}{}
+	knownFailing.findUnmatched("", unmatched)
+	if len(unmatched) > 0 {
+		unmatchedSlice := make([]string, 0, len(unmatched))
+		for name := range unmatched {
+			unmatchedSlice = append(unmatchedSlice, name)
+		}
+		sort.Strings(unmatchedSlice)
+		return fmt.Errorf("file %s contains unmatched and possibly invalid patterns:\n%v",
+			flags.KnownFailingFile, strings.Join(unmatchedSlice, "\n"))
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	isClient := flags.Mode == conformancev1alpha1.TestSuite_TEST_MODE_CLIENT
+	var startClient processStarter
+	if isClient {
+		startClient = runCommand(command)
+	} else {
+		startClient = runInProcess("reference-client", client.Run)
+	}
+	clientProcess, err := runClient(ctx, startClient)
+	if err != nil {
+		return fmt.Errorf("error starting client: %w", err)
+	}
+	defer clientProcess.stop()
+
+	results := newResults(knownFailing)
+
+	var startServer processStarter
+	if isClient {
+		startServer = runInProcess("reference-server", server.Run)
+	} else {
+		startServer = runCommand(command)
+	}
+	// TODO: start servers in parallel (up to a limit) to allow parallelism and faster test execution
+	for svrInstance, testCases := range testCaseLib.casesByServer {
+		runTestCasesForServer(ctx, isClient, svrInstance, testCases, startServer, results, clientProcess)
+		if !clientProcess.isRunning() {
+			return clientProcess.waitForResponses()
+		}
+	}
+	clientProcess.closeSend()
+	if err := clientProcess.waitForResponses(); err != nil {
+		return err
+	}
+
+	return results.report(logOut)
+}

--- a/internal/app/connectconformance/process.go
+++ b/internal/app/connectconformance/process.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:unused // some stuff is currently unused but will be used by future changes
 package connectconformance
 
 import (

--- a/internal/app/connectconformance/results.go
+++ b/internal/app/connectconformance/results.go
@@ -15,16 +15,23 @@
 package connectconformance
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 
 	conformancev1alpha1 "connectrpc.com/conformance/internal/gen/proto/go/connectrpc/conformance/v1alpha1"
+	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/anypb"
 )
+
+const timeoutCheckGracePeriodMillis = 500
 
 // testResults represents the results of running conformance tests. It accumulates
 // the state of passed and failed test cases and also reports failures to a given
@@ -99,16 +106,41 @@ func (r *testResults) failed(testCase string, err *conformancev1alpha1.ClientErr
 // assert will examine the actual and expected RPC result and mark the test
 // case as successful or failed accordingly.
 func (r *testResults) assert(testCase string, expected, actual *conformancev1alpha1.ClientResponseResult) {
-	// TODO: Need to do smart processing of expected and actual to make sure
-	//       actual *complies* with expected (doesn't necessarily have to match
-	//       exactly; for example extra response headers are fine...)
-	//       Also, more bespoke checks will also result in better error messages
-	//       for users, so they know what went wrong.
-	var err error
-	if !proto.Equal(expected, actual) {
-		err = &expectationFailedError{expected: expected, actual: actual}
+	var errs multiErrors
+
+	if len(expected.Payloads) == 0 && expected.Error != nil && (len(actual.ResponseHeaders) == 0 || len(actual.ResponseTrailers) == 0) {
+		// When there are no messages in the body, only an error, the server may send a
+		// trailers-only response. In that case, it is acceptable for the client the
+		// expected headers and trailers to be merged into one set, and it is acceptable
+		// for the client to interpret them as either headers or trailers.
+		merged := mergeHeaders(expected.ResponseHeaders, expected.ResponseTrailers)
+		var actualHeaders []*conformancev1alpha1.Header
+		if len(actual.ResponseHeaders) == 0 {
+			actualHeaders = actual.ResponseTrailers
+		} else {
+			actualHeaders = actual.ResponseHeaders
+		}
+		errs = append(errs, checkHeaders("response metadata", merged, actualHeaders)...)
+	} else {
+		errs = append(errs, checkHeaders("response headers", expected.ResponseHeaders, actual.ResponseHeaders)...)
+		errs = append(errs, checkHeaders("response trailers", expected.ResponseTrailers, actual.ResponseTrailers)...)
 	}
-	r.setOutcome(testCase, false, err)
+
+	errs = append(errs, checkPayloads(expected.Payloads, actual.Payloads)...)
+
+	if diff := cmp.Diff(expected.Error, actual.Error, protocmp.Transform()); diff != "" {
+		errs = append(errs, fmt.Errorf("actual error does not match expected error: - wanted, + got\n%s", diff))
+	}
+
+	// If client didn't provide actual raw error, we skip this check.
+	if expected.ConnectErrorRaw != nil && actual.ConnectErrorRaw != nil {
+		diff := cmp.Diff(expected.ConnectErrorRaw, actual.ConnectErrorRaw, protocmp.Transform())
+		if diff != "" {
+			errs = append(errs, fmt.Errorf("raw Connect error does not match: - wanted, + got\n%s", diff))
+		}
+	}
+
+	r.setOutcome(testCase, false, errs.Result())
 }
 
 // recordServerSideband accepts an error message for a test that was sent
@@ -183,10 +215,138 @@ type testOutcome struct {
 	knownFailing bool
 }
 
-type expectationFailedError struct {
-	expected, actual *conformancev1alpha1.ClientResponseResult
+type multiErrors []error
+
+func (e multiErrors) Error() string {
+	var buf bytes.Buffer
+	for i, err := range e {
+		if i > 0 {
+			buf.WriteByte('\n')
+		}
+		buf.WriteString(err.Error())
+	}
+	return buf.String()
 }
 
-func (e *expectationFailedError) Error() string {
-	return "actual result did not match expected result"
+func (e multiErrors) Result() error {
+	switch len(e) {
+	case 0:
+		return nil
+	case 1:
+		return e[0]
+	default:
+		return e
+	}
+}
+
+func mergeHeaders(a, b []*conformancev1alpha1.Header) []*conformancev1alpha1.Header {
+	mergedMap := map[string][]string{}
+	for _, hdr := range a {
+		mergedMap[strings.ToLower(hdr.Name)] = hdr.Value
+	}
+	for _, hdr := range b {
+		mergedMap[strings.ToLower(hdr.Name)] = append(mergedMap[strings.ToLower(hdr.Name)], hdr.Value...)
+	}
+	results := make([]*conformancev1alpha1.Header, 0, len(mergedMap))
+	for k, v := range mergedMap {
+		results = append(results, &conformancev1alpha1.Header{Name: k, Value: v})
+	}
+	return results
+}
+
+func checkHeaders(what string, expected, actual []*conformancev1alpha1.Header) multiErrors {
+	var errs multiErrors
+	actualHeaders := map[string][]string{}
+	for _, hdr := range actual {
+		actualHeaders[strings.ToLower(hdr.Name)] = hdr.Value
+	}
+	for _, hdr := range expected {
+		name := strings.ToLower(hdr.Name)
+		actualVals, ok := actualHeaders[name]
+		if !ok {
+			errs = append(errs, fmt.Errorf("actual %s missing %q", what, name))
+			continue
+		}
+		actualStr := headerValsToString(actualVals)
+		expectedStr := headerValsToString(hdr.Value)
+		if actualStr != expectedStr {
+			errs = append(errs, fmt.Errorf("%s has incorrect values for %q: expected [%s], got [%s]", what, name, expectedStr, actualStr))
+		}
+	}
+	return errs
+}
+
+func headerValsToString(vals []string) string {
+	var buf bytes.Buffer
+	for i, val := range vals {
+		if i > 0 {
+			buf.WriteString(", ")
+		}
+		buf.WriteString(strconv.Quote(val))
+	}
+	return buf.String()
+}
+
+func checkPayloads(expected, actual []*conformancev1alpha1.ConformancePayload) multiErrors {
+	var errs multiErrors
+	if len(actual) != len(expected) {
+		errs = append(errs, fmt.Errorf("expecting %d response messages but instead got %d", len(expected), len(actual)))
+	}
+	reqNum := 0
+	for i := 0; i < len(actual) && i < len(expected); i++ {
+		actualPayload := actual[i]
+		expectedPayload := expected[i]
+		if !bytes.Equal(actualPayload.Data, expectedPayload.Data) {
+			errs = append(errs, fmt.Errorf("response #%d: expecting data %x, got %x", i+1, expectedPayload.Data, actualPayload.Data))
+		}
+		actualReq := actualPayload.GetRequestInfo()
+		expectedReq := expectedPayload.GetRequestInfo()
+
+		if i == 0 { //nolint:nestif
+			// Validate headers, timeout, and query params. We only need to do this once, for first payload.
+			errs = append(errs, checkHeaders("request headers", expectedReq.GetRequestHeaders(), actualReq.GetRequestHeaders())...)
+			if expectedReq != nil && expectedReq.TimeoutMs != nil {
+				if actualReq == nil || actualReq.TimeoutMs == nil {
+					errs = append(errs, fmt.Errorf("server did not echo back a timeout but one was expected (%d ms)", expectedReq.GetTimeoutMs()))
+				} else {
+					max := expectedReq.GetTimeoutMs()
+					min := max - timeoutCheckGracePeriodMillis
+					if min < 0 {
+						min = 0
+					}
+					if actualReq.GetTimeoutMs() > max || actualReq.GetTimeoutMs() < min {
+						errs = append(errs, fmt.Errorf("server echoed back a timeout (%d ms) that did not match expected (%d ms)", actualReq.GetTimeoutMs(), expectedReq.GetTimeoutMs()))
+					}
+				}
+			} else if actualReq != nil && actualReq.TimeoutMs != nil {
+				errs = append(errs, fmt.Errorf("server echoed back a timeout (%d ms) but none was expected", actualReq.GetTimeoutMs()))
+			}
+			if len(expectedReq.GetConnectGetInfo().GetQueryParams()) > 0 && len(actualReq.GetConnectGetInfo().GetQueryParams()) > 0 {
+				errs = append(errs, checkHeaders("request query params", expectedReq.GetConnectGetInfo().GetQueryParams(), actualReq.GetConnectGetInfo().GetQueryParams())...)
+			}
+		}
+
+		if len(actualReq.GetRequests()) != len(expectedReq.GetRequests()) {
+			errs = append(errs, fmt.Errorf("response #%d: expecting %d request messages to be described but instead got %d", i+1, len(expectedReq.GetRequests()), len(actualReq.GetRequests())))
+		}
+		for i := 0; i < len(actualReq.GetRequests()) && i < len(expectedReq.GetRequests()); i++ {
+			reqNum++
+			actualMsg, err := anypb.UnmarshalNew(actualReq.GetRequests()[i], proto.UnmarshalOptions{})
+			if err != nil {
+				errs = append(errs, fmt.Errorf("request #%d: failed to unmarshal actual message: %w", reqNum, err))
+				continue
+			}
+			expectedMsg, err := anypb.UnmarshalNew(expectedReq.GetRequests()[i], proto.UnmarshalOptions{})
+			if err != nil {
+				errs = append(errs, fmt.Errorf("request #%d: failed to unmarshal expected message: %w", reqNum, err))
+				continue
+			}
+			diff := cmp.Diff(expectedMsg, actualMsg, protocmp.Transform())
+			if diff != "" {
+				errs = append(errs, fmt.Errorf("request #%d: did not survive round-trip: - wanted, + got\n%s", reqNum, diff))
+			}
+		}
+	}
+
+	return errs
 }

--- a/internal/app/connectconformance/results_test.go
+++ b/internal/app/connectconformance/results_test.go
@@ -17,6 +17,7 @@ package connectconformance
 import (
 	"bytes"
 	"errors"
+	"strings"
 	"testing"
 
 	conformancev1alpha1 "connectrpc.com/conformance/internal/gen/proto/go/connectrpc/conformance/v1alpha1"
@@ -123,13 +124,20 @@ func TestResults_Assert(t *testing.T) {
 	logger := &lineWriter{}
 	err := results.report(logger)
 	require.NoError(t, err)
-	require.Len(t, logger.lines, 6)
-	require.Contains(t, logger.lines[0], "FAILED: foo/bar/1: ")
-	require.Contains(t, logger.lines[1], "FAILED: foo/bar/2: ")
-	require.Contains(t, logger.lines[2], "INFO: known-to-fail/1 failed (as expected): ")
-	require.Contains(t, logger.lines[3], "INFO: known-to-fail/2 failed (as expected): ")
-	require.Equal(t, logger.lines[4], "FAILED: known-to-fail/3 was expected to fail but did not\n")
-	require.Equal(t, logger.lines[5], "FAILED: known-to-fail/4 was expected to fail but did not\n")
+	// only keep the summary lines:
+	var lines []string
+	for _, line := range logger.lines {
+		if strings.HasPrefix(line, "FAILED: ") || strings.HasPrefix(line, "INFO: ") {
+			lines = append(lines, line)
+		}
+	}
+	require.Len(t, lines, 6)
+	require.Contains(t, lines[0], "FAILED: foo/bar/1: ")
+	require.Contains(t, lines[1], "FAILED: foo/bar/2: ")
+	require.Contains(t, lines[2], "INFO: known-to-fail/1 failed (as expected): ")
+	require.Contains(t, lines[3], "INFO: known-to-fail/2 failed (as expected): ")
+	require.Equal(t, lines[4], "FAILED: known-to-fail/3 was expected to fail but did not\n")
+	require.Equal(t, lines[5], "FAILED: known-to-fail/4 was expected to fail but did not\n")
 }
 
 func TestResults_ServerSideband(t *testing.T) {

--- a/internal/app/connectconformance/testsuites/basic.yaml
+++ b/internal/app/connectconformance/testsuites/basic.yaml
@@ -1,3 +1,48 @@
 name: Basic
-# TODO: define test cases
-testCases: []
+# TODO: define more test cases
+testCases:
+- request:
+    testName: client stream success
+    service: connectrpc.conformance.v1alpha1.ConformanceService
+    method: ClientStream
+    streamType: STREAM_TYPE_CLIENT_STREAM
+    requestHeaders:
+    - name: X-Conformance-Test
+      value: ["Value1","Value2"]
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1alpha1.ClientStreamRequest
+      responseDefinition:
+        responseHeaders:
+        - name: x-custom-header
+          value: ["foo","bar","baz"]
+        responseData: "dGVzdCByZXNwb25zZQ=="
+        responseTrailers:
+        - name: x-custom-trailer
+          value: ["bing","quux"]
+    - "@type": type.googleapis.com/connectrpc.conformance.v1alpha1.ClientStreamRequest
+      requestData: "dGVzdCByZXNwb25zZQ=="
+  expectedResponse:
+    responseHeaders:
+    - name: X-Custom-Header
+      value: ["foo","bar","baz"]
+    payloads:
+    - data: "dGVzdCByZXNwb25zZQ=="
+      requestInfo:
+        requestHeaders:
+        - name: X-Conformance-Test
+          value: ["Value1","Value2"]
+        requests:
+        - "@type": type.googleapis.com/connectrpc.conformance.v1alpha1.ClientStreamRequest
+          responseDefinition:
+            responseHeaders:
+            - name: x-custom-header
+              value: ["foo","bar","baz"]
+            responseData: "dGVzdCByZXNwb25zZQ=="
+            responseTrailers:
+            - name: x-custom-trailer
+              value: ["bing","quux"]
+        - "@type": type.googleapis.com/connectrpc.conformance.v1alpha1.ClientStreamRequest
+          requestData: "dGVzdCByZXNwb25zZQ=="
+    responseTrailers:
+    - name: X-Custom-Trailer
+      value: ["bing","quux"]


### PR DESCRIPTION
This finally brings it all together. This also adds a single test case to the embedded test suites (which gets expanded to 20 test cases with default config, due to permutations with HTTP versions, protocols, codecs, etc).