### PR TITLE
Speed up conformance runs with parallelism

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/net v0.19.0
+	golang.org/x/sync v0.3.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230920204549-e6e6cdab5c13
 	google.golang.org/grpc v1.59.0
 	google.golang.org/protobuf v1.31.0

--- a/go.sum
+++ b/go.sum
@@ -439,6 +439,8 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
+golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/internal/app/connectconformance/client_runner_test.go
+++ b/internal/app/connectconformance/client_runner_test.go
@@ -101,7 +101,7 @@ func TestRunClient(t *testing.T) {
 		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
-			start := runInProcess("testclient", testCase.clientFunc)
+			start := runInProcess([]string{"testclient"}, testCase.clientFunc)
 			runner, err := runClient(context.Background(), start)
 			require.NoError(t, err)
 

--- a/internal/app/connectconformance/connectconformance.go
+++ b/internal/app/connectconformance/connectconformance.go
@@ -46,6 +46,7 @@ type Flags struct {
 	ClientCommand    []string
 	ServerCommand    []string
 	TestFile         string
+	MaxServers       uint
 	Parallelism      uint
 }
 
@@ -232,7 +233,7 @@ func Run(flags *Flags, logOut io.Writer) (bool, error) { //nolint:gocyclo
 		err = func() error {
 			var wg sync.WaitGroup
 			defer wg.Wait()
-			sema := semaphore.NewWeighted(int64(flags.Parallelism))
+			sema := semaphore.NewWeighted(int64(flags.MaxServers))
 
 			for _, serverInfo := range servers {
 				for _, svrInstance := range svrInstances {

--- a/internal/app/connectconformance/connectconformance.go
+++ b/internal/app/connectconformance/connectconformance.go
@@ -22,7 +22,9 @@ import (
 	"os"
 	"path"
 	"sort"
+	"strconv"
 	"strings"
+	"sync"
 
 	"connectrpc.com/conformance/internal"
 	"connectrpc.com/conformance/internal/app/connectconformance/testsuites"
@@ -31,6 +33,7 @@ import (
 	"connectrpc.com/conformance/internal/app/referenceclient"
 	"connectrpc.com/conformance/internal/app/referenceserver"
 	conformancev1 "connectrpc.com/conformance/internal/gen/proto/go/connectrpc/conformance/v1"
+	"golang.org/x/sync/semaphore"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -43,6 +46,7 @@ type Flags struct {
 	ClientCommand    []string
 	ServerCommand    []string
 	TestFile         string
+	Parallelism      uint
 }
 
 func Run(flags *Flags, logOut io.Writer) (bool, error) { //nolint:gocyclo
@@ -177,12 +181,12 @@ func Run(flags *Flags, logOut io.Writer) (bool, error) { //nolint:gocyclo
 		clients = []processInfo{
 			{
 				name:            "reference client",
-				start:           runInProcess("reference-client", referenceclient.Run),
+				start:           runInProcess([]string{"reference-client", "-p", strconv.Itoa(int(flags.Parallelism))}, referenceclient.Run),
 				isReferenceImpl: true,
 			},
 			{
 				name:       "reference client (grpc)",
-				start:      runInProcess("grpc-reference-client", grpcclient.Run),
+				start:      runInProcess([]string{"grpc-reference-client", "-p", strconv.Itoa(int(flags.Parallelism))}, grpcclient.Run),
 				isGrpcImpl: true,
 			},
 		}
@@ -208,12 +212,12 @@ func Run(flags *Flags, logOut io.Writer) (bool, error) { //nolint:gocyclo
 			servers = []processInfo{
 				{
 					name:            "reference server",
-					start:           runInProcess("reference-server", referenceserver.RunInReferenceMode),
+					start:           runInProcess([]string{"reference-server"}, referenceserver.RunInReferenceMode),
 					isReferenceImpl: true,
 				},
 				{
 					name:       "reference server (grpc)",
-					start:      runInProcess("grpc-reference-server", grpcserver.Run),
+					start:      runInProcess([]string{"grpc-reference-server"}, grpcserver.Run),
 					isGrpcImpl: true,
 				},
 			}
@@ -225,34 +229,57 @@ func Run(flags *Flags, logOut io.Writer) (bool, error) { //nolint:gocyclo
 			}
 		}
 
-		// TODO: start servers in parallel (up to a limit) to allow parallelism and faster test execution
-		for _, serverInfo := range servers {
-			for _, svrInstance := range svrInstances {
-				testCases := testCaseLib.casesByServer[svrInstance]
-				if clientInfo.isGrpcImpl || serverInfo.isGrpcImpl {
-					testCases = filterGRPCImplTestCases(testCases, clientInfo.isGrpcImpl)
-					if len(testCases) == 0 {
-						continue
+		err = func() error {
+			var wg sync.WaitGroup
+			defer wg.Wait()
+			sema := semaphore.NewWeighted(int64(flags.Parallelism))
+
+			for _, serverInfo := range servers {
+				for _, svrInstance := range svrInstances {
+					testCases := testCaseLib.casesByServer[svrInstance]
+					if clientInfo.isGrpcImpl || serverInfo.isGrpcImpl {
+						testCases = filterGRPCImplTestCases(testCases, clientInfo.isGrpcImpl)
+						if len(testCases) == 0 {
+							continue
+						}
 					}
-				}
-				if flags.Verbose {
-					with := serverInfo.name
-					if with == "" {
-						with = clientInfo.name
+
+					if err := sema.Acquire(ctx, 1); err != nil {
+						return err
 					}
-					logTestCaseInfo(with, svrInstance, len(testCases), logOut)
-				}
-				runTestCasesForServer(ctx, clientInfo.isReferenceImpl, serverInfo.isReferenceImpl, svrInstance, testCases, clientCreds, serverInfo.start, results, clientProcess)
-				if !clientProcess.isRunning() {
-					err := clientProcess.waitForResponses()
-					if err == nil {
-						err = errors.New("client process unexpectedly stopped")
-					} else {
-						err = fmt.Errorf("client process unexpectedly stopped: %w", err)
+
+					if flags.Verbose {
+						with := serverInfo.name
+						if with == "" {
+							with = clientInfo.name
+						}
+						logTestCaseInfo(with, svrInstance, len(testCases), logOut)
 					}
-					return false, err
+
+					// Double-check that client is still running before spawning a server process.
+					if !clientProcess.isRunning() {
+						err := clientProcess.waitForResponses()
+						if err == nil {
+							err = errors.New("client process unexpectedly stopped")
+						} else {
+							err = fmt.Errorf("client process unexpectedly stopped: %w", err)
+						}
+						return err
+					}
+
+					wg.Add(1)
+					go func(ctx context.Context, clientInfo processInfo, serverInfo processInfo, svrInstance serverInstance) {
+						defer wg.Done()
+						defer sema.Release(1)
+						runTestCasesForServer(ctx, clientInfo.isReferenceImpl, serverInfo.isReferenceImpl, svrInstance, testCases, clientCreds, serverInfo.start, results, clientProcess)
+					}(ctx, clientInfo, serverInfo, svrInstance)
 				}
 			}
+			return nil
+		}()
+
+		if err != nil {
+			return false, err
 		}
 
 		clientProcess.closeSend()

--- a/internal/app/connectconformance/process.go
+++ b/internal/app/connectconformance/process.go
@@ -99,7 +99,7 @@ func runCommand(command []string) processStarter {
 
 // runInProcess returns a process starter that invokes the given function
 // in another goroutine.
-func runInProcess(name string, impl func(ctx context.Context, args []string, in io.ReadCloser, out, err io.WriteCloser) error) processStarter {
+func runInProcess(args []string, impl func(ctx context.Context, args []string, in io.ReadCloser, out, err io.WriteCloser) error) processStarter {
 	return makeProcess(func(ctx context.Context, stdin io.ReadCloser, stdout, stderr io.WriteCloser) (processController, error) {
 		ctx, cancel := context.WithCancel(ctx)
 		proc := &localProcess{
@@ -128,7 +128,7 @@ func runInProcess(name string, impl func(ctx context.Context, args []string, in 
 					_ = stderr.Close()
 				}
 			}()
-			proc.err = impl(ctx, []string{name}, stdin, stdout, stderr)
+			proc.err = impl(ctx, args, stdin, stdout, stderr)
 		}()
 		return proc, nil
 	})

--- a/internal/app/grpcclient/client.go
+++ b/internal/app/grpcclient/client.go
@@ -43,7 +43,7 @@ import (
 func Run(ctx context.Context, args []string, inReader io.ReadCloser, outWriter, _ io.WriteCloser) (retErr error) {
 	flags := flag.NewFlagSet(args[0], flag.ExitOnError)
 	json := flags.Bool("json", false, "whether to use the JSON format for marshaling / unmarshaling messages")
-	parallel := flags.Uint("p", uint(runtime.GOMAXPROCS(0)), "the number of parallel RPCs to issue")
+	parallel := flags.Uint("p", uint(runtime.GOMAXPROCS(0))*4, "the number of parallel RPCs to issue")
 	showVersion := flags.Bool("version", false, "show version and exit")
 
 	_ = flags.Parse(args[1:])

--- a/internal/app/referenceclient/client.go
+++ b/internal/app/referenceclient/client.go
@@ -47,7 +47,7 @@ import (
 func Run(ctx context.Context, args []string, inReader io.ReadCloser, outWriter, _ io.WriteCloser) (retErr error) {
 	flags := flag.NewFlagSet(args[0], flag.ExitOnError)
 	json := flags.Bool("json", false, "whether to use the JSON format for marshaling / unmarshaling messages")
-	parallel := flags.Uint("p", uint(runtime.GOMAXPROCS(0)), "the number of parallel RPCs to issue")
+	parallel := flags.Uint("p", uint(runtime.GOMAXPROCS(0))*4, "the number of parallel RPCs to issue")
 	showVersion := flags.Bool("version", false, "show version and exit")
 
 	_ = flags.Parse(args[1:])

--- a/internal/app/referenceclient/client.go
+++ b/internal/app/referenceclient/client.go
@@ -25,7 +25,10 @@ import (
 	"net/http"
 	"net/url"
 	"path/filepath"
+	"runtime"
 	"strconv"
+	"sync"
+	"sync/atomic"
 
 	"connectrpc.com/conformance/internal"
 	"connectrpc.com/conformance/internal/compression"
@@ -34,15 +37,17 @@ import (
 	"connectrpc.com/connect"
 	"github.com/quic-go/quic-go/http3"
 	"golang.org/x/net/http2"
+	"golang.org/x/sync/semaphore"
 )
 
 // Run runs the client according to a client config read from the 'in' reader. The result of the run
 // is written to the 'out' writer, including any errors encountered during the actual run. Any error
 // returned from this function is indicative of an issue with the reader or writer and should not be related
 // to the actual run.
-func Run(ctx context.Context, args []string, inReader io.ReadCloser, outWriter, _ io.WriteCloser) error {
+func Run(ctx context.Context, args []string, inReader io.ReadCloser, outWriter, _ io.WriteCloser) (retErr error) {
 	flags := flag.NewFlagSet(args[0], flag.ExitOnError)
 	json := flags.Bool("json", false, "whether to use the JSON format for marshaling / unmarshaling messages")
+	parallel := flags.Uint("p", uint(runtime.GOMAXPROCS(0)), "the number of parallel RPCs to issue")
 	showVersion := flags.Bool("version", false, "show version and exit")
 
 	_ = flags.Parse(args[1:])
@@ -53,10 +58,27 @@ func Run(ctx context.Context, args []string, inReader io.ReadCloser, outWriter, 
 	if flags.NArg() != 0 {
 		return errors.New("this command does not accept any positional arguments")
 	}
+	if *parallel == 0 {
+		return errors.New("invalid parallelism; must be greater than zero")
+	}
 
 	codec := internal.NewCodec(*json)
 	decoder := codec.NewDecoder(inReader)
 	encoder := codec.NewEncoder(outWriter)
+	var encoderMu sync.Mutex
+
+	var failure atomic.Pointer[error]
+	defer func() {
+		// if we're about to return nil error, but a goroutine reported
+		// a failure, return that failure as the error
+		if errPtr := failure.Load(); errPtr != nil && retErr == nil {
+			retErr = *errPtr
+		}
+	}()
+
+	var wg sync.WaitGroup
+	defer wg.Wait()
+	sema := semaphore.NewWeighted(int64(*parallel))
 
 	for {
 		var req v1.ClientCompatRequest
@@ -67,31 +89,51 @@ func Run(ctx context.Context, args []string, inReader io.ReadCloser, outWriter, 
 			}
 			return err
 		}
-		result, err := invoke(ctx, &req)
 
-		// Build the result for the out writer.
-		resp := &v1.ClientCompatResponse{
-			TestName: req.TestName,
-		}
-		// If an error was returned, it was a runtime / unexpected internal error so
-		// the written response should contain an error result, not a response with
-		// any RPC information
-		if err != nil {
-			resp.Result = &v1.ClientCompatResponse_Error{
-				Error: &v1.ClientErrorResult{
-					Message: err.Error(),
-				},
-			}
-		} else {
-			resp.Result = &v1.ClientCompatResponse_Response{
-				Response: result,
-			}
-		}
-
-		// Marshal the response and write the output
-		if err := encoder.Encode(resp); err != nil {
+		if err := sema.Acquire(ctx, 1); err != nil {
 			return err
 		}
+		if errPtr := failure.Load(); errPtr != nil {
+			// If there's already been a terminal failure, don't spawn
+			// anymore goroutines.
+			return *errPtr
+		}
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer sema.Release(1)
+
+			result, err := invoke(ctx, &req)
+
+			// Build the result for the out writer.
+			resp := &v1.ClientCompatResponse{
+				TestName: req.TestName,
+			}
+			// If an error was returned, it was a runtime / unexpected internal error so
+			// the written response should contain an error result, not a response with
+			// any RPC information
+			if err != nil {
+				resp.Result = &v1.ClientCompatResponse_Error{
+					Error: &v1.ClientErrorResult{
+						Message: err.Error(),
+					},
+				}
+			} else {
+				resp.Result = &v1.ClientCompatResponse_Response{
+					Response: result,
+				}
+			}
+
+			// Marshal the response and write the output
+			func() {
+				encoderMu.Lock()
+				defer encoderMu.Unlock()
+				if err := encoder.Encode(resp); err != nil {
+					failure.CompareAndSwap(nil, &err)
+				}
+			}()
+		}()
 	}
 }
 


### PR DESCRIPTION
This introduces two new flags to the `connectconformance` runner:
1. `max-servers`: the number of concurrent server processes to start. Test cases for all of them will be written to the client's stdin in parallel (thread-safe, but interleaving test cases for various servers). Defaults to 4.
2. `parallel`: the number of RPCs to issue in parallel when `--mode` is `server` (so this only controls the reference client). In `--mode` of `client`, it's up to the client-under-test to implement parallelism. Defaults to 4 * GOMAXPROC (and GOMAXPROC defaults to the number of CPU cores detected).

This speeds up conformance runs on my MBP from about 3 minutes down to less than 15 seconds,.

