### PR TITLE
Update version const to create v1.0.0-rc1 release

### DIFF
--- a/internal/version.go
+++ b/internal/version.go
@@ -17,7 +17,7 @@ package internal
 //nolint:gochecknoglobals
 var (
 	// NB: These are vars instead of consts so they can be changed via -X ldflags.
-	buildVersion       = "v1.0.0-rc1-dev"
+	buildVersion       = "v1.0.0-rc1"
 	buildVersionSuffix = ""
 
 	// Version is the version to report from all binaries.


### PR DESCRIPTION
Although the `Makefile` and `gorelease` config are smart enough to put the right version number here, it's also nice to edit the constant so that someone just doing `go build ...` will still see the correct number reported. (The make and release config stuff is mostly a fallback, so that at least the official binaries will print the correct version even if we forget to edit this.)

Once merged, this commit will be tagged and released, and then I'll open another PR to set it to `v1.0.0-rc2-dev`.