### PR TITLE
V2: Create config that represents capabilities of the reference implementations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,12 +73,14 @@ checkgenerate:
 runconformance: runservertests runclienttests
 
 .PHONY: runservertests
-runservertests: $(BIN)/connectconformance $(BIN)/referenceserver
-	$(BIN)/connectconformance --mode server $(BIN)/referenceserver
+runservertests: $(BIN)/connectconformance $(BIN)/referenceserver $(BIN)/grpcserver
+	$(BIN)/connectconformance --conf ./testdata/reference-impls-config.yaml --mode server $(BIN)/referenceserver
+	$(BIN)/connectconformance --conf ./testdata/grpc-impls-config.yaml --mode server $(BIN)/grpcserver
 
 .PHONY: runclienttests
-runclienttests: $(BIN)/connectconformance $(BIN)/referenceclient
-	$(BIN)/connectconformance --mode client $(BIN)/referenceclient
+runclienttests: $(BIN)/connectconformance $(BIN)/referenceclient $(BIN)/grpcclient
+	$(BIN)/connectconformance --conf ./testdata/reference-impls-config.yaml --mode client $(BIN)/referenceclient
+	$(BIN)/connectconformance --conf ./testdata/grpc-impls-config.yaml --mode client $(BIN)/grpcclient
 
 $(BIN)/connectconformance: Makefile generate
 	go build -o $(@) ./cmd/connectconformance/

--- a/internal/app/grpcserver/server.go
+++ b/internal/app/grpcserver/server.go
@@ -26,7 +26,7 @@ import (
 	"connectrpc.com/conformance/internal"
 	v1alpha1 "connectrpc.com/conformance/internal/gen/proto/go/connectrpc/conformance/v1alpha1"
 	"google.golang.org/grpc"
-	_ "google.golang.org/grpc/encoding/gzip"
+	_ "google.golang.org/grpc/encoding/gzip" // enables GZIP compression w/ gRPC
 )
 
 // Run runs the server according to server config read from the 'in' reader.

--- a/internal/app/grpcserver/server.go
+++ b/internal/app/grpcserver/server.go
@@ -26,6 +26,7 @@ import (
 	"connectrpc.com/conformance/internal"
 	v1alpha1 "connectrpc.com/conformance/internal/gen/proto/go/connectrpc/conformance/v1alpha1"
 	"google.golang.org/grpc"
+	_ "google.golang.org/grpc/encoding/gzip"
 )
 
 // Run runs the server according to server config read from the 'in' reader.

--- a/internal/compression/zstd.go
+++ b/internal/compression/zstd.go
@@ -27,13 +27,26 @@ type zstdDecompressor struct {
 }
 
 func (c *zstdDecompressor) Read(bytes []byte) (int, error) {
+	if c.decoder == nil {
+		return 0, io.EOF
+	}
 	return c.decoder.Read(bytes)
 }
 func (c *zstdDecompressor) Reset(rdr io.Reader) error {
+	if c.decoder == nil {
+		var err error
+		c.decoder, err = zstd.NewReader(rdr)
+		return err
+	}
 	return c.decoder.Reset(rdr)
 }
 func (c *zstdDecompressor) Close() error {
+	if c.decoder == nil {
+		return nil
+	}
 	c.decoder.Close()
+	// zstd.Decoder cannot be re-used after close, even via Reset
+	c.decoder = nil
 	return nil
 }
 

--- a/testdata/grpc-impls-config.yaml
+++ b/testdata/grpc-impls-config.yaml
@@ -1,0 +1,8 @@
+features:
+  versions:
+    - HTTP_VERSION_2
+  protocols:
+    - PROTOCOL_GRPC
+  codecs:
+    - CODEC_PROTO
+  supportsTls: false

--- a/testdata/reference-impls-config.yaml
+++ b/testdata/reference-impls-config.yaml
@@ -1,0 +1,20 @@
+features:
+  versions:
+  - HTTP_VERSION_1
+  - HTTP_VERSION_2
+  - HTTP_VERSION_3
+  protocols:
+  - PROTOCOL_CONNECT
+  - PROTOCOL_GRPC
+  - PROTOCOL_GRPC_WEB
+  codecs:
+  - CODEC_PROTO
+  - CODEC_JSON
+  compressions:
+  - COMPRESSION_IDENTITY
+  - COMPRESSION_GZIP
+  - COMPRESSION_BR
+  - COMPRESSION_ZSTD
+  - COMPRESSION_DEFLATE
+  - COMPRESSION_SNAPPY
+  supportsTlsClientCerts: true


### PR DESCRIPTION
This uses the configs to enable a greater number of test cases in `make runconformance` (up to 288 cases/permutations now!). It also runs tests against the gRPC impls as part of `make runconformance`.

This also meant fixing some small issues I found along the way:

1. In order to enable gzip support with gRPC, you have to import their encoding/gzip package.
2. The zstd compression implementation complained if a decoder was used for more than one request. Strangely, unlike all of the other implementations, a zstd decoder cannot be re-used, not even via `Reset`, after it has been `Close`d. 🤷 
3. The logic in the gRPC client to translate a `status.Error` to the error proto in the `ClientCompatResponse` wasn't working. I didn't dig much into exactly why, but I did realize that there was a much simpler way to translate since the error proto and the gRPC status proto are nearly identical. When I simplified the code, the bug went away. (The bug was that error details were getting dropped for some reason.)

This builds on top of #653.