### PR TITLE
Add basic success and error tests

### DIFF
--- a/internal/app/connectconformance/testsuites/basic.yaml
+++ b/internal/app/connectconformance/testsuites/basic.yaml
@@ -14,7 +14,7 @@ testCases:
       responseDefinition:
         responseHeaders:
         - name: x-custom-header
-          value: ["foo", "bar","baz"]
+          value: ["foo","bar","baz"]
         responseData: "dGVzdCByZXNwb25zZQ=="
         responseTrailers:
         - name: x-custom-trailer
@@ -55,7 +55,7 @@ testCases:
       responseDefinition:
         responseHeaders:
         - name: x-custom-header
-          value: ["foo", "bar","baz"]
+          value: ["foo","bar","baz"]
         error:
           code: 13
           message: "unary failed"
@@ -95,7 +95,7 @@ testCases:
       responseDefinition:
         responseHeaders:
         - name: x-custom-header
-          value: ["foo", "bar","baz"]
+          value: ["foo","bar","baz"]
         responseData: "dGVzdCByZXNwb25zZQ=="
         responseTrailers:
         - name: x-custom-trailer
@@ -140,7 +140,7 @@ testCases:
       responseDefinition:
         responseHeaders:
         - name: x-custom-header
-          value: ["foo", "bar","baz"]
+          value: ["foo","bar","baz"]
         error:
           code: 13
           message: "client stream failed"
@@ -182,7 +182,7 @@ testCases:
       responseDefinition:
         responseHeaders:
         - name: x-custom-header
-          value: ["foo", "bar","baz"]
+          value: ["foo","bar","baz"]
         responseData:
           - "dGVzdCByZXNwb25zZQ=="
           - "dGVzdCByZXNwb25zZQ=="
@@ -228,7 +228,7 @@ testCases:
       responseDefinition:
         responseHeaders:
         - name: x-custom-header
-          value: ["foo", "bar","baz"]
+          value: ["foo","bar","baz"]
         responseData:
           - "dGVzdCByZXNwb25zZQ=="
           - "dGVzdCByZXNwb25zZQ=="

--- a/internal/app/connectconformance/testsuites/basic.yaml
+++ b/internal/app/connectconformance/testsuites/basic.yaml
@@ -2,6 +2,87 @@ name: Basic
 # TODO: define more test cases
 testCases:
 - request:
+    testName: unary success
+    service: connectrpc.conformance.v1alpha1.ConformanceService
+    method: Unary
+    streamType: STREAM_TYPE_UNARY
+    requestHeaders:
+    - name: X-Conformance-Test
+      value: ["Value1","Value2"]
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1alpha1.UnaryRequest
+      responseDefinition:
+        responseHeaders:
+        - name: x-custom-header
+          value: ["foo", "bar","baz"]
+        responseData: "dGVzdCByZXNwb25zZQ=="
+        responseTrailers:
+        - name: x-custom-trailer
+          value: ["bing","quux"]
+  expectedResponse:
+    responseHeaders:
+    - name: X-Custom-Header
+      value: ["foo","bar","baz"]
+    payloads:
+    - data: "dGVzdCByZXNwb25zZQ=="
+      requestInfo:
+        requestHeaders:
+        - name: X-Conformance-Test
+          value: ["Value1","Value2"]
+        requests:
+        - "@type": type.googleapis.com/connectrpc.conformance.v1alpha1.UnaryRequest
+          responseDefinition:
+            responseHeaders:
+            - name: x-custom-header
+              value: ["foo","bar","baz"]
+            responseData: "dGVzdCByZXNwb25zZQ=="
+            responseTrailers:
+            - name: x-custom-trailer
+              value: ["bing","quux"]
+    responseTrailers:
+    - name: X-Custom-Trailer
+      value: ["bing","quux"]
+- request:
+    testName: unary error
+    service: connectrpc.conformance.v1alpha1.ConformanceService
+    method: Unary
+    streamType: STREAM_TYPE_UNARY
+    requestHeaders:
+    - name: X-Conformance-Test
+      value: ["Value1","Value2"]
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1alpha1.UnaryRequest
+      responseDefinition:
+        responseHeaders:
+        - name: x-custom-header
+          value: ["foo", "bar","baz"]
+        error:
+          code: 13
+          message: "unary failed"
+          details:
+            - "@type": "connectrpc.conformance.v1alpha1.Header"
+              name: "test error detail name"
+              value:
+                - "test error detail value"
+        responseTrailers:
+        - name: x-custom-trailer
+          value: ["bing","quux"]
+  expectedResponse:
+    responseHeaders:
+    - name: X-Custom-Header
+      value: ["foo","bar","baz"]
+    error:
+      code: 13
+      message: "unary failed"
+      details:
+        - "@type": "connectrpc.conformance.v1alpha1.Header"
+          name: "test error detail name"
+          value:
+            - "test error detail value"
+    responseTrailers:
+    - name: X-Custom-Trailer
+      value: ["bing","quux"]
+- request:
     testName: client stream success
     service: connectrpc.conformance.v1alpha1.ConformanceService
     method: ClientStream
@@ -14,7 +95,7 @@ testCases:
       responseDefinition:
         responseHeaders:
         - name: x-custom-header
-          value: ["foo","bar","baz"]
+          value: ["foo", "bar","baz"]
         responseData: "dGVzdCByZXNwb25zZQ=="
         responseTrailers:
         - name: x-custom-trailer
@@ -43,6 +124,164 @@ testCases:
               value: ["bing","quux"]
         - "@type": type.googleapis.com/connectrpc.conformance.v1alpha1.ClientStreamRequest
           requestData: "dGVzdCByZXNwb25zZQ=="
+    responseTrailers:
+    - name: X-Custom-Trailer
+      value: ["bing","quux"]
+- request:
+    testName: client stream error
+    service: connectrpc.conformance.v1alpha1.ConformanceService
+    method: ClientStream
+    streamType: STREAM_TYPE_CLIENT_STREAM
+    requestHeaders:
+    - name: X-Conformance-Test
+      value: ["Value1","Value2"]
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1alpha1.ClientStreamRequest
+      responseDefinition:
+        responseHeaders:
+        - name: x-custom-header
+          value: ["foo", "bar","baz"]
+        error:
+          code: 13
+          message: "client stream failed"
+          details:
+            - "@type": "connectrpc.conformance.v1alpha1.Header"
+              name: "test error detail name"
+              value:
+                - "test error detail value"
+        responseTrailers:
+        - name: x-custom-trailer
+          value: ["bing","quux"]
+    - "@type": type.googleapis.com/connectrpc.conformance.v1alpha1.ClientStreamRequest
+      requestData: "dGVzdCByZXNwb25zZQ=="
+  expectedResponse:
+    responseHeaders:
+    - name: X-Custom-Header
+      value: ["foo","bar","baz"]
+    error:
+      code: 13
+      message: "client stream failed"
+      details:
+        - "@type": "connectrpc.conformance.v1alpha1.Header"
+          name: "test error detail name"
+          value:
+            - "test error detail value"
+    responseTrailers:
+    - name: X-Custom-Trailer
+      value: ["bing","quux"]
+- request:
+    testName: server stream success
+    service: connectrpc.conformance.v1alpha1.ConformanceService
+    method: ServerStream
+    streamType: STREAM_TYPE_SERVER_STREAM
+    requestHeaders:
+    - name: X-Conformance-Test
+      value: ["Value1","Value2"]
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1alpha1.ServerStreamRequest
+      responseDefinition:
+        responseHeaders:
+        - name: x-custom-header
+          value: ["foo", "bar","baz"]
+        responseData:
+          - "dGVzdCByZXNwb25zZQ=="
+          - "dGVzdCByZXNwb25zZQ=="
+        responseTrailers:
+        - name: x-custom-trailer
+          value: ["bing","quux"]
+  expectedResponse:
+    responseHeaders:
+    - name: X-Custom-Header
+      value: ["foo","bar","baz"]
+    payloads:
+    - data: "dGVzdCByZXNwb25zZQ=="
+      requestInfo:
+        requestHeaders:
+        - name: X-Conformance-Test
+          value: ["Value1","Value2"]
+        requests:
+        - "@type": type.googleapis.com/connectrpc.conformance.v1alpha1.ServerStreamRequest
+          responseDefinition:
+            responseHeaders:
+            - name: x-custom-header
+              value: ["foo","bar","baz"]
+            responseData:
+              - "dGVzdCByZXNwb25zZQ=="
+              - "dGVzdCByZXNwb25zZQ=="
+            responseTrailers:
+            - name: x-custom-trailer
+              value: ["bing","quux"]
+    - data: "dGVzdCByZXNwb25zZQ=="
+    responseTrailers:
+    - name: X-Custom-Trailer
+      value: ["bing","quux"]
+- request:
+    testName: server stream error
+    service: connectrpc.conformance.v1alpha1.ConformanceService
+    method: ServerStream
+    streamType: STREAM_TYPE_SERVER_STREAM
+    requestHeaders:
+    - name: X-Conformance-Test
+      value: ["Value1","Value2"]
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1alpha1.ServerStreamRequest
+      responseDefinition:
+        responseHeaders:
+        - name: x-custom-header
+          value: ["foo", "bar","baz"]
+        responseData:
+          - "dGVzdCByZXNwb25zZQ=="
+          - "dGVzdCByZXNwb25zZQ=="
+        error:
+          code: 13
+          message: "server stream failed"
+          details:
+            - "@type": "connectrpc.conformance.v1alpha1.Header"
+              name: "test error detail name"
+              value:
+                - "test error detail value"
+        responseTrailers:
+        - name: x-custom-trailer
+          value: ["bing","quux"]
+  expectedResponse:
+    responseHeaders:
+    - name: X-Custom-Header
+      value: ["foo","bar","baz"]
+    payloads:
+    - data: "dGVzdCByZXNwb25zZQ=="
+      requestInfo:
+        requestHeaders:
+        - name: X-Conformance-Test
+          value: ["Value1","Value2"]
+        requests:
+        - "@type": type.googleapis.com/connectrpc.conformance.v1alpha1.ServerStreamRequest
+          responseDefinition:
+            responseHeaders:
+            - name: x-custom-header
+              value: ["foo","bar","baz"]
+            responseData:
+              - "dGVzdCByZXNwb25zZQ=="
+              - "dGVzdCByZXNwb25zZQ=="
+            error:
+              code: 13
+              message: "server stream failed"
+              details:
+                - "@type": "connectrpc.conformance.v1alpha1.Header"
+                  name: "test error detail name"
+                  value:
+                    - "test error detail value"
+            responseTrailers:
+            - name: x-custom-trailer
+              value: ["bing","quux"]
+    - data: "dGVzdCByZXNwb25zZQ=="
+    error:
+      code: 13
+      message: "server stream failed"
+      details:
+        - "@type": "connectrpc.conformance.v1alpha1.Header"
+          name: "test error detail name"
+          value:
+            - "test error detail value"
     responseTrailers:
     - name: X-Custom-Trailer
       value: ["bing","quux"]


### PR DESCRIPTION
This adds basic success and error tests for the remaining rpc types (unary, server stream, and client stream (error))