### PR TITLE
V1: Add --version flag to all programs

### DIFF
--- a/internal/app/connectconformance/connectconformance.go
+++ b/internal/app/connectconformance/connectconformance.go
@@ -34,6 +34,8 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+// Flags are the config values for the test runner that may be provided via
+// command-line flags and arguments.
 type Flags struct {
 	ConfigFile       string
 	KnownFailingFile string

--- a/internal/app/grpcclient/client.go
+++ b/internal/app/grpcclient/client.go
@@ -18,8 +18,10 @@ import (
 	"context"
 	"errors"
 	"flag"
+	"fmt"
 	"io"
 	"net"
+	"path/filepath"
 	"strconv"
 	"time"
 
@@ -37,8 +39,13 @@ import (
 func Run(ctx context.Context, args []string, inReader io.ReadCloser, outWriter, _ io.WriteCloser) error {
 	flags := flag.NewFlagSet(args[0], flag.ExitOnError)
 	json := flags.Bool("json", false, "whether to use the JSON format for marshaling / unmarshaling messages")
+	showVersion := flags.Bool("version", false, "show version and exit")
 
 	_ = flags.Parse(args[1:])
+	if *showVersion {
+		_, _ = fmt.Fprintf(outWriter, "%s %s\n", filepath.Base(args[0]), internal.Version)
+		return nil
+	}
 	if flags.NArg() != 0 {
 		return errors.New("this command does not accept any positional arguments")
 	}
@@ -94,6 +101,8 @@ func invoke(ctx context.Context, req *v1.ClientCompatRequest) (*v1.ClientRespons
 		grpc.WithTransportCredentials(transportCredentials),
 		grpc.WithBlock(),
 		grpc.WithReturnConnectionError(),
+		grpc.WithUnaryInterceptor(userAgentUnaryClientInterceptor),
+		grpc.WithStreamInterceptor(userAgentStreamClientInterceptor),
 	}
 	if req.Compression == v1.Compression_COMPRESSION_GZIP {
 		dialOpts = append(dialOpts, grpc.WithDefaultCallOptions(grpc.UseCompressor(gzip.Name)))

--- a/internal/app/grpcclient/impl.go
+++ b/internal/app/grpcclient/impl.go
@@ -17,14 +17,18 @@ package grpcclient
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"time"
 
+	"connectrpc.com/conformance/internal"
 	v1 "connectrpc.com/conformance/internal/gen/proto/go/connectrpc/conformance/v1"
 	"connectrpc.com/conformance/internal/grpcutil"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )
+
+const clientName = "connectconformance-grpcclient"
 
 type invoker struct {
 	client v1.ConformanceServiceClient
@@ -335,4 +339,23 @@ func newInvoker(clientConn grpc.ClientConnInterface) *invoker {
 	return &invoker{
 		client: client,
 	}
+}
+
+func userAgentUnaryClientInterceptor(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+	return invoker(addUserAgent(ctx), method, req, reply, cc, opts...)
+}
+
+func userAgentStreamClientInterceptor(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	return streamer(addUserAgent(ctx), desc, cc, method, opts...)
+}
+
+func addUserAgent(ctx context.Context) context.Context {
+	reqMD, ok := metadata.FromOutgoingContext(ctx)
+	if !ok {
+		reqMD = metadata.MD{}
+	}
+	// decorate user-agent with the program name and version
+	userAgent := fmt.Sprintf("%s %s/%s", reqMD.Get("User-Agent"), clientName, internal.Version)
+	reqMD.Set("User-Agent", userAgent)
+	return metadata.NewOutgoingContext(ctx, reqMD)
 }

--- a/internal/app/grpcserver/impl.go
+++ b/internal/app/grpcserver/impl.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"time"
 
+	"connectrpc.com/conformance/internal"
 	v1 "connectrpc.com/conformance/internal/gen/proto/go/connectrpc/conformance/v1"
 	"connectrpc.com/conformance/internal/grpcutil"
 	"google.golang.org/grpc"
@@ -30,6 +31,8 @@ import (
 	proto "google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 )
+
+const serverName = "connectconformance-grpcserver"
 
 // NewConformanceServiceServer creates a new Conformance Service server.
 func NewConformanceServiceServer() v1.ConformanceServiceServer {
@@ -378,4 +381,19 @@ func asAny(msg proto.Message) (*anypb.Any, error) {
 		)
 	}
 	return msgAsAny, nil
+}
+
+func serverNameUnaryInterceptor(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {
+	_ = grpc.SetHeader(ctx, serverNameMetadata())
+	return handler(ctx, req)
+}
+
+func serverNameStreamInterceptor(srv any, ss grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	_ = ss.SetHeader(serverNameMetadata())
+	return handler(srv, ss)
+}
+
+func serverNameMetadata() metadata.MD {
+	server := fmt.Sprintf("%s/%s", serverName, internal.Version)
+	return metadata.Pairs("Server", server)
 }

--- a/internal/app/referenceclient/client.go
+++ b/internal/app/referenceclient/client.go
@@ -19,10 +19,12 @@ import (
 	"crypto/tls"
 	"errors"
 	"flag"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"net/url"
+	"path/filepath"
 	"strconv"
 
 	"connectrpc.com/conformance/internal"
@@ -41,8 +43,13 @@ import (
 func Run(ctx context.Context, args []string, inReader io.ReadCloser, outWriter, _ io.WriteCloser) error {
 	flags := flag.NewFlagSet(args[0], flag.ExitOnError)
 	json := flags.Bool("json", false, "whether to use the JSON format for marshaling / unmarshaling messages")
+	showVersion := flags.Bool("version", false, "show version and exit")
 
 	_ = flags.Parse(args[1:])
+	if *showVersion {
+		_, _ = fmt.Fprintf(outWriter, "%s %s\n", filepath.Base(args[0]), internal.Version)
+		return nil
+	}
 	if flags.NArg() != 0 {
 		return errors.New("this command does not accept any positional arguments")
 	}

--- a/internal/app/referenceserver/impl.go
+++ b/internal/app/referenceserver/impl.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"connectrpc.com/conformance/internal"
@@ -29,6 +30,8 @@ import (
 	proto "google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 )
+
+const serverName = "connectconformance-referenceserver"
 
 // ConformanceRequest is a general interface for all conformance requests (UnaryRequest, ServerStreamRequest, etc.)
 type ConformanceRequest interface {
@@ -356,4 +359,45 @@ func asAny(msg proto.Message) (*anypb.Any, error) {
 		)
 	}
 	return msgAsAny, nil
+}
+
+// serverNameHandlerInterceptor adds a "server" header on outgoing responses.
+type serverNameHandlerInterceptor struct{}
+
+func (i serverNameHandlerInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
+	return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+		resp, err := next(ctx, req)
+		if req.Spec().IsClient {
+			return resp, err
+		}
+
+		var headers http.Header
+		if err != nil {
+			var connErr *connect.Error
+			if !errors.As(err, &connErr) {
+				connErr = connect.NewError(connect.CodeUnknown, err)
+				err = connErr
+			}
+			headers = connErr.Meta()
+		} else {
+			headers = resp.Header()
+		}
+		// decorate server with the program name and version
+		server := strings.TrimSpace(fmt.Sprintf("%s %s/%s", headers.Get("Server"), serverName, internal.Version))
+		headers.Set("Server", server)
+		return resp, err
+	}
+}
+
+func (i serverNameHandlerInterceptor) WrapStreamingClient(next connect.StreamingClientFunc) connect.StreamingClientFunc {
+	return next
+}
+
+func (i serverNameHandlerInterceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
+	return func(ctx context.Context, stream connect.StreamingHandlerConn) error {
+		// decorate server with the program name and version
+		server := strings.TrimSpace(fmt.Sprintf("%s %s/%s", stream.ResponseHeader().Get("Server"), serverName, internal.Version))
+		stream.ResponseHeader().Set("Server", server)
+		return next(ctx, stream)
+	}
 }

--- a/internal/version.go
+++ b/internal/version.go
@@ -1,0 +1,25 @@
+// Copyright 2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+//nolint:gochecknoglobals
+var (
+	// NB: These are vars instead of consts so they can be changed via -X ldflags.
+	buildVersion       = "v1.0.0-rc1-dev"
+	buildVersionSuffix = ""
+
+	// Version is the version to report from all binaries.
+	Version = buildVersion + buildVersionSuffix
+)


### PR DESCRIPTION
Also updates reference clients and servers to indicate their identity and version in headers ("user-agent" request header for clients; "server" response header for servers).