### PR TITLE
V2: Test runner considers reference client feedback, adds headers for reference server

### DIFF
--- a/internal/app/connectconformance/connectconformance.go
+++ b/internal/app/connectconformance/connectconformance.go
@@ -137,7 +137,7 @@ func Run(flags *Flags, command []string, logOut io.Writer) (bool, error) {
 	}
 	// TODO: start servers in parallel (up to a limit) to allow parallelism and faster test execution
 	for svrInstance, testCases := range testCaseLib.casesByServer {
-		runTestCasesForServer(ctx, isClient, svrInstance, testCases, startServer, results, clientProcess)
+		runTestCasesForServer(ctx, !isClient, isClient, svrInstance, testCases, startServer, results, clientProcess)
 		if !clientProcess.isRunning() {
 			err := clientProcess.waitForResponses()
 			if err == nil {

--- a/internal/app/connectconformance/results.go
+++ b/internal/app/connectconformance/results.go
@@ -143,18 +143,19 @@ func (r *testResults) assert(testCase string, expected, actual *conformancev1alp
 	r.setOutcome(testCase, false, errs.Result())
 }
 
-// recordServerSideband accepts an error message for a test that was sent
-// out-of-band by a reference server.
-func (r *testResults) recordServerSideband(testCase string, errMsg string) {
+// recordSideband accepts an error message for a test that was sent
+// out-of-band by a reference server or included as feedback in the
+// response from a reference client.
+func (r *testResults) recordSideband(testCase string, errMsg string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.serverSideband[testCase] = errMsg
 }
 
-// processServerSidebandInfoLocked merges the data recorded during calls
-// to recordServerSideband into the outcomes. This is done when a report
+// processSidebandInfoLocked merges the data recorded during calls
+// to recordSideband into the outcomes. This is done when a report
 // is created.
-func (r *testResults) processServerSidebandInfoLocked() {
+func (r *testResults) processSidebandInfoLocked() {
 	for name, msg := range r.serverSideband {
 		outcome, ok := r.outcomes[name]
 		if ok {
@@ -175,7 +176,7 @@ func (r *testResults) report(writer io.Writer) (bool, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if len(r.serverSideband) > 0 {
-		r.processServerSidebandInfoLocked()
+		r.processSidebandInfoLocked()
 		r.serverSideband = map[string]string{}
 	}
 	testCaseNames := make([]string, 0, len(r.outcomes))

--- a/internal/app/connectconformance/results_test.go
+++ b/internal/app/connectconformance/results_test.go
@@ -725,9 +725,9 @@ func TestResults_ServerSideband(t *testing.T) {
 	results.setOutcome("foo/bar/3", false, nil)
 	results.setOutcome("known-to-fail/1", false, nil)
 	results.setOutcome("known-to-fail/2", false, errors.New("fail"))
-	results.recordServerSideband("foo/bar/2", "something awkward in wire format")
-	results.recordServerSideband("foo/bar/3", "something awkward in wire format")
-	results.recordServerSideband("known-to-fail/1", "something awkward in wire format")
+	results.recordSideband("foo/bar/2", "something awkward in wire format")
+	results.recordSideband("foo/bar/3", "something awkward in wire format")
+	results.recordSideband("known-to-fail/1", "something awkward in wire format")
 
 	logger := &lineWriter{}
 	success, err := results.report(logger)

--- a/internal/app/connectconformance/server_runner.go
+++ b/internal/app/connectconformance/server_runner.go
@@ -40,6 +40,7 @@ import (
 // record out-of-band feedback about the client requests.
 func runTestCasesForServer(
 	ctx context.Context,
+	isReferenceClient bool,
 	isReferenceServer bool,
 	meta serverInstance,
 	testCases []*conformancev1alpha1.TestCase,
@@ -78,7 +79,7 @@ func runTestCasesForServer(
 					if len(parts) == 2 {
 						if _, ok := expectations[parts[0]]; ok {
 							// appears to be valid message in the form "test case: error message"
-							results.recordServerSideband(parts[0], parts[1])
+							results.recordSideband(parts[0], parts[1])
 						}
 					}
 				}
@@ -138,6 +139,11 @@ func runTestCasesForServer(
 				results.failed(name, resp.GetError())
 			default:
 				results.assert(name, expectations[resp.TestName], resp.GetResponse())
+			}
+			if isReferenceClient {
+				for _, msg := range resp.Feedback {
+					results.recordSideband(resp.TestName, msg)
+				}
 			}
 		})
 		if err != nil {

--- a/internal/app/connectconformance/server_runner.go
+++ b/internal/app/connectconformance/server_runner.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -128,6 +129,16 @@ func runTestCasesForServer(
 		req.Host = resp.Host
 		req.Port = resp.Port
 		req.ServerTlsCert = resp.PemCert
+		if isReferenceServer {
+			req.RequestHeaders = append(
+				req.RequestHeaders,
+				&conformancev1alpha1.Header{Name: "x-test-case-name", Value: []string{testCase.Request.TestName}},
+				&conformancev1alpha1.Header{Name: "x-expect-http-version", Value: []string{strconv.Itoa(int(req.HttpVersion))}},
+				&conformancev1alpha1.Header{Name: "x-expect-protocol", Value: []string{strconv.Itoa(int(req.Protocol))}},
+				&conformancev1alpha1.Header{Name: "x-expect-codec", Value: []string{strconv.Itoa(int(req.Codec))}},
+				&conformancev1alpha1.Header{Name: "x-expect-compression", Value: []string{strconv.Itoa(int(req.Compression))}},
+			)
+		}
 
 		wg.Add(1)
 		err := client.sendRequest(req, func(name string, resp *conformancev1alpha1.ClientCompatResponse, err error) {

--- a/internal/app/connectconformance/server_runner_test.go
+++ b/internal/app/connectconformance/server_runner_test.go
@@ -237,6 +237,7 @@ func TestRunTestCasesForServer(t *testing.T) {
 
 			runTestCasesForServer(
 				context.Background(),
+				!testCase.isReferenceServer,
 				testCase.isReferenceServer,
 				svrInstance,
 				testCaseData,
@@ -257,7 +258,7 @@ func TestRunTestCasesForServer(t *testing.T) {
 				res := map[string]bool{}
 				results.mu.Lock()
 				defer results.mu.Unlock()
-				results.processServerSidebandInfoLocked()
+				results.processSidebandInfoLocked()
 				for name, outcome := range results.outcomes {
 					res[name] = outcome.actualFailure == nil
 				}

--- a/internal/app/connectconformance/server_runner_test.go
+++ b/internal/app/connectconformance/server_runner_test.go
@@ -222,6 +222,23 @@ func TestRunTestCasesForServer(t *testing.T) {
 				client.requestHookCount = testCase.svrKillAfter
 				expectedRequests = requests[:testCase.svrKillAfter]
 			}
+			if testCase.isReferenceServer {
+				copyOfRequests := make([]*conformancev1alpha1.ClientCompatRequest, len(expectedRequests))
+				// runner adds headers for the reference server
+				for i, req := range expectedRequests {
+					req = proto.Clone(req).(*conformancev1alpha1.ClientCompatRequest) //nolint:errcheck,forcetypeassert
+					req.RequestHeaders = append(req.RequestHeaders,
+						&conformancev1alpha1.Header{Name: "x-test-case-name", Value: []string{req.TestName}},
+						// we didn't set this above, so they're all zero/unspecified
+						&conformancev1alpha1.Header{Name: "x-expect-http-version", Value: []string{"0"}},
+						&conformancev1alpha1.Header{Name: "x-expect-protocol", Value: []string{"0"}},
+						&conformancev1alpha1.Header{Name: "x-expect-codec", Value: []string{"0"}},
+						&conformancev1alpha1.Header{Name: "x-expect-compression", Value: []string{"0"}},
+					)
+					copyOfRequests[i] = req
+				}
+				expectedRequests = copyOfRequests
+			}
 
 			responsesToSend := responses
 			if testCase.clientCloseAfter > 0 {


### PR DESCRIPTION
The headers will be used by the reference server to verify that the client sent the request with the expected properties.