### PR TITLE
V2: Add verbose flag to test runner

### DIFF
--- a/cmd/connectconformance/main.go
+++ b/cmd/connectconformance/main.go
@@ -29,12 +29,15 @@ const (
 	modeFlagName         = "mode"
 	configFlagName       = "conf"
 	knownFailingFlagName = "known-failing"
+	verboseFlagName      = "verbose"
+	verboseFlagShortName = "v"
 )
 
 type flags struct {
 	mode             string
 	configFile       string
 	knownFailingFile string
+	verbose          bool
 }
 
 func main() {
@@ -88,6 +91,7 @@ func bind(cmd *cobra.Command, flags *flags) {
 	cmd.Flags().StringVar(&flags.mode, modeFlagName, "", "required: the mode of the test to run; must be 'client' or 'server'")
 	cmd.Flags().StringVar(&flags.configFile, configFlagName, "", "a config file in YAML format with supported features")
 	cmd.Flags().StringVar(&flags.knownFailingFile, knownFailingFlagName, "", "a file with a list of known-failing test cases")
+	cmd.Flags().BoolVarP(&flags.verbose, verboseFlagName, verboseFlagShortName, false, "enables verbose output")
 }
 
 func run(flags *flags, command []string) {
@@ -127,6 +131,7 @@ func run(flags *flags, command []string) {
 			Mode:             mode,
 			ConfigFile:       flags.configFile,
 			KnownFailingFile: flags.knownFailingFile,
+			Verbose:          flags.verbose,
 		},
 		command,
 		os.Stdout,

--- a/internal/app/connectconformance/connectconformance.go
+++ b/internal/app/connectconformance/connectconformance.go
@@ -91,24 +91,7 @@ func Run(flags *Flags, command []string, logOut io.Writer) (bool, error) {
 		return false, err
 	}
 	if flags.Verbose {
-		svrInstances := make([]serverInstance, 0, len(testCaseLib.casesByServer))
-		for svrInstance := range testCaseLib.casesByServer {
-			svrInstances = append(svrInstances, svrInstance)
-		}
-		sort.Slice(svrInstances, func(i, j int) bool {
-			if svrInstances[i].httpVersion != svrInstances[j].httpVersion {
-				return svrInstances[i].httpVersion < svrInstances[j].httpVersion
-			}
-			if svrInstances[i].protocol != svrInstances[j].protocol {
-				return svrInstances[i].protocol < svrInstances[j].protocol
-			}
-			return !svrInstances[i].useTLS || svrInstances[j].useTLS
-		})
-		for _, svrInstance := range svrInstances {
-			testCases := testCaseLib.casesByServer[svrInstance]
-			_, _ = fmt.Fprintf(logOut, "Running %d tests for server config {%s, %s, TLS:%v}...\n",
-				len(testCases), svrInstance.httpVersion, svrInstance.protocol, svrInstance.useTLS)
-		}
+		logTestCaseInfo(testCaseLib, logOut)
 	}
 
 	// Validate keys in knownFailing, to make sure they match actual test names
@@ -171,4 +154,25 @@ func Run(flags *Flags, command []string, logOut io.Writer) (bool, error) {
 	}
 
 	return results.report(logOut)
+}
+
+func logTestCaseInfo(testCaseLib *testCaseLibrary, logOut io.Writer) {
+	svrInstances := make([]serverInstance, 0, len(testCaseLib.casesByServer))
+	for svrInstance := range testCaseLib.casesByServer {
+		svrInstances = append(svrInstances, svrInstance)
+	}
+	sort.Slice(svrInstances, func(i, j int) bool { //nolint:varnamelen
+		if svrInstances[i].httpVersion != svrInstances[j].httpVersion {
+			return svrInstances[i].httpVersion < svrInstances[j].httpVersion
+		}
+		if svrInstances[i].protocol != svrInstances[j].protocol {
+			return svrInstances[i].protocol < svrInstances[j].protocol
+		}
+		return !svrInstances[i].useTLS || svrInstances[j].useTLS
+	})
+	for _, svrInstance := range svrInstances {
+		testCases := testCaseLib.casesByServer[svrInstance]
+		_, _ = fmt.Fprintf(logOut, "Running %d tests for server config {%s, %s, TLS:%v}...\n",
+			len(testCases), svrInstance.httpVersion, svrInstance.protocol, svrInstance.useTLS)
+	}
 }

--- a/internal/app/connectconformance/known_failing.go
+++ b/internal/app/connectconformance/known_failing.go
@@ -123,3 +123,14 @@ func (k *knownFailingTrie) findUnmatched(prefix string, unmatched map[string]str
 		child.findUnmatched(childPrefix, unmatched)
 	}
 }
+
+func (k *knownFailingTrie) length() int {
+	var result int
+	if k.present {
+		result++
+	}
+	for _, child := range k.children {
+		result += child.length()
+	}
+	return result
+}


### PR DESCRIPTION
This enables verbose output, which can be interesting to see, and also helpful to sanity check that it's loading thing as expected.