### PR TITLE
Add support for raw requests and responses to reference implementations

### DIFF
--- a/internal/app/connectconformance/server_runner.go
+++ b/internal/app/connectconformance/server_runner.go
@@ -176,7 +176,7 @@ func runTestCasesForServer(
 				results.assert(name, expectations[resp.TestName], resp.GetResponse())
 			}
 			if isReferenceClient {
-				for _, msg := range resp.Feedback {
+				for _, msg := range resp.GetFeedback() {
 					results.recordSideband(resp.TestName, msg)
 				}
 			}

--- a/internal/app/connectconformance/test_case_library.go
+++ b/internal/app/connectconformance/test_case_library.go
@@ -220,6 +220,14 @@ func serverInstanceForCase(testCase *conformancev1.TestCase) serverInstance {
 	}
 }
 
+type unaryResponseDefiner interface {
+	GetResponseDefinition() *conformancev1.UnaryResponseDefinition
+}
+
+type streamResponseDefiner interface {
+	GetResponseDefinition() *conformancev1.StreamResponseDefinition
+}
+
 // parseTestSuites processes the given file contents. The given map is keyed
 // by test file name. Each entry's value is the contents of the named file.
 // The given argument often represents the embedded test suite data. Also
@@ -235,6 +243,14 @@ func parseTestSuites(testFileData map[string][]byte) (map[string]*conformancev1.
 			return nil, ensureFileName(err, testFilePath)
 		}
 		for _, testCase := range suite.TestCases {
+			if testCase.Request.RawRequest != nil && suite.Mode != conformancev1.TestSuite_TEST_MODE_SERVER {
+				return nil, fmt.Errorf("%s: test case %q has raw request, but that is only allowed when mode is TEST_MODE_SERVER",
+					testFilePath, testCase.Request.TestName)
+			}
+			if hasRawResponse(testCase.Request.RequestMessages) && suite.Mode != conformancev1.TestSuite_TEST_MODE_CLIENT {
+				return nil, fmt.Errorf("%s: test case %q has raw response, but that is only allowed when mode is TEST_MODE_CLIENT",
+					testFilePath, testCase.Request.TestName)
+			}
 			if err := expandRequestData(testCase); err != nil {
 				return nil, fmt.Errorf("%s: failed to expand request sizes as directed for test case %q: %w",
 					testFilePath, testCase.Request.TestName, err)
@@ -333,6 +349,11 @@ func populateExpectedResponse(testCase *conformancev1.TestCase) error {
 	if testCase.ExpectedResponse != nil {
 		return nil
 	}
+
+	if testCase.Request.RawRequest != nil || hasRawResponse(testCase.Request.RequestMessages) {
+		return errors.New("test case must specify expected response when using raw request or response")
+	}
+
 	// TODO - This is just a temporary constraint to protect against panics for now.
 	// Eventually, we want to be able to test client and bidi streams where there are no request messages.
 	// The potential plan is for server impls to produce (and the code below to expect) a single response
@@ -359,6 +380,27 @@ func populateExpectedResponse(testCase *conformancev1.TestCase) error {
 	}
 }
 
+func hasRawResponse(reqs []*anypb.Any) bool {
+	if len(reqs) == 0 {
+		return false
+	}
+	msg, err := reqs[0].UnmarshalNew()
+	if err != nil {
+		return false // we'll deal with this error later
+	}
+	switch msg := msg.(type) {
+	case unaryResponseDefiner:
+		if msg.GetResponseDefinition().GetRawResponse() != nil {
+			return true
+		}
+	case streamResponseDefiner:
+		if msg.GetResponseDefinition().GetRawResponse() != nil {
+			return true
+		}
+	}
+	return false
+}
+
 // populates the expected response for a unary test case.
 func populateExpectedUnaryResponse(testCase *conformancev1.TestCase) error {
 	req := testCase.Request.RequestMessages[0]
@@ -366,9 +408,6 @@ func populateExpectedUnaryResponse(testCase *conformancev1.TestCase) error {
 	concreteReq, err := req.UnmarshalNew()
 	if err != nil {
 		return err
-	}
-	type unaryResponseDefiner interface {
-		GetResponseDefinition() *conformancev1.UnaryResponseDefinition
 	}
 
 	definer, ok := concreteReq.(unaryResponseDefiner)
@@ -450,9 +489,6 @@ func populateExpectedStreamResponse(testCase *conformancev1.TestCase) error {
 	concreteReq, err := req.UnmarshalNew()
 	if err != nil {
 		return err
-	}
-	type streamResponseDefiner interface {
-		GetResponseDefinition() *conformancev1.StreamResponseDefinition
 	}
 
 	definer, ok := concreteReq.(streamResponseDefiner)

--- a/internal/app/referenceclient/client.go
+++ b/internal/app/referenceclient/client.go
@@ -158,6 +158,10 @@ func invoke(ctx context.Context, req *v1.ClientCompatRequest) (*v1.ClientRespons
 		return nil, errors.New("an HTTP version must be specified")
 	}
 
+	if req.RawRequest != nil {
+		transport = &rawRequestSender{transport: transport, rawRequest: req.RawRequest}
+	}
+
 	// Create client options based on protocol of the implementation
 	clientOptions := []connect.ClientOption{connect.WithHTTPGet()}
 	switch req.Protocol {

--- a/internal/app/referenceclient/raw_request.go
+++ b/internal/app/referenceclient/raw_request.go
@@ -1,0 +1,99 @@
+// Copyright 2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package referenceclient
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"connectrpc.com/conformance/internal"
+	conformancev1 "connectrpc.com/conformance/internal/gen/proto/go/connectrpc/conformance/v1"
+)
+
+type rawRequestSender struct {
+	transport  http.RoundTripper
+	rawRequest *conformancev1.RawHTTPRequest
+}
+
+func (r *rawRequestSender) RoundTrip(orig *http.Request) (*http.Response, error) {
+	switch r.rawRequest.Body.(type) {
+	case *conformancev1.RawHTTPRequest_Unary, *conformancev1.RawHTTPRequest_Stream:
+	default:
+		return nil, fmt.Errorf("raw request has invalid body definition: %T", r.rawRequest.Body)
+	}
+
+	uri := r.rawRequest.Uri
+	if len(r.rawRequest.RawQueryParams) > 0 || len(r.rawRequest.EncodedQueryParams) > 0 {
+		reqURL, err := url.Parse(r.rawRequest.Uri)
+		if err != nil {
+			return nil, fmt.Errorf("raw request has invalid URI: %s: %w", r.rawRequest.Uri, err)
+		}
+		vals := reqURL.Query()
+		for _, param := range r.rawRequest.RawQueryParams {
+			vals[param.Name] = append(vals[param.Name], param.Value...)
+		}
+		for _, param := range r.rawRequest.EncodedQueryParams {
+			var buf bytes.Buffer
+			if err := internal.WriteRawMessageContents(param.Value, &buf); err != nil {
+				return nil, fmt.Errorf("raw request has invalid encoded query param %s: %w", param.Name, err)
+			}
+			var paramVal string
+			if param.Base64Encode {
+				paramVal = base64.URLEncoding.EncodeToString(buf.Bytes())
+			} else {
+				paramVal = buf.String()
+			}
+			vals[param.Name] = append(vals[param.Name], paramVal)
+		}
+		reqURL.RawQuery = vals.Encode()
+		uri = reqURL.String()
+	}
+
+	pipeReader, pipeWriter := io.Pipe()
+	req, err := http.NewRequestWithContext(orig.Context(), r.rawRequest.Verb, uri, pipeReader)
+	if err != nil {
+		if orig.Body != nil {
+			_ = orig.Body.Close()
+		}
+		return nil, err
+	}
+
+	// Write the request body to the pipe.
+	go func() {
+		defer func() {
+			_ = pipeWriter.Close()
+		}()
+		switch contents := r.rawRequest.Body.(type) {
+		case *conformancev1.RawHTTPRequest_Unary:
+			_ = internal.WriteRawMessageContents(contents.Unary, pipeWriter)
+		case *conformancev1.RawHTTPRequest_Stream:
+			_ = internal.WriteRawStreamContents(contents.Stream, pipeWriter)
+		}
+	}()
+
+	// Consume the request body and close it.
+	go func() {
+		defer func() {
+			_ = orig.Body.Close()
+		}()
+		_, _ = io.Copy(io.Discard, orig.Body)
+	}()
+
+	return r.transport.RoundTrip(req)
+}

--- a/internal/app/referenceserver/raw_response.go
+++ b/internal/app/referenceserver/raw_response.go
@@ -1,0 +1,233 @@
+// Copyright 2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package referenceserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+
+	"connectrpc.com/conformance/internal"
+	v1 "connectrpc.com/conformance/internal/gen/proto/go/connectrpc/conformance/v1"
+	connectv1 "connectrpc.com/conformance/internal/gen/proto/go/connectrpc/conformance/v1/conformancev1connect"
+	"connectrpc.com/connect"
+	"google.golang.org/protobuf/proto"
+)
+
+// rawResponseKey is used to store the raw response that the server
+// should send in the context. The value type will be **v1.RawHTTPResponse.
+type rawResponseKey struct{}
+
+type rawResponseWriter struct {
+	respWriter      http.ResponseWriter
+	mu              sync.Mutex
+	rawResp         **v1.RawHTTPResponse
+	startedResponse bool
+}
+
+// canSendResponse returns true if the server handler can use the
+// http.ResponseWriter methods to send a response. This returns false
+// if we will instead be finishing the call with a raw response.
+func (r *rawResponseWriter) canSendResponse() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.startedResponse {
+		return true
+	}
+	if *r.rawResp == nil {
+		r.startedResponse = true
+		return true
+	}
+	return false
+}
+
+// rawResponse returns non-nil if the call will be finished with a
+// raw response. If it returns nil, nothing need be done to finish
+// the call; the server handler was already allowed to send it.
+func (r *rawResponseWriter) rawResponse(feedback *feedbackWriter) *v1.RawHTTPResponse {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.startedResponse {
+		if *r.rawResp != nil {
+			// Oops. There's a raw response, but it was set too late.
+			feedback.Printf("Could not send raw response; handler sent response too soon")
+		}
+		return nil
+	}
+	return *r.rawResp
+}
+
+func (r *rawResponseWriter) Header() http.Header {
+	return r.respWriter.Header()
+}
+
+func (r *rawResponseWriter) Write(bytes []byte) (int, error) {
+	if r.canSendResponse() {
+		return r.respWriter.Write(bytes)
+	}
+	return len(bytes), nil
+}
+
+func (r *rawResponseWriter) WriteHeader(statusCode int) {
+	if r.canSendResponse() {
+		r.respWriter.WriteHeader(statusCode)
+	}
+}
+
+func (r *rawResponseWriter) Flush() {
+	if r.canSendResponse() {
+		if flusher, ok := r.respWriter.(http.Flusher); ok {
+			flusher.Flush()
+		}
+	}
+}
+
+func (r *rawResponseWriter) Unwrap() http.ResponseWriter {
+	return r.respWriter
+}
+
+func (r *rawResponseWriter) finish(feedback *feedbackWriter) {
+	resp := r.rawResponse(feedback)
+	if resp == nil {
+		return
+	}
+
+	// clean any headers that may have been set by the handler
+	for k := range r.respWriter.Header() {
+		delete(r.respWriter.Header(), k)
+	}
+	internal.AddHeaders(resp.Headers, r.respWriter.Header())
+	r.respWriter.WriteHeader(int(resp.StatusCode))
+	switch contents := resp.Body.(type) {
+	case *v1.RawHTTPResponse_Unary:
+		_ = internal.WriteRawMessageContents(contents.Unary, r.respWriter)
+	case *v1.RawHTTPResponse_Stream:
+		_ = internal.WriteRawStreamContents(contents.Stream, r.respWriter)
+	}
+	internal.AddTrailers(resp.Trailers, r.respWriter.Header())
+}
+
+type rawResponseRecorder struct{}
+
+func (r rawResponseRecorder) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
+	return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+		if msg, ok := req.Any().(*v1.UnaryRequest); ok {
+			rawResponse := msg.ResponseDefinition.RawResponse
+			if rawResponse != nil {
+				respPtr, ok := ctx.Value(rawResponseKey{}).(**v1.RawHTTPResponse)
+				if !ok {
+					return nil, errors.New("request contains raw response definition but no RawHTTPResponse holder in context")
+				}
+				*respPtr = rawResponse
+				return nil, connect.NewError(connect.CodeAborted, errors.New("use raw response instead"))
+			}
+		}
+		return next(ctx, req)
+	}
+}
+
+func (r rawResponseRecorder) WrapStreamingClient(next connect.StreamingClientFunc) connect.StreamingClientFunc {
+	return next
+}
+
+func (r rawResponseRecorder) WrapStreamingHandler(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
+	return func(ctx context.Context, stream connect.StreamingHandlerConn) error {
+		var req proto.Message
+		var rawResponseFunc func() *v1.RawHTTPResponse
+		switch stream.Spec().Procedure {
+		case connectv1.ConformanceServiceClientStreamProcedure:
+			streamReq := &v1.ClientStreamRequest{}
+			rawResponseFunc = func() *v1.RawHTTPResponse {
+				return streamReq.GetResponseDefinition().GetRawResponse()
+			}
+			req = streamReq
+		case connectv1.ConformanceServiceServerStreamProcedure:
+			streamReq := &v1.ServerStreamRequest{}
+			rawResponseFunc = func() *v1.RawHTTPResponse {
+				return streamReq.GetResponseDefinition().GetRawResponse()
+			}
+			req = streamReq
+		case connectv1.ConformanceServiceBidiStreamProcedure:
+			streamReq := &v1.BidiStreamRequest{}
+			rawResponseFunc = func() *v1.RawHTTPResponse {
+				return streamReq.GetResponseDefinition().GetRawResponse()
+			}
+			req = streamReq
+		}
+		var reqErr error
+		if req == nil {
+			return next(ctx, stream)
+		}
+		reqErr = stream.Receive(req)
+		if reqErr == nil { //nolint:nestif
+			rawResponse := rawResponseFunc()
+			if rawResponse != nil {
+				respPtr, ok := ctx.Value(rawResponseKey{}).(**v1.RawHTTPResponse)
+				if !ok {
+					return errors.New("request contains raw response definition but no RawHTTPResponse holder in context")
+				}
+				*respPtr = rawResponse
+				// If we have a raw response, go ahead and drain the request stream
+				// before sending back the raw response.
+				// NOTE: This means that raw responses cannot be used with full-duplex
+				//       request definitions.
+				for {
+					if err := stream.Receive(req); err != nil {
+						break
+					}
+				}
+				return connect.NewError(connect.CodeAborted, errors.New("use raw response instead"))
+			}
+		}
+		return next(ctx, &firstReqCachingStream{
+			StreamingHandlerConn: stream,
+			request:              req,
+			recvErr:              reqErr,
+		})
+	}
+}
+
+type firstReqCachingStream struct {
+	connect.StreamingHandlerConn
+	request any
+	recvErr error
+}
+
+func (str *firstReqCachingStream) Receive(dest any) error {
+	if str.recvErr != nil {
+		err := str.recvErr
+		str.request, str.recvErr = nil, nil
+		return err
+	}
+	if str.request != nil {
+		destMsg, ok := dest.(proto.Message)
+		if !ok {
+			return fmt.Errorf("%T does not implement proto.Message", dest)
+		}
+		srcMsg, ok := str.request.(proto.Message)
+		if !ok {
+			return fmt.Errorf("%T does not implement proto.Message", dest)
+		}
+		proto.Reset(destMsg)
+		proto.Merge(destMsg, srcMsg)
+		str.request, str.recvErr = nil, nil
+		return nil
+	}
+	// Otherwise, we've already provided the cached first request.
+	// So all subsequent receives use the underlying stream.
+	return str.StreamingHandlerConn.Receive(dest)
+}

--- a/internal/app/referenceserver/server.go
+++ b/internal/app/referenceserver/server.go
@@ -151,7 +151,7 @@ func createServer(req *v1.ServerCompatRequest, listenAddr string, referenceMode 
 		connect.WithCompression(compression.Snappy, compression.NewSnappyDecompressor, compression.NewSnappyCompressor),
 		connect.WithCompression(compression.Zstd, compression.NewZstdDecompressor, compression.NewZstdCompressor),
 		connect.WithCodec(&internal.TextConnectCodec{}),
-		connect.WithInterceptors(serverNameHandlerInterceptor{}),
+		connect.WithInterceptors(serverNameHandlerInterceptor{}, rawResponseRecorder{}),
 	}
 	if req.MessageReceiveLimit > 0 {
 		opts = append(opts, connect.WithReadMaxBytes(int(req.MessageReceiveLimit)))

--- a/internal/headers.go
+++ b/internal/headers.go
@@ -32,6 +32,19 @@ func AddHeaders(
 	}
 }
 
+// AddTrailers adds all header values in src to dest, but
+// it prefixes each header name with http.TrailerPrefix.
+func AddTrailers(
+	src []*v1.Header,
+	dest http.Header,
+) {
+	for _, header := range src {
+		for _, val := range header.Value {
+			dest.Add(http.TrailerPrefix+header.Name, val)
+		}
+	}
+}
+
 // ConvertToProtoHeader converts HTTP headers to a slice of proto Headers.
 func ConvertToProtoHeader(
 	src http.Header,

--- a/internal/raw_http_body.go
+++ b/internal/raw_http_body.go
@@ -1,0 +1,107 @@
+// Copyright 2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	"connectrpc.com/conformance/internal/compression"
+	conformancev1 "connectrpc.com/conformance/internal/gen/proto/go/connectrpc/conformance/v1"
+	"connectrpc.com/connect"
+	"github.com/klauspost/compress/gzip"
+)
+
+// WriteRawMessageContents writes the given message contents to w.
+func WriteRawMessageContents(contents *conformancev1.MessageContents, writer io.Writer) error {
+	var msgBytes []byte
+	switch data := contents.Data.(type) {
+	case nil:
+		// empty, so nothing to write
+		return nil
+	case *conformancev1.MessageContents_Binary:
+		msgBytes = data.Binary
+	case *conformancev1.MessageContents_BinaryMessage:
+		msgBytes = data.BinaryMessage.Value
+	case *conformancev1.MessageContents_Text:
+		msgBytes = []byte(data.Text)
+	default:
+		return fmt.Errorf("invalid message contents data type: %T", data)
+	}
+
+	var compressor connect.Compressor
+	switch contents.Compression {
+	case conformancev1.Compression_COMPRESSION_IDENTITY, conformancev1.Compression_COMPRESSION_UNSPECIFIED:
+		// no compression
+		_, err := writer.Write(msgBytes)
+		return err
+	case conformancev1.Compression_COMPRESSION_GZIP:
+		compressor = gzip.NewWriter(nil)
+	case conformancev1.Compression_COMPRESSION_BR:
+		compressor = compression.NewBrotliCompressor()
+	case conformancev1.Compression_COMPRESSION_ZSTD:
+		compressor = compression.NewZstdCompressor()
+	case conformancev1.Compression_COMPRESSION_SNAPPY:
+		compressor = compression.NewSnappyCompressor()
+	case conformancev1.Compression_COMPRESSION_DEFLATE:
+		compressor = compression.NewDeflateCompressor()
+	default:
+		return fmt.Errorf("unknown compression type: %v", contents.Compression)
+	}
+	compressor.Reset(writer)
+	_, err := compressor.Write(msgBytes)
+	if err == nil {
+		err = compressor.Close()
+	}
+	return err
+}
+
+// WriteRawStreamContents writes the given stream contents to w.
+func WriteRawStreamContents(contents *conformancev1.StreamContents, writer io.Writer) error {
+	for i, item := range contents.Items {
+		var prefix [5]byte
+		if item.Flags > 255 {
+			return fmt.Errorf("message #%d: flags is out of range: %d, should be [0,255]", i+1, item.Flags)
+		}
+		prefix[0] = byte(item.Flags)
+		if item.Length != nil {
+			binary.BigEndian.PutUint32(prefix[1:], item.GetLength())
+			_, err := writer.Write(prefix[:])
+			if err == nil {
+				err = WriteRawMessageContents(item.Payload, writer)
+			}
+			if err != nil {
+				return fmt.Errorf("message #%d: %w", i+1, err)
+			}
+			continue
+		}
+
+		var buf bytes.Buffer
+		if err := WriteRawMessageContents(item.Payload, &buf); err != nil {
+			return fmt.Errorf("message #%d: %w", i+1, err)
+		}
+		binary.BigEndian.PutUint32(prefix[1:], uint32(buf.Len()))
+		_, err := writer.Write(prefix[:])
+		if err == nil {
+			_, err = buf.WriteTo(writer)
+		}
+		if err != nil {
+			return fmt.Errorf("message #%d: %w", i+1, err)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This still needs testing. It's also big enough, that I'll probably break it up into separate PRs for the test runner (the smallest portion), the reference server (the largest), and the reference client.