### PR TITLE
Pin to v1.12 temporarily

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -7,7 +7,7 @@ plugins:
   - plugin: buf.build/protocolbuffers/go:v1.31.0
     out: internal/gen/proto/go
     opt: paths=source_relative
-  - plugin: buf.build/connectrpc/go
+  - plugin: buf.build/connectrpc/go:v1.12.0
     out: internal/gen/proto/go
     opt: paths=source_relative
   - plugin: buf.build/grpc/go:v1.3.0


### PR DESCRIPTION
This pins to Connect-Go v1.12.0 temporarily until we can update to v1.13.0 officially. Using the v1.13.0 plugin while still using 1.12.0 in our go.mod causes compilation failures on the generated code.