### PR TITLE
V1: Enable CI again after branch rename

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,9 +1,9 @@
 name: ci
 on:
   push:
-    branches: [main, v2] # TODO: Switch to just main once v2 is merged
+    branches: [main, v1] # TODO: Switch to just main once v1 is merged
   pull_request:
-    branches: [main, v2] # TODO: Switch to just main once v2 is merged
+    branches: [main, v1] # TODO: Switch to just main once v1 is merged
   workflow_dispatch: {} # support manual runs
 permissions:
   contents: read


### PR DESCRIPTION
After we renamed v2 -> v1, CI jobs no longer run. So we need to merge this change and rebase any open PRs so their checks will run.