### PR TITLE
Helpers for writing raw HTTP body; handle test cases with raw request/response in test runnerf

### DIFF
--- a/internal/app/connectconformance/server_runner.go
+++ b/internal/app/connectconformance/server_runner.go
@@ -176,7 +176,7 @@ func runTestCasesForServer(
 				results.assert(name, expectations[resp.TestName], resp.GetResponse())
 			}
 			if isReferenceClient {
-				for _, msg := range resp.Feedback {
+				for _, msg := range resp.GetFeedback() {
 					results.recordSideband(resp.TestName, msg)
 				}
 			}

--- a/internal/app/connectconformance/test_case_library.go
+++ b/internal/app/connectconformance/test_case_library.go
@@ -220,6 +220,14 @@ func serverInstanceForCase(testCase *conformancev1.TestCase) serverInstance {
 	}
 }
 
+type unaryResponseDefiner interface {
+	GetResponseDefinition() *conformancev1.UnaryResponseDefinition
+}
+
+type streamResponseDefiner interface {
+	GetResponseDefinition() *conformancev1.StreamResponseDefinition
+}
+
 // parseTestSuites processes the given file contents. The given map is keyed
 // by test file name. Each entry's value is the contents of the named file.
 // The given argument often represents the embedded test suite data. Also
@@ -235,6 +243,14 @@ func parseTestSuites(testFileData map[string][]byte) (map[string]*conformancev1.
 			return nil, ensureFileName(err, testFilePath)
 		}
 		for _, testCase := range suite.TestCases {
+			if testCase.Request.RawRequest != nil && suite.Mode != conformancev1.TestSuite_TEST_MODE_SERVER {
+				return nil, fmt.Errorf("%s: test case %q has raw request, but that is only allowed when mode is TEST_MODE_SERVER",
+					testFilePath, testCase.Request.TestName)
+			}
+			if hasRawResponse(testCase.Request.RequestMessages) && suite.Mode != conformancev1.TestSuite_TEST_MODE_CLIENT {
+				return nil, fmt.Errorf("%s: test case %q has raw response, but that is only allowed when mode is TEST_MODE_CLIENT",
+					testFilePath, testCase.Request.TestName)
+			}
 			if err := expandRequestData(testCase); err != nil {
 				return nil, fmt.Errorf("%s: failed to expand request sizes as directed for test case %q: %w",
 					testFilePath, testCase.Request.TestName, err)
@@ -333,6 +349,11 @@ func populateExpectedResponse(testCase *conformancev1.TestCase) error {
 	if testCase.ExpectedResponse != nil {
 		return nil
 	}
+
+	if testCase.Request.RawRequest != nil || hasRawResponse(testCase.Request.RequestMessages) {
+		return errors.New("test case must specify expected response when using raw request or response")
+	}
+
 	// TODO - This is just a temporary constraint to protect against panics for now.
 	// Eventually, we want to be able to test client and bidi streams where there are no request messages.
 	// The potential plan is for server impls to produce (and the code below to expect) a single response
@@ -359,6 +380,27 @@ func populateExpectedResponse(testCase *conformancev1.TestCase) error {
 	}
 }
 
+func hasRawResponse(reqs []*anypb.Any) bool {
+	if len(reqs) == 0 {
+		return false
+	}
+	msg, err := reqs[0].UnmarshalNew()
+	if err != nil {
+		return false // we'll deal with this error later
+	}
+	switch msg := msg.(type) {
+	case unaryResponseDefiner:
+		if msg.GetResponseDefinition().GetRawResponse() != nil {
+			return true
+		}
+	case streamResponseDefiner:
+		if msg.GetResponseDefinition().GetRawResponse() != nil {
+			return true
+		}
+	}
+	return false
+}
+
 // populates the expected response for a unary test case.
 func populateExpectedUnaryResponse(testCase *conformancev1.TestCase) error {
 	req := testCase.Request.RequestMessages[0]
@@ -366,9 +408,6 @@ func populateExpectedUnaryResponse(testCase *conformancev1.TestCase) error {
 	concreteReq, err := req.UnmarshalNew()
 	if err != nil {
 		return err
-	}
-	type unaryResponseDefiner interface {
-		GetResponseDefinition() *conformancev1.UnaryResponseDefinition
 	}
 
 	definer, ok := concreteReq.(unaryResponseDefiner)
@@ -450,9 +489,6 @@ func populateExpectedStreamResponse(testCase *conformancev1.TestCase) error {
 	concreteReq, err := req.UnmarshalNew()
 	if err != nil {
 		return err
-	}
-	type streamResponseDefiner interface {
-		GetResponseDefinition() *conformancev1.StreamResponseDefinition
 	}
 
 	definer, ok := concreteReq.(streamResponseDefiner)

--- a/internal/headers.go
+++ b/internal/headers.go
@@ -32,6 +32,19 @@ func AddHeaders(
 	}
 }
 
+// AddTrailers adds all header values in src to dest, but
+// it prefixes each header name with http.TrailerPrefix.
+func AddTrailers(
+	src []*v1.Header,
+	dest http.Header,
+) {
+	for _, header := range src {
+		for _, val := range header.Value {
+			dest.Add(http.TrailerPrefix+header.Name, val)
+		}
+	}
+}
+
 // ConvertToProtoHeader converts HTTP headers to a slice of proto Headers.
 func ConvertToProtoHeader(
 	src http.Header,

--- a/internal/raw_http_body.go
+++ b/internal/raw_http_body.go
@@ -1,0 +1,107 @@
+// Copyright 2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	"connectrpc.com/conformance/internal/compression"
+	conformancev1 "connectrpc.com/conformance/internal/gen/proto/go/connectrpc/conformance/v1"
+	"connectrpc.com/connect"
+	"github.com/klauspost/compress/gzip"
+)
+
+// WriteRawMessageContents writes the given message contents to the given writer.
+func WriteRawMessageContents(contents *conformancev1.MessageContents, writer io.Writer) error {
+	var msgBytes []byte
+	switch data := contents.Data.(type) {
+	case nil:
+		// empty, so nothing to write
+		return nil
+	case *conformancev1.MessageContents_Binary:
+		msgBytes = data.Binary
+	case *conformancev1.MessageContents_BinaryMessage:
+		msgBytes = data.BinaryMessage.Value
+	case *conformancev1.MessageContents_Text:
+		msgBytes = []byte(data.Text)
+	default:
+		return fmt.Errorf("invalid message contents data type: %T", data)
+	}
+
+	var compressor connect.Compressor
+	switch contents.Compression {
+	case conformancev1.Compression_COMPRESSION_IDENTITY, conformancev1.Compression_COMPRESSION_UNSPECIFIED:
+		// no compression
+		_, err := writer.Write(msgBytes)
+		return err
+	case conformancev1.Compression_COMPRESSION_GZIP:
+		compressor = gzip.NewWriter(nil)
+	case conformancev1.Compression_COMPRESSION_BR:
+		compressor = compression.NewBrotliCompressor()
+	case conformancev1.Compression_COMPRESSION_ZSTD:
+		compressor = compression.NewZstdCompressor()
+	case conformancev1.Compression_COMPRESSION_SNAPPY:
+		compressor = compression.NewSnappyCompressor()
+	case conformancev1.Compression_COMPRESSION_DEFLATE:
+		compressor = compression.NewDeflateCompressor()
+	default:
+		return fmt.Errorf("unknown compression type: %v", contents.Compression)
+	}
+	compressor.Reset(writer)
+	_, err := compressor.Write(msgBytes)
+	if err == nil {
+		err = compressor.Close()
+	}
+	return err
+}
+
+// WriteRawStreamContents writes the given stream contents to the given writer.
+func WriteRawStreamContents(contents *conformancev1.StreamContents, writer io.Writer) error {
+	for i, item := range contents.Items {
+		var prefix [5]byte
+		if item.Flags > 255 {
+			return fmt.Errorf("message #%d: flags is out of range: %d, should be [0,255]", i+1, item.Flags)
+		}
+		prefix[0] = byte(item.Flags)
+		if item.Length != nil {
+			binary.BigEndian.PutUint32(prefix[1:], item.GetLength())
+			_, err := writer.Write(prefix[:])
+			if err == nil {
+				err = WriteRawMessageContents(item.Payload, writer)
+			}
+			if err != nil {
+				return fmt.Errorf("message #%d: %w", i+1, err)
+			}
+			continue
+		}
+
+		var buf bytes.Buffer
+		if err := WriteRawMessageContents(item.Payload, &buf); err != nil {
+			return fmt.Errorf("message #%d: %w", i+1, err)
+		}
+		binary.BigEndian.PutUint32(prefix[1:], uint32(buf.Len()))
+		_, err := writer.Write(prefix[:])
+		if err == nil {
+			_, err = buf.WriteTo(writer)
+		}
+		if err != nil {
+			return fmt.Errorf("message #%d: %w", i+1, err)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This is a preliminary change that adds a couple of `internal` helpers that the reference client and server will use and to add a little validation to the test runner related to the use of raw requests and responses.