### PR TITLE
Add 'buf push' and 'make checkrelease' to CI and remove refs to 'v1' branch

### DIFF
--- a/.github/workflows/buf.yaml
+++ b/.github/workflows/buf.yaml
@@ -1,0 +1,40 @@
+name: buf
+on:
+  push:
+    branches: [main]
+    paths: ['proto/**']
+  pull_request:
+    branches: [main]
+    paths: ['proto/**']
+  workflow_dispatch: {} # support manual runs
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bufbuild/buf-setup-action@v1
+      - uses: bufbuild/buf-lint-action@v1.1.0
+        with:
+          input: proto
+  breaking:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bufbuild/buf-setup-action@v1
+      - uses: bufbuild/buf-breaking-action@v1.1.3
+        with:
+          input: proto
+          against: 'buf.build/connectrpc/conformance'
+  push:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    needs:
+      - lint
+      - breaking
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bufbuild/buf-setup-action@v1
+      - uses: bufbuild/buf-push-action@v1.1.1
+        with:
+          input: 'proto'
+          buf_token: ${{ secrets.BUF_TOKEN }}

--- a/.github/workflows/buf.yaml
+++ b/.github/workflows/buf.yaml
@@ -2,10 +2,10 @@ name: buf
 on:
   push:
     branches: [main]
-    paths: ['proto/**']
+    paths: ['proto/**', '.github/workflows/buf.yaml']
   pull_request:
     branches: [main]
-    paths: ['proto/**']
+    paths: ['proto/**', '.github/workflows/buf.yaml']
   workflow_dispatch: {} # support manual runs
 jobs:
   lint:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,9 +1,9 @@
 name: ci
 on:
   push:
-    branches: [main, v1] # TODO: Switch to just main once v1 is merged
+    branches: [main]
   pull_request:
-    branches: [main, v1] # TODO: Switch to just main once v1 is merged
+    branches: [main]
   workflow_dispatch: {} # support manual runs
 permissions:
   contents: read
@@ -18,17 +18,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - name: Install Buf
-        uses: bufbuild/buf-setup-action@v1
-      - name: Validate Protos
-        uses: bufbuild/buf-breaking-action@v1
-        with:
-          input: proto
-          against: 'buf.build/connectrpc/conformance'
-      - name: Lint Protos
-        uses: bufbuild/buf-lint-action@v1
-        with:
-          input: proto
       - name: Install Go
         uses: actions/setup-go@v4
         with:
@@ -50,3 +39,8 @@ jobs:
         # supported version.
         if: matrix.go-version == '1.21.x'
         run: make checkgenerate && make lint
+      - name: Check Release
+        # We'll only be building releases w/ latest Go, so we only need to
+        # test that it can be built w/ latest.
+        if: matrix.go-version == '1.21.x'
+        run: make checkrelease

--- a/internal/version.go
+++ b/internal/version.go
@@ -17,7 +17,7 @@ package internal
 //nolint:gochecknoglobals
 var (
 	// NB: These are vars instead of consts so they can be changed via -X ldflags.
-	buildVersion       = "v1.0.0-rc1"
+	buildVersion       = "v1.0.0-rc2-dev"
 	buildVersionSuffix = ""
 
 	// Version is the version to report from all binaries.


### PR DESCRIPTION
This also re-organizes the Buf checks in their own file, following the layout of some other repos, such as bufbuild/buf. This applies the same recipe as in that repo so that the Buf actions are only run when the protos actually change and so that the new "push" task is only run for commits on `main`.