### PR TITLE
Fix some error-handling issues in the reference client's server stream impl

### DIFF
--- a/internal/app/connectconformance/server_runner.go
+++ b/internal/app/connectconformance/server_runner.go
@@ -175,8 +175,8 @@ func runTestCasesForServer(
 			default:
 				results.assert(name, expectations[resp.TestName], resp.GetResponse())
 			}
-			if isReferenceClient {
-				for _, msg := range resp.GetFeedback() {
+			if isReferenceClient && resp != nil {
+				for _, msg := range resp.Feedback {
 					results.recordSideband(resp.TestName, msg)
 				}
 			}

--- a/internal/app/referenceclient/impl.go
+++ b/internal/app/referenceclient/impl.go
@@ -153,7 +153,16 @@ func (i *invoker) serverStream(
 
 	stream, err := i.client.ServerStream(ctx, request)
 	if err != nil {
-		return nil, err
+		// If an error was returned, first convert it to a Connect error
+		// so that we can get the headers from the Meta property. Then,
+		// convert _that_ to a proto Error so we can set it in the response.
+		connectErr := internal.ConvertErrorToConnectError(err)
+		headers := internal.ConvertToProtoHeader(connectErr.Meta())
+		protoErr := internal.ConvertConnectToProtoError(connectErr)
+		return &v1.ClientResponseResult{
+			ResponseHeaders: headers,
+			Error:           protoErr,
+		}, nil
 	}
 	var protoErr *v1.Error
 	var headers []*v1.Header
@@ -179,7 +188,9 @@ func (i *invoker) serverStream(
 
 	err = stream.Close()
 	if err != nil {
-		return nil, err
+		if protoErr == nil {
+			protoErr = internal.ConvertErrorToProtoError(err)
+		}
 	}
 	return &v1.ClientResponseResult{
 		ResponseHeaders:  headers,
@@ -246,7 +257,7 @@ func (i *invoker) clientStream(
 func (i *invoker) bidiStream(
 	ctx context.Context,
 	req *v1.ClientCompatRequest,
-) (result *v1.ClientResponseResult, retErr error) {
+) (result *v1.ClientResponseResult, _ error) {
 	result = &v1.ClientResponseResult{
 		ConnectErrorRaw: nil, // TODO
 	}
@@ -267,11 +278,6 @@ func (i *invoker) bidiStream(
 
 	var protoErr *v1.Error
 	for _, msg := range req.RequestMessages {
-		if err := ctx.Err(); err != nil {
-			// If an error was returned, convert it to a proto Error
-			protoErr = internal.ConvertErrorToProtoError(err)
-			break
-		}
 		bsr := &v1.BidiStreamRequest{}
 		if err := msg.UnmarshalTo(bsr); err != nil {
 			// Return the error and nil result because this is an


### PR DESCRIPTION
There were two cases where the `serverStream` method was just doing `return nil, err`, when it really should have been converting the error to a `*conformancev1.Error` and storing it in a non-nil response. That was causing server-stream timeout error to frequently be interpreted as a test case failure, even though the error was a "deadline exceeded" error, and that's also what the test case was expecting.