### PR TITLE
V2: Run clients and servers under test against gRPC impls

### DIFF
--- a/internal/app/connectconformance/connectconformance.go
+++ b/internal/app/connectconformance/connectconformance.go
@@ -20,24 +20,29 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"sort"
 	"strings"
 
 	"connectrpc.com/conformance/internal"
 	"connectrpc.com/conformance/internal/app/connectconformance/testsuites"
+	"connectrpc.com/conformance/internal/app/grpcclient"
+	"connectrpc.com/conformance/internal/app/grpcserver"
 	"connectrpc.com/conformance/internal/app/referenceclient"
 	"connectrpc.com/conformance/internal/app/referenceserver"
 	conformancev1alpha1 "connectrpc.com/conformance/internal/gen/proto/go/connectrpc/conformance/v1alpha1"
+	"google.golang.org/protobuf/proto"
 )
 
 type Flags struct {
-	Mode             conformancev1alpha1.TestSuite_TestMode
 	ConfigFile       string
 	KnownFailingFile string
 	Verbose          bool
+	ClientCommand    []string
+	ServerCommand    []string
 }
 
-func Run(flags *Flags, command []string, logOut io.Writer) (bool, error) {
+func Run(flags *Flags, logOut io.Writer) (bool, error) { //nolint:gocyclo
 	var configData []byte
 	if flags.ConfigFile != "" {
 		var err error
@@ -87,7 +92,23 @@ func Run(flags *Flags, command []string, logOut io.Writer) (bool, error) {
 		}
 		_, _ = fmt.Fprintf(logOut, "Loaded %d test suites, %d test case templates.\n", len(allSuites), numCases)
 	}
-	testCaseLib, err := newTestCaseLibrary(allSuites, configCases, flags.Mode)
+	mode := conformancev1alpha1.TestSuite_TEST_MODE_UNSPECIFIED
+	var useReferenceClient, useReferenceServer bool
+	switch {
+	case len(flags.ClientCommand) > 0 && len(flags.ServerCommand) == 0:
+		// Client mode uses a reference server to test a client
+		mode = conformancev1alpha1.TestSuite_TEST_MODE_CLIENT
+		useReferenceServer = true
+	case len(flags.ClientCommand) == 0 && len(flags.ServerCommand) > 0:
+		// Server mode uses a reference client to test a server
+		mode = conformancev1alpha1.TestSuite_TEST_MODE_SERVER
+		useReferenceClient = true
+	default:
+		// Otherwise, no reference server or client is used, so
+		// leave mode as "unspecified" (so we'll include neither
+		// client-specific nor server-specific cases).
+	}
+	testCaseLib, err := newTestCaseLibrary(allSuites, configCases, mode)
 	if err != nil {
 		return false, err
 	}
@@ -130,43 +151,81 @@ func Run(flags *Flags, command []string, logOut io.Writer) (bool, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	isClient := flags.Mode == conformancev1alpha1.TestSuite_TEST_MODE_CLIENT
-	var startClient processStarter
-	if isClient {
-		startClient = runCommand(command)
+	var clients []processInfo
+	if useReferenceClient {
+		clients = []processInfo{
+			{
+				start:           runInProcess("reference-client", referenceclient.Run),
+				isReferenceImpl: true,
+			},
+			{
+				start:      runInProcess("grpc-reference-client", grpcclient.Run),
+				isGrpcImpl: true,
+			},
+		}
 	} else {
-		startClient = runInProcess("reference-client", referenceclient.Run)
+		clients = []processInfo{
+			{
+				start: runCommand(flags.ClientCommand),
+			},
+		}
 	}
-	clientProcess, err := runClient(ctx, startClient)
-	if err != nil {
-		return false, fmt.Errorf("error starting client: %w", err)
-	}
-	defer clientProcess.stop()
 
 	results := newResults(knownFailing)
 
-	var startServer processStarter
-	if isClient {
-		startServer = runInProcess("reference-server", referenceserver.RunInReferenceMode)
-	} else {
-		startServer = runCommand(command)
-	}
-	// TODO: start servers in parallel (up to a limit) to allow parallelism and faster test execution
-	for svrInstance, testCases := range testCaseLib.casesByServer {
-		runTestCasesForServer(ctx, !isClient, isClient, svrInstance, testCases, clientCreds, startServer, results, clientProcess)
-		if !clientProcess.isRunning() {
-			err := clientProcess.waitForResponses()
-			if err == nil {
-				err = errors.New("client process unexpectedly stopped")
-			} else {
-				err = fmt.Errorf("client process unexpectedly stopped: %w", err)
+	for _, clientInfo := range clients {
+		clientProcess, err := runClient(ctx, clientInfo.start)
+		if err != nil {
+			return false, fmt.Errorf("error starting client: %w", err)
+		}
+		defer clientProcess.stop()
+
+		var servers []processInfo
+		if useReferenceServer {
+			servers = []processInfo{
+				{
+					start:           runInProcess("reference-server", referenceserver.RunInReferenceMode),
+					isReferenceImpl: true,
+				},
+				{
+					start:      runInProcess("grpc-reference-server", grpcserver.Run),
+					isGrpcImpl: true,
+				},
 			}
+		} else {
+			servers = []processInfo{
+				{
+					start: runCommand(flags.ServerCommand),
+				},
+			}
+		}
+
+		// TODO: start servers in parallel (up to a limit) to allow parallelism and faster test execution
+		for _, serverInfo := range servers {
+			for svrInstance, testCases := range testCaseLib.casesByServer {
+				if clientInfo.isGrpcImpl || serverInfo.isGrpcImpl {
+					testCases = filterGRPCImplTestCases(testCases)
+					if len(testCases) == 0 {
+						continue
+					}
+				}
+				runTestCasesForServer(ctx, clientInfo.isReferenceImpl, serverInfo.isReferenceImpl, svrInstance, testCases, clientCreds, serverInfo.start, results, clientProcess)
+				if !clientProcess.isRunning() {
+					err := clientProcess.waitForResponses()
+					if err == nil {
+						err = errors.New("client process unexpectedly stopped")
+					} else {
+						err = fmt.Errorf("client process unexpectedly stopped: %w", err)
+					}
+					return false, err
+				}
+			}
+		}
+
+		clientProcess.closeSend()
+		if err := clientProcess.waitForResponses(); err != nil {
 			return false, err
 		}
-	}
-	clientProcess.closeSend()
-	if err := clientProcess.waitForResponses(); err != nil {
-		return false, err
 	}
 
 	return results.report(logOut)
@@ -191,4 +250,40 @@ func logTestCaseInfo(testCaseLib *testCaseLibrary, logOut io.Writer) {
 		_, _ = fmt.Fprintf(logOut, "Running %d tests for server config {%s, %s, TLS:%v}...\n",
 			len(testCases), svrInstance.httpVersion, svrInstance.protocol, svrInstance.useTLS)
 	}
+}
+
+type processInfo struct {
+	start           processStarter
+	isReferenceImpl bool
+	isGrpcImpl      bool
+}
+
+func filterGRPCImplTestCases(testCases []*conformancev1alpha1.TestCase) []*conformancev1alpha1.TestCase {
+	// The gRPC reference impl does not support everything that the main reference impl does. So
+	// we must filter away any test cases that aren't applicable to the gRPC impls.
+	filtered := make([]*conformancev1alpha1.TestCase, 0, len(testCases))
+	for _, testCase := range testCases {
+		if testCase.Request.HttpVersion != conformancev1alpha1.HTTPVersion_HTTP_VERSION_2 {
+			continue
+		}
+		if testCase.Request.Protocol != conformancev1alpha1.Protocol_PROTOCOL_GRPC {
+			continue
+		}
+		if testCase.Request.Codec != conformancev1alpha1.Codec_CODEC_PROTO {
+			continue
+		}
+		if testCase.Request.Compression != conformancev1alpha1.Compression_COMPRESSION_IDENTITY &&
+			testCase.Request.Compression != conformancev1alpha1.Compression_COMPRESSION_GZIP {
+			continue
+		}
+		if len(testCase.Request.ServerTlsCert) > 0 {
+			continue
+		}
+		filteredCase := proto.Clone(testCase).(*conformancev1alpha1.TestCase) //nolint:errcheck,forcetypeassert
+		// Insert a path in the test name to indicate that this is against the gRPC impl.
+		dir, base := path.Dir(filteredCase.Request.TestName), path.Base(filteredCase.Request.TestName)
+		filteredCase.Request.TestName = path.Join(dir, "(grpc impl)", base)
+		filtered = append(filtered, filteredCase)
+	}
+	return filtered
 }

--- a/internal/app/connectconformance/testsuites/grpc_only.yaml
+++ b/internal/app/connectconformance/testsuites/grpc_only.yaml
@@ -30,6 +30,9 @@ testCases:
         - name: x-custom-trailer
           value: ["bing","quux"]
   expectedResponse:
+    responseHeaders:
+    - name: x-custom-header
+      value: ["foo","bar","baz"]
     error:
       code: 13
       message: "unary failed"
@@ -41,8 +44,6 @@ testCases:
     responseTrailers:
     - name: X-Custom-Trailer
       value: ["bing","quux"]
-    - name: x-custom-header
-      value: ["foo","bar","baz"]
 - request:
     testName: unary error trailers only response unicode
     service: connectrpc.conformance.v1alpha1.ConformanceService
@@ -69,6 +70,9 @@ testCases:
         - name: x-custom-trailer
           value: ["bing","quux"]
   expectedResponse:
+    responseHeaders:
+    - name: x-custom-header
+      value: ["foo","bar","baz"]
     error:
       code: 13
       message: "\ntest with whitespace\r\nand Unicode BMP ☺ and non-BMP 😈\n"
@@ -78,8 +82,6 @@ testCases:
           value:
             - "test error detail value"
     responseTrailers:
-    - name: x-custom-header
-      value: ["foo","bar","baz"]
     - name: X-Custom-Trailer
       value: ["bing","quux"]
 - request:
@@ -111,6 +113,9 @@ testCases:
     - "@type": type.googleapis.com/connectrpc.conformance.v1alpha1.ClientStreamRequest
       requestData: "dGVzdCByZXNwb25zZQ=="
   expectedResponse:
+    responseHeaders:
+    - name: X-Custom-Header
+      value: ["foo","bar","baz"]
     error:
       code: 13
       message: "client stream failed"
@@ -120,8 +125,6 @@ testCases:
           value:
             - "test error detail value"
     responseTrailers:
-    - name: X-Custom-Header
-      value: ["foo","bar","baz"]
     - name: X-Custom-Trailer
       value: ["bing","quux"]
 - request:


### PR DESCRIPTION
This also allows running an arbitrary client against an arbitrary server -- so you don't have to run a reference impl at all.

I had to tweak the "trailers only response" test cases and the logic for asserting the results because this reported failures otherwise: when running a gRPC client against a gRPC server, it was successfully distinguishing headers and trailers, but the test case expected to see them consolidated. Once I fixed the test case data, it wouldn't work against a Connect server, since the Connect server APIs don't allow a handler to set headers and trailers independently for unary and client-stream methods.

TBH, the hack to get the test cases to pass is rather unsatisfying. But I don't think we can really change the behavior of the connect-go server since it would require API changes that would not be backwards compatible (a non-starter). It would have been much nicer if the error API allowed at least _trying_ to set headers and trailers independently, even if they might be consolidated into a single set of metadata in a trailers-only response. 🤷
