### PR TITLE
V1: Don't quote headers

### DIFF
--- a/internal/app/connectconformance/results.go
+++ b/internal/app/connectconformance/results.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 
@@ -312,7 +311,7 @@ func headerValsToString(vals []string) string {
 		if i > 0 {
 			buf.WriteString(", ")
 		}
-		buf.WriteString(strconv.Quote(val))
+		buf.WriteString(val)
 	}
 	return buf.String()
 }


### PR DESCRIPTION
Don't quote headers before checking for equality. If we quote them headers that are already `,` seperated will fail the check.