### PR TITLE
V2: Add checks to reference server to verify http version, protocol, codec, compression, etc

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,6 +32,7 @@ linters:
     - depguard          # unnecessary for small libraries
     - deadcode          # abandoned
     - exhaustivestruct  # replaced by exhaustruct
+    - exhaustive        # lots of false positives when using default cases
     - funlen            # rely on code review to limit function length
     - gocognit          # dubious "cognitive overhead" quantification
     - gofumpt           # prefer standard gofmt

--- a/internal/app/connectconformance/connectconformance.go
+++ b/internal/app/connectconformance/connectconformance.go
@@ -147,7 +147,7 @@ func Run(flags *Flags, command []string, logOut io.Writer) (bool, error) {
 
 	var startServer processStarter
 	if isClient {
-		startServer = runInProcess("reference-server", referenceserver.Run)
+		startServer = runInProcess("reference-server", referenceserver.RunInReferenceMode)
 	} else {
 		startServer = runCommand(command)
 	}

--- a/internal/app/connectconformance/server_runner_test.go
+++ b/internal/app/connectconformance/server_runner_test.go
@@ -39,9 +39,8 @@ func TestRunTestCasesForServer(t *testing.T) {
 
 	var svrResponseBuf bytes.Buffer
 	svrResponse := &conformancev1alpha1.ServerCompatResponse{
-		Host:    "127.0.0.1",
-		Port:    12345,
-		PemCert: []byte("some cert"),
+		Host: "127.0.0.1",
+		Port: 12345,
 	}
 	err := internal.WriteDelimitedMessage(&svrResponseBuf, svrResponse)
 	require.NoError(t, err)
@@ -233,9 +232,11 @@ func TestRunTestCasesForServer(t *testing.T) {
 						&conformancev1alpha1.Header{Name: "x-test-case-name", Value: []string{req.TestName}},
 						// we didn't set this above, so they're all zero/unspecified
 						&conformancev1alpha1.Header{Name: "x-expect-http-version", Value: []string{"0"}},
+						&conformancev1alpha1.Header{Name: "x-expect-http-method", Value: []string{"POST"}},
 						&conformancev1alpha1.Header{Name: "x-expect-protocol", Value: []string{"0"}},
 						&conformancev1alpha1.Header{Name: "x-expect-codec", Value: []string{"0"}},
 						&conformancev1alpha1.Header{Name: "x-expect-compression", Value: []string{"0"}},
+						&conformancev1alpha1.Header{Name: "x-expect-tls", Value: []string{"false"}},
 					)
 					copyOfRequests[i] = req
 				}

--- a/internal/app/referenceclient/client.go
+++ b/internal/app/referenceclient/client.go
@@ -164,8 +164,15 @@ func invoke(ctx context.Context, req *v1alpha1.ClientCompatRequest) (*v1alpha1.C
 		return nil, errors.New("a protocol must be specified")
 	}
 
-	if req.Codec == v1alpha1.Codec_CODEC_JSON {
+	switch req.Codec {
+	case v1alpha1.Codec_CODEC_PROTO:
+		// this is the default, no option needed
+	case v1alpha1.Codec_CODEC_JSON:
 		clientOptions = append(clientOptions, connect.WithProtoJSON())
+	case v1alpha1.Codec_CODEC_TEXT:
+		clientOptions = append(clientOptions, connect.WithCodec(&internal.TextConnectCodec{}))
+	default:
+		return nil, errors.New("a codec must be specified")
 	}
 
 	switch req.Compression {

--- a/internal/app/referenceclient/impl.go
+++ b/internal/app/referenceclient/impl.go
@@ -350,6 +350,7 @@ func (i *invoker) unimplemented(
 	}
 
 	request := connect.NewRequest(ur)
+	internal.AddHeaders(req.RequestHeaders, request.Header())
 
 	// Invoke the Unary call
 	_, err := i.client.Unimplemented(ctx, request)

--- a/internal/app/referenceserver/checks.go
+++ b/internal/app/referenceserver/checks.go
@@ -1,0 +1,285 @@
+// Copyright 2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package referenceserver
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"connectrpc.com/conformance/internal/compression"
+	v1alpha1 "connectrpc.com/conformance/internal/gen/proto/go/connectrpc/conformance/v1alpha1"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+const (
+	grpcContentType                = "application/grpc"
+	grpcContentTypePrefix          = grpcContentType + "+"
+	grpcWebContentType             = "application/grpc-web"
+	grpcWebContentTypePrefix       = grpcWebContentType + "+"
+	connectUnaryContentTypePrefix  = "application/"
+	connectStreamContentTypePrefix = "application/connect+"
+	connectContentTypePrefix       = connectUnaryContentTypePrefix
+
+	codecProto = "proto"
+	codecJSON  = "json"
+	codecText  = "text"
+)
+
+func referenceServerChecks(handler http.Handler, errWriter io.Writer) http.HandlerFunc {
+	return func(respWriter http.ResponseWriter, req *http.Request) {
+		testCaseName := req.Header.Get("x-test-case-name")
+		if testCaseName == "" {
+			// This is the only hard failure. Without it, we cannot provide feedback.
+			// All other checks below write to stderr to provide feedback.
+			http.Error(respWriter, "missing x-test-case-name header", http.StatusBadRequest)
+			return
+		}
+
+		feedback := &feedbackWriter{w: errWriter, testCaseName: testCaseName}
+
+		if httpVersion, ok := enumValue("x-expect-http-version", req.Header, v1alpha1.HTTPVersion(0), feedback); ok {
+			checkHTTPVersion(httpVersion, req, feedback)
+		}
+		if protocol, ok := enumValue("x-expect-protocol", req.Header, v1alpha1.Protocol(0), feedback); ok {
+			checkProtocol(protocol, req, feedback)
+		}
+		if codec, ok := enumValue("x-expect-codec", req.Header, v1alpha1.Codec(0), feedback); ok {
+			checkCodec(codec, req, feedback)
+		}
+		if compress, ok := enumValue("x-expect-compression", req.Header, v1alpha1.Compression(0), feedback); ok {
+			checkCompression(compress, req, feedback)
+		}
+
+		checkTLS(req, feedback)
+
+		if expectedMethod, _ := getHeader(req.Header, "x-expect-http-method", feedback); req.Method != expectedMethod {
+			feedback.Printf("expected HTTP method %q, got %q", expectedMethod, req.Method)
+		}
+
+		handler.ServeHTTP(respWriter, req)
+	}
+}
+
+type int32Enum interface {
+	~int32
+	protoreflect.Enum
+}
+
+func enumValue[E int32Enum](headerName string, headers http.Header, zero E, feedback *feedbackWriter) (E, bool) {
+	val, _ := getHeader(headers, headerName, feedback)
+	intVal, err := strconv.ParseInt(val, 10, 32)
+	if err != nil {
+		feedback.Printf("invalid value for %q header: %q: %v", headerName, val, err)
+		return 0, false
+	}
+	if zero.Descriptor().Values().ByNumber(protoreflect.EnumNumber(intVal)) == nil {
+		feedback.Printf("invalid value for %q header: %d is not in range", headerName, intVal)
+		return 0, false
+	}
+	return E(int32(intVal)), true
+}
+
+func checkHTTPVersion(expected v1alpha1.HTTPVersion, req *http.Request, feedback *feedbackWriter) {
+	var expectVersion int
+	switch expected {
+	case v1alpha1.HTTPVersion_HTTP_VERSION_1:
+		expectVersion = 1
+	case v1alpha1.HTTPVersion_HTTP_VERSION_2:
+		expectVersion = 2
+	case v1alpha1.HTTPVersion_HTTP_VERSION_3:
+		expectVersion = 3
+	default:
+		feedback.Printf("invalid expected HTTP version %d", expected)
+		return
+	}
+	if req.ProtoMajor != expectVersion {
+		feedback.Printf("expected HTTP version %d; instead got %d", expectVersion, req.ProtoMajor)
+	}
+}
+
+func checkProtocol(expected v1alpha1.Protocol, req *http.Request, feedback *feedbackWriter) {
+	var actual v1alpha1.Protocol
+	contentType := req.Header.Get("content-type")
+	switch {
+	case contentType == grpcContentType || strings.HasPrefix(contentType, grpcContentTypePrefix):
+		actual = v1alpha1.Protocol_PROTOCOL_GRPC
+	case contentType == grpcWebContentType || strings.HasPrefix(contentType, grpcWebContentTypePrefix):
+		actual = v1alpha1.Protocol_PROTOCOL_GRPC_WEB
+	case strings.HasPrefix(contentType, connectContentTypePrefix) || req.Method == http.MethodGet:
+		actual = v1alpha1.Protocol_PROTOCOL_CONNECT
+	default:
+		feedback.Printf("could not determine protocol from content-type %q", contentType)
+		return
+	}
+	if expected != actual {
+		feedback.Printf("expected protocol %v; instead got %v", expected, actual)
+	}
+}
+
+func checkCodec(expected v1alpha1.Codec, req *http.Request, feedback *feedbackWriter) {
+	var expect string
+	switch expected {
+	case v1alpha1.Codec_CODEC_PROTO:
+		expect = codecProto
+	case v1alpha1.Codec_CODEC_JSON:
+		expect = codecJSON
+	case v1alpha1.Codec_CODEC_TEXT:
+		expect = codecText
+	default:
+		feedback.Printf("invalid expected codec %d", expected)
+		return
+	}
+	contentType, hasContentType := getHeader(req.Header, "content-type", feedback)
+	var actual string
+	switch {
+	case req.Method == http.MethodGet:
+		if hasContentType {
+			feedback.Printf("content-type header should not appear with method GET")
+		}
+		var hasActual bool
+		actual, hasActual = getQueryParam(req.URL.Query(), "encoding", feedback)
+		if !hasActual {
+			feedback.Printf("encoding query parameter is missing")
+			return
+		}
+	case contentType == "application/grpc" || contentType == "application/grpc-web":
+		actual = codecProto // these protocols default to proto if they have no "+codec" suffix
+	case strings.HasPrefix(contentType, "application/grpc+"):
+		actual = strings.TrimPrefix(contentType, "application/grpc+")
+	case strings.HasPrefix(contentType, "application/grpc-web+"):
+		actual = strings.TrimPrefix(contentType, "application/grpc-web+")
+	case strings.HasPrefix(contentType, "application/connect+"):
+		actual = strings.TrimPrefix(contentType, "application/connect+")
+	case strings.HasPrefix(contentType, "application/"):
+		actual = strings.TrimPrefix(contentType, "application/")
+	default:
+		// We already complained about bad content-type when checking protocol.
+		return
+	}
+	if expect != actual {
+		feedback.Printf("expected codec %v; instead got %v", expect, actual)
+	}
+}
+
+func checkCompression(expected v1alpha1.Compression, req *http.Request, feedback *feedbackWriter) {
+	var expect string
+	switch expected {
+	case v1alpha1.Compression_COMPRESSION_IDENTITY:
+		expect = compression.Identity
+	case v1alpha1.Compression_COMPRESSION_GZIP:
+		expect = compression.Gzip
+	case v1alpha1.Compression_COMPRESSION_BR:
+		expect = compression.Brotli
+	case v1alpha1.Compression_COMPRESSION_ZSTD:
+		expect = compression.Zstd
+	case v1alpha1.Compression_COMPRESSION_DEFLATE:
+		expect = compression.Deflate
+	case v1alpha1.Compression_COMPRESSION_SNAPPY:
+		expect = compression.Snappy
+	default:
+		feedback.Printf("invalid expected compression %d", expected)
+		return
+	}
+	var actual string
+	var hasActual bool
+	if req.Method == http.MethodGet {
+		actual, hasActual = getQueryParam(req.URL.Query(), "compression", feedback)
+	} else {
+		contentType := req.Header.Get("content-type")
+		var encodingHeader string
+		switch {
+		case contentType == grpcContentType || contentType == grpcWebContentType ||
+			strings.HasPrefix(contentType, grpcContentTypePrefix) ||
+			strings.HasPrefix(contentType, grpcWebContentTypePrefix):
+			encodingHeader = "grpc-encoding"
+		case strings.HasPrefix(contentType, connectStreamContentTypePrefix):
+			encodingHeader = "connect-content-encoding"
+		case strings.HasPrefix(contentType, connectUnaryContentTypePrefix):
+			encodingHeader = "content-encoding"
+		default:
+			// We already complained about bad content-type when checking protocol.
+			return
+		}
+		actual, hasActual = getHeader(req.Header, encodingHeader, feedback)
+	}
+
+	if !hasActual {
+		actual = compression.Identity
+	}
+
+	if expect != actual {
+		feedback.Printf("expected compression %v; instead got %v", expect, actual)
+	}
+}
+
+func checkTLS(req *http.Request, feedback *feedbackWriter) {
+	tlsHeaderVal, _ := getHeader(req.Header, "x-expect-tls", feedback)
+	expectTLS, err := strconv.ParseBool(tlsHeaderVal)
+	if err != nil {
+		feedback.Printf("invalid value for %q header: %q: %v", "x-expect-tls", tlsHeaderVal, err)
+		return
+	}
+	if expectTLS && req.TLS == nil {
+		feedback.Printf("expecting TLS request but instead was plain-text")
+		return
+	} else if !expectTLS && req.TLS != nil {
+		feedback.Printf("expecting plain-text request but instead was TLS")
+		return
+	}
+	if req.TLS == nil {
+		return
+	}
+	expectedClientCert, _ := getHeader(req.Header, "x-expect-client-cert", feedback)
+	var actualClientCert string
+	if len(req.TLS.PeerCertificates) > 0 {
+		actualClientCert = req.TLS.PeerCertificates[0].Subject.CommonName
+	}
+	if expectedClientCert != actualClientCert {
+		feedback.Printf("expecting client cert %q, instead was %q", expectedClientCert, actualClientCert)
+	}
+}
+
+func getHeader(headers http.Header, headerName string, feedback *feedbackWriter) (string, bool) {
+	headerVals := headers.Values(headerName)
+	if len(headerVals) > 1 {
+		feedback.Printf("%s header appears %d times; should appear just once", headerName, len(headerVals))
+	}
+	return headers.Get(headerName), len(headerVals) > 0
+}
+
+func getQueryParam(values url.Values, paramName string, feedback *feedbackWriter) (string, bool) {
+	paramVals := values[paramName]
+	if len(paramVals) > 1 {
+		feedback.Printf("%s query string param appears %d times; should appear just once", paramName, len(paramVals))
+	}
+	return values.Get(paramName), len(paramVals) > 0
+}
+
+type feedbackWriter struct {
+	w            io.Writer
+	testCaseName string
+}
+
+func (w *feedbackWriter) Printf(format string, args ...any) {
+	msg := fmt.Sprintf(format, args...)
+	if !strings.HasSuffix(msg, "\n") {
+		msg += "\n"
+	}
+	_, _ = fmt.Fprintf(w.w, "%s: %s", w.testCaseName, msg)
+}

--- a/internal/codec.go
+++ b/internal/codec.go
@@ -21,6 +21,7 @@ import (
 	"io"
 
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -156,4 +157,31 @@ func (p *protoEncoder) Encode(msg proto.Message) error {
 		return fmt.Errorf("failed to marshal response to binary: %w", err)
 	}
 	return writeDelimitedMessageRaw(p.out, data)
+}
+
+// TextConnectCodec implements the connect.Codec interface, providing the
+// protobuf text format.
+type TextConnectCodec struct {
+	prototext.MarshalOptions
+	prototext.UnmarshalOptions
+}
+
+func (t *TextConnectCodec) Name() string {
+	return "text"
+}
+
+func (t *TextConnectCodec) Marshal(a any) ([]byte, error) {
+	msg, ok := a.(proto.Message)
+	if !ok {
+		return nil, fmt.Errorf("message type %T does not implement proto.Message", a)
+	}
+	return t.MarshalOptions.Marshal(msg)
+}
+
+func (t *TextConnectCodec) Unmarshal(bytes []byte, a any) error {
+	msg, ok := a.(proto.Message)
+	if !ok {
+		return fmt.Errorf("message type %T does not implement proto.Message", a)
+	}
+	return t.UnmarshalOptions.Unmarshal(bytes, msg)
 }

--- a/internal/compression/compression.go
+++ b/internal/compression/compression.go
@@ -16,8 +16,10 @@ package compression
 
 // The IANA names for supported compression algorithms.
 const (
-	Brotli  = "br"
-	Deflate = "deflate"
-	Snappy  = "snappy"
-	Zstd    = "zstd"
+	Identity = "identity"
+	Gzip     = "gzip"
+	Brotli   = "br"
+	Deflate  = "deflate"
+	Snappy   = "snappy"
+	Zstd     = "zstd"
 )

--- a/internal/errors.go
+++ b/internal/errors.go
@@ -36,7 +36,7 @@ func ConvertErrorToConnectError(err error) *connect.Error {
 	return connectErr
 }
 
-// ConvertErrorToConnectError converts the given error to a proto Error
+// ConvertErrorToProtoError converts the given error to a proto Error
 // If err is nil, function will also return nil. If err is not
 // of type connect.Error, a code representing Unknown is returned.
 func ConvertErrorToProtoError(err error) *v1alpha1.Error {

--- a/internal/tls.go
+++ b/internal/tls.go
@@ -27,6 +27,11 @@ import (
 	"time"
 )
 
+const (
+	ClientCertName = "Conformance Client"
+	ServerCertName = "Conformance Server"
+)
+
 // NewClientTLSConfig returns a TLS configuration for an RPC client that uses
 // the given PEM-encoded certs/keys. The caCert parameter must not be empty, and
 // is the server certificate to trust (or a CA cert for the issuer of the server
@@ -153,10 +158,10 @@ func newCert(isClientCert bool) ([]byte, []byte, error) {
 		BasicConstraintsValid: true,
 	}
 	if isClientCert {
-		template.Subject.CommonName = "Conformance Client"
+		template.Subject.CommonName = ClientCertName
 		template.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
 	} else {
-		template.Subject.CommonName = "Conformance Server"
+		template.Subject.CommonName = ServerCertName
 		template.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
 		template.IPAddresses = []net.IP{net.IPv6loopback, net.IPv4(127, 0, 0, 1)}
 		template.DNSNames = []string{"localhost"}

--- a/testdata/reference-impls-config.yaml
+++ b/testdata/reference-impls-config.yaml
@@ -10,6 +10,7 @@ features:
   codecs:
   - CODEC_PROTO
   - CODEC_JSON
+  - CODEC_TEXT
   compressions:
   - COMPRESSION_IDENTITY
   - COMPRESSION_GZIP


### PR DESCRIPTION
This uses the "x-expect-..." headers added in previous PR in the reference server.

The test runner only sends them when running the reference server in-process, so we need a command-line flag to the server to tell it whether to include them or not. To be cautious, I have the checks default to _on_, which means when we run it out-of-process (like when running tests in "server mode" against the reference server) we have to turn them off.

This found a bug in the gRPC client: it was not respecting the use of gzip compression. (Maybe that was intentional, but just not caught previously after configuring gRPC client and server to use gzip.)