### PR TITLE
Add test case for runner and remove races in I/O

### DIFF
--- a/cmd/connectconformance/main.go
+++ b/cmd/connectconformance/main.go
@@ -186,7 +186,7 @@ func run(flags *flags, command []string) {
 			MaxServers:       flags.maxServers,
 			Parallelism:      flags.parallel,
 		},
-		os.Stdout,
+		internal.NewPrinter(os.Stdout),
 	)
 	if err != nil {
 		fatal("%s", err)

--- a/internal/app/connectconformance/connectconformance_test.go
+++ b/internal/app/connectconformance/connectconformance_test.go
@@ -1,0 +1,85 @@
+// Copyright 2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connectconformance
+
+import (
+	"fmt"
+	"testing"
+
+	"connectrpc.com/conformance/internal/app/connectconformance/testsuites"
+	conformancev1 "connectrpc.com/conformance/internal/gen/proto/go/connectrpc/conformance/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRun(t *testing.T) {
+	t.Parallel()
+
+	// Simple sanity check that the basics of run work.
+	testSuiteData, err := testsuites.LoadTestSuites()
+	require.NoError(t, err)
+	allSuites, err := parseTestSuites(testSuiteData)
+	require.NoError(t, err)
+
+	logger := &testPrinter{t}
+	results, err := run(
+		[]configCase{
+			{
+				Version:                conformancev1.HTTPVersion_HTTP_VERSION_1,
+				Protocol:               conformancev1.Protocol_PROTOCOL_CONNECT,
+				Codec:                  conformancev1.Codec_CODEC_JSON,
+				Compression:            conformancev1.Compression_COMPRESSION_IDENTITY,
+				StreamType:             conformancev1.StreamType_STREAM_TYPE_UNARY,
+				UseTLS:                 false,
+				UseTLSClientCerts:      false,
+				UseConnectGET:          false,
+				UseMessageReceiveLimit: false,
+				ConnectVersionMode:     conformancev1.TestSuite_CONNECT_VERSION_MODE_UNSPECIFIED,
+			},
+			{
+				Version:                conformancev1.HTTPVersion_HTTP_VERSION_2,
+				Protocol:               conformancev1.Protocol_PROTOCOL_GRPC,
+				Codec:                  conformancev1.Codec_CODEC_PROTO,
+				Compression:            conformancev1.Compression_COMPRESSION_IDENTITY,
+				StreamType:             conformancev1.StreamType_STREAM_TYPE_FULL_DUPLEX_BIDI_STREAM,
+				UseTLS:                 false,
+				UseTLSClientCerts:      false,
+				UseConnectGET:          false,
+				UseMessageReceiveLimit: false,
+				ConnectVersionMode:     conformancev1.TestSuite_CONNECT_VERSION_MODE_UNSPECIFIED,
+			},
+		},
+		&knownFailingTrie{},
+		allSuites,
+		logger,
+		&Flags{Verbose: true, MaxServers: 2, Parallelism: 4},
+	)
+	require.NoError(t, err)
+	require.True(t, results.report(logger))
+	// 19 test cases as of this writing, but we will likely add more
+	require.GreaterOrEqual(t, len(results.outcomes), 19)
+}
+
+type testPrinter struct {
+	t *testing.T
+}
+
+func (t testPrinter) Printf(msg string, args ...any) {
+	t.t.Logf(msg, args...)
+}
+
+func (t testPrinter) PrefixPrintf(prefix, msg string, args ...any) {
+	msg = fmt.Sprintf(msg, args...)
+	t.t.Logf("%s: %s", prefix, msg)
+}

--- a/internal/app/referenceserver/checks.go
+++ b/internal/app/referenceserver/checks.go
@@ -15,13 +15,12 @@
 package referenceserver
 
 import (
-	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
 
+	"connectrpc.com/conformance/internal"
 	"connectrpc.com/conformance/internal/compression"
 	v1 "connectrpc.com/conformance/internal/gen/proto/go/connectrpc/conformance/v1"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -41,7 +40,7 @@ const (
 	codecText  = "text"
 )
 
-func referenceServerChecks(handler http.Handler, errWriter io.Writer) http.HandlerFunc {
+func referenceServerChecks(handler http.Handler, errPrinter internal.Printer) http.HandlerFunc {
 	return func(respWriter http.ResponseWriter, req *http.Request) {
 		testCaseName := req.Header.Get("x-test-case-name")
 		if testCaseName == "" {
@@ -51,7 +50,7 @@ func referenceServerChecks(handler http.Handler, errWriter io.Writer) http.Handl
 			return
 		}
 
-		feedback := &feedbackWriter{w: errWriter, testCaseName: testCaseName}
+		feedback := &feedbackPrinter{p: errPrinter, testCaseName: testCaseName}
 
 		if httpVersion, ok := enumValue("x-expect-http-version", req.Header, v1.HTTPVersion(0), feedback); ok {
 			checkHTTPVersion(httpVersion, req, feedback)
@@ -81,7 +80,7 @@ type int32Enum interface {
 	protoreflect.Enum
 }
 
-func enumValue[E int32Enum](headerName string, headers http.Header, zero E, feedback *feedbackWriter) (E, bool) {
+func enumValue[E int32Enum](headerName string, headers http.Header, zero E, feedback *feedbackPrinter) (E, bool) {
 	val, _ := getHeader(headers, headerName, feedback)
 	intVal, err := strconv.ParseInt(val, 10, 32)
 	if err != nil {
@@ -95,7 +94,7 @@ func enumValue[E int32Enum](headerName string, headers http.Header, zero E, feed
 	return E(int32(intVal)), true
 }
 
-func checkHTTPVersion(expected v1.HTTPVersion, req *http.Request, feedback *feedbackWriter) {
+func checkHTTPVersion(expected v1.HTTPVersion, req *http.Request, feedback *feedbackPrinter) {
 	var expectVersion int
 	switch expected {
 	case v1.HTTPVersion_HTTP_VERSION_1:
@@ -113,7 +112,7 @@ func checkHTTPVersion(expected v1.HTTPVersion, req *http.Request, feedback *feed
 	}
 }
 
-func checkProtocol(expected v1.Protocol, req *http.Request, feedback *feedbackWriter) {
+func checkProtocol(expected v1.Protocol, req *http.Request, feedback *feedbackPrinter) {
 	var actual v1.Protocol
 	contentType := req.Header.Get("content-type")
 	switch {
@@ -132,7 +131,7 @@ func checkProtocol(expected v1.Protocol, req *http.Request, feedback *feedbackWr
 	}
 }
 
-func checkCodec(expected v1.Codec, req *http.Request, feedback *feedbackWriter) {
+func checkCodec(expected v1.Codec, req *http.Request, feedback *feedbackPrinter) {
 	var expect string
 	switch expected {
 	case v1.Codec_CODEC_PROTO:
@@ -177,7 +176,7 @@ func checkCodec(expected v1.Codec, req *http.Request, feedback *feedbackWriter) 
 	}
 }
 
-func checkCompression(expected v1.Compression, req *http.Request, feedback *feedbackWriter) {
+func checkCompression(expected v1.Compression, req *http.Request, feedback *feedbackPrinter) {
 	var expect string
 	switch expected {
 	case v1.Compression_COMPRESSION_IDENTITY:
@@ -228,7 +227,7 @@ func checkCompression(expected v1.Compression, req *http.Request, feedback *feed
 	}
 }
 
-func checkTLS(req *http.Request, feedback *feedbackWriter) {
+func checkTLS(req *http.Request, feedback *feedbackPrinter) {
 	tlsHeaderVal, _ := getHeader(req.Header, "x-expect-tls", feedback)
 	expectTLS, err := strconv.ParseBool(tlsHeaderVal)
 	if err != nil {
@@ -255,7 +254,7 @@ func checkTLS(req *http.Request, feedback *feedbackWriter) {
 	}
 }
 
-func getHeader(headers http.Header, headerName string, feedback *feedbackWriter) (string, bool) {
+func getHeader(headers http.Header, headerName string, feedback *feedbackPrinter) (string, bool) {
 	headerVals := headers.Values(headerName)
 	if len(headerVals) > 1 {
 		feedback.Printf("%s header appears %d times; should appear just once", headerName, len(headerVals))
@@ -263,7 +262,7 @@ func getHeader(headers http.Header, headerName string, feedback *feedbackWriter)
 	return headers.Get(headerName), len(headerVals) > 0
 }
 
-func getQueryParam(values url.Values, paramName string, feedback *feedbackWriter) (string, bool) {
+func getQueryParam(values url.Values, paramName string, feedback *feedbackPrinter) (string, bool) {
 	paramVals := values[paramName]
 	if len(paramVals) > 1 {
 		feedback.Printf("%s query string param appears %d times; should appear just once", paramName, len(paramVals))
@@ -271,15 +270,11 @@ func getQueryParam(values url.Values, paramName string, feedback *feedbackWriter
 	return values.Get(paramName), len(paramVals) > 0
 }
 
-type feedbackWriter struct {
-	w            io.Writer
+type feedbackPrinter struct {
+	p            internal.Printer
 	testCaseName string
 }
 
-func (w *feedbackWriter) Printf(format string, args ...any) {
-	msg := fmt.Sprintf(format, args...)
-	if !strings.HasSuffix(msg, "\n") {
-		msg += "\n"
-	}
-	_, _ = fmt.Fprintf(w.w, "%s: %s", w.testCaseName, msg)
+func (p *feedbackPrinter) Printf(format string, args ...any) {
+	p.p.PrefixPrintf(p.testCaseName, format, args...)
 }

--- a/internal/printer.go
+++ b/internal/printer.go
@@ -1,0 +1,80 @@
+// Copyright 2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"fmt"
+	"io"
+	"sync"
+)
+
+// Printer is a simple interface for formatting human-readable messages.
+type Printer interface {
+	// Printf formats the given message and arguments. A newline
+	// is automatically added, so it is not necessary to include
+	// an explicit "\n" at the end.
+	Printf(msg string, args ...any)
+	// PrefixPrintf is just like Printf except it will print
+	// the given prefix followed by ": " before printing the
+	// messages and arguments.
+	PrefixPrintf(prefix, msg string, args ...any)
+}
+
+// NewPrinter returns a thread-safe printer that prints messages
+// to the given writer. The returned printer may safely be used
+// from concurrent goroutines, even if the given writer is not
+// safe for concurrent use.
+func NewPrinter(w io.Writer) Printer {
+	return &safePrinter{w: &peekWriter{w: w}}
+}
+
+// safePrinter is a thread-safe printer.
+type safePrinter struct {
+	mu sync.Mutex
+	w  *peekWriter
+}
+
+func (p *safePrinter) Printf(msg string, args ...any) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	_, _ = fmt.Fprintf(p.w, msg, args...)
+	if p.w.last != '\n' {
+		_, _ = p.w.Write([]byte{'\n'})
+	}
+}
+
+func (p *safePrinter) PrefixPrintf(prefix, msg string, args ...any) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	_, _ = fmt.Fprintf(p.w, "%s: ", prefix)
+	_, _ = fmt.Fprintf(p.w, msg, args...)
+	if p.w.last != '\n' {
+		_, _ = p.w.Write([]byte{'\n'})
+	}
+}
+
+// peekWriter is a writer that can peek at the last byte written.
+type peekWriter struct {
+	w    io.Writer
+	last byte
+}
+
+func (p *peekWriter) Write(data []byte) (int, error) {
+	n, err := p.w.Write(data)
+	if n > 0 {
+		p.last = data[n-1]
+	}
+	return n, err
+}


### PR DESCRIPTION
This is a follow-up to #720.

Since that PR is merged, accessing the `outWriter` and `errWriter` from multiple goroutines is racy. Even if the underlying writer were thread-safe, this means that writing a message or line could end up being "interrupted" by a concurrent write, interleaving lines and leaving the output unreadable, since writing a single formatted message could involve multiple calls to the `Write` method. This PR fixes that by introducing a `Printer` interface with a thread-safe implementation to do logging.

To make sure there aren't any actual data races in this code (if there were, they should be fixed by the new thread-safe printer), this also adds a new test that exercises a more significant portion of the conformance test runner.