### PR TITLE
Add error tests

### DIFF
--- a/internal/app/connectconformance/testsuites/basic.yaml
+++ b/internal/app/connectconformance/testsuites/basic.yaml
@@ -34,46 +34,6 @@ testCases:
     streamType: STREAM_TYPE_UNARY
     requestMessages:
     - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
-- request:
-    testName: unary error
-    service: connectrpc.conformance.v1.ConformanceService
-    method: Unary
-    streamType: STREAM_TYPE_UNARY
-    requestHeaders:
-    - name: X-Conformance-Test
-      value: ["Value1","Value2"]
-    requestMessages:
-    - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
-      responseDefinition:
-        responseHeaders:
-        - name: x-custom-header
-          value: ["foo","bar","baz"]
-        error:
-          code: 13
-          message: "unary failed"
-        responseTrailers:
-        - name: x-custom-trailer
-          value: ["bing","quux"]
-- request:
-    testName: unary error unicode
-    service: connectrpc.conformance.v1.ConformanceService
-    method: Unary
-    streamType: STREAM_TYPE_UNARY
-    requestHeaders:
-    - name: X-Conformance-Test
-      value: ["Value1","Value2"]
-    requestMessages:
-    - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
-      responseDefinition:
-        responseHeaders:
-        - name: x-custom-header
-          value: ["foo","bar","baz"]
-        error:
-          code: 13
-          message: "\ntest with whitespace\r\nand Unicode BMP ☺ and non-BMP 😈\n"
-        responseTrailers:
-        - name: x-custom-trailer
-          value: ["bing","quux"]
 # Client Stream Tests ---------------------------------------------------------
 - request:
     testName: client stream success
@@ -90,28 +50,6 @@ testCases:
         - name: x-custom-header
           value: ["foo","bar","baz"]
         responseData: "dGVzdCByZXNwb25zZQ=="
-        responseTrailers:
-        - name: x-custom-trailer
-          value: ["bing","quux"]
-    - "@type": type.googleapis.com/connectrpc.conformance.v1.ClientStreamRequest
-      requestData: "dGVzdCByZXNwb25zZQ=="
-- request:
-    testName: client stream error
-    service: connectrpc.conformance.v1.ConformanceService
-    method: ClientStream
-    streamType: STREAM_TYPE_CLIENT_STREAM
-    requestHeaders:
-    - name: X-Conformance-Test
-      value: ["Value1","Value2"]
-    requestMessages:
-    - "@type": type.googleapis.com/connectrpc.conformance.v1.ClientStreamRequest
-      responseDefinition:
-        responseHeaders:
-        - name: x-custom-header
-          value: ["foo","bar","baz"]
-        error:
-          code: 13
-          message: "client stream failed"
         responseTrailers:
         - name: x-custom-trailer
           value: ["bing","quux"]
@@ -174,49 +112,6 @@ testCases:
     streamType: STREAM_TYPE_SERVER_STREAM
     requestMessages:
     - "@type": type.googleapis.com/connectrpc.conformance.v1.ServerStreamRequest
-- request:
-    testName: server stream error with responses
-    service: connectrpc.conformance.v1.ConformanceService
-    method: ServerStream
-    streamType: STREAM_TYPE_SERVER_STREAM
-    requestHeaders:
-    - name: X-Conformance-Test
-      value: ["Value1","Value2"]
-    requestMessages:
-    - "@type": type.googleapis.com/connectrpc.conformance.v1.ServerStreamRequest
-      responseDefinition:
-        responseHeaders:
-        - name: x-custom-header
-          value: ["foo","bar","baz"]
-        responseData:
-          - "dGVzdCByZXNwb25zZQ=="
-          - "dGVzdCByZXNwb25zZQ=="
-        error:
-          code: 13
-          message: "server stream failed"
-        responseTrailers:
-        - name: x-custom-trailer
-          value: ["bing","quux"]
-- request:
-    testName: server stream error with no responses
-    service: connectrpc.conformance.v1.ConformanceService
-    method: ServerStream
-    streamType: STREAM_TYPE_SERVER_STREAM
-    requestHeaders:
-    - name: X-Conformance-Test
-      value: ["Value1","Value2"]
-    requestMessages:
-    - "@type": type.googleapis.com/connectrpc.conformance.v1.ServerStreamRequest
-      responseDefinition:
-        responseHeaders:
-        - name: x-custom-header
-          value: ["foo","bar","baz"]
-        error:
-          code: 13
-          message: "server stream failed"
-        responseTrailers:
-        - name: x-custom-trailer
-          value: ["bing","quux"]
 # Bidi Stream Tests -----------------------------------------------------------
 - request:
     testName: bidi full duplex stream success
@@ -242,53 +137,6 @@ testCases:
     - "@type": type.googleapis.com/connectrpc.conformance.v1.BidiStreamRequest
       requestData: "dGVzdCByZXNwb25zZQ=="
 - request:
-    testName: bidi full duplex stream error with responses
-    service: connectrpc.conformance.v1.ConformanceService
-    method: BidiStream
-    streamType: STREAM_TYPE_FULL_DUPLEX_BIDI_STREAM
-    requestHeaders:
-      - name: X-Conformance-Test
-        value: ["Value1","Value2"]
-    requestMessages:
-    - "@type": type.googleapis.com/connectrpc.conformance.v1.BidiStreamRequest
-      responseDefinition:
-        responseHeaders:
-          - name: x-custom-header
-            value: ["foo","bar","baz"]
-        responseData:
-          - "dGVzdCByZXNwb25zZQ=="
-          - "dGVzdCByZXNwb25zZQ=="
-        error:
-          code: 13
-          message: "bidi full duplex stream failed"
-        responseTrailers:
-        - name: x-custom-trailer
-          value: ["bing","quux"]
-      fullDuplex: true
-    - "@type": type.googleapis.com/connectrpc.conformance.v1.BidiStreamRequest
-      requestData: "dGVzdCByZXNwb25zZQ=="
-- request:
-    testName: bidi full duplex stream error no responses
-    service: connectrpc.conformance.v1.ConformanceService
-    method: BidiStream
-    streamType: STREAM_TYPE_FULL_DUPLEX_BIDI_STREAM
-    requestHeaders:
-      - name: X-Conformance-Test
-        value: ["Value1","Value2"]
-    requestMessages:
-    - "@type": type.googleapis.com/connectrpc.conformance.v1.BidiStreamRequest
-      responseDefinition:
-        responseHeaders:
-          - name: x-custom-header
-            value: ["foo","bar","baz"]
-        error:
-          code: 13
-          message: "bidi full duplex stream failed"
-        responseTrailers:
-        - name: x-custom-trailer
-          value: ["bing","quux"]
-      fullDuplex: true
-- request:
     testName: bidi half duplex stream success
     service: connectrpc.conformance.v1.ConformanceService
     method: BidiStream
@@ -305,53 +153,6 @@ testCases:
         responseData:
           - "dGVzdCByZXNwb25zZQ=="
           - "dGVzdCByZXNwb25zZQ=="
-        responseTrailers:
-        - name: x-custom-trailer
-          value: ["bing","quux"]
-    - "@type": type.googleapis.com/connectrpc.conformance.v1.BidiStreamRequest
-      requestData: "dGVzdCByZXNwb25zZQ=="
-- request:
-    testName: bidi half duplex stream error with responses
-    service: connectrpc.conformance.v1.ConformanceService
-    method: BidiStream
-    streamType: STREAM_TYPE_HALF_DUPLEX_BIDI_STREAM
-    requestHeaders:
-      - name: X-Conformance-Test
-        value: ["Value1","Value2"]
-    requestMessages:
-    - "@type": type.googleapis.com/connectrpc.conformance.v1.BidiStreamRequest
-      responseDefinition:
-        responseHeaders:
-          - name: x-custom-header
-            value: ["foo","bar","baz"]
-        responseData:
-          - "dGVzdCByZXNwb25zZQ=="
-          - "dGVzdCByZXNwb25zZQ=="
-        error:
-          code: 13
-          message: "bidi half duplex stream failed"
-        responseTrailers:
-        - name: x-custom-trailer
-          value: ["bing","quux"]
-    - "@type": type.googleapis.com/connectrpc.conformance.v1.BidiStreamRequest
-      requestData: "dGVzdCByZXNwb25zZQ=="
-- request:
-    testName: bidi half duplex stream error with no responses
-    service: connectrpc.conformance.v1.ConformanceService
-    method: BidiStream
-    streamType: STREAM_TYPE_HALF_DUPLEX_BIDI_STREAM
-    requestHeaders:
-      - name: X-Conformance-Test
-        value: ["Value1","Value2"]
-    requestMessages:
-    - "@type": type.googleapis.com/connectrpc.conformance.v1.BidiStreamRequest
-      responseDefinition:
-        responseHeaders:
-          - name: x-custom-header
-            value: ["foo","bar","baz"]
-        error:
-          code: 13
-          message: "bidi half duplex stream failed"
         responseTrailers:
         - name: x-custom-trailer
           value: ["bing","quux"]

--- a/internal/app/connectconformance/testsuites/errors.yaml
+++ b/internal/app/connectconformance/testsuites/errors.yaml
@@ -1,0 +1,552 @@
+name: Errors
+# This suite contains various tests for error handling. In addition to testing
+# scenarios per RPC type, it tests that all Connect error codes are able to be
+# returned for both unary responses and streaming responses, since errors are
+# represented differently on the wire for each.
+testCases:
+# Unary Tests -----------------------------------------------------------------
+- request:
+    testName: unary canceled error
+    service: connectrpc.conformance.v1.ConformanceService
+    method: Unary
+    streamType: STREAM_TYPE_UNARY
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
+      responseDefinition:
+        error:
+          code: 1
+          message: "canceled"
+- request:
+    testName: unary unknown error
+    service: connectrpc.conformance.v1.ConformanceService
+    method: Unary
+    streamType: STREAM_TYPE_UNARY
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
+      responseDefinition:
+        error:
+          code: 2
+          message: "unknown"
+- request:
+    testName: unary invalid argument error
+    service: connectrpc.conformance.v1.ConformanceService
+    method: Unary
+    streamType: STREAM_TYPE_UNARY
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
+      responseDefinition:
+        error:
+          code: 3
+          message: "invalid argument"
+- request:
+    testName: unary deadline exceeded error
+    service: connectrpc.conformance.v1.ConformanceService
+    method: Unary
+    streamType: STREAM_TYPE_UNARY
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
+      responseDefinition:
+        error:
+          code: 4
+          message: "deadline exceeded"
+- request:
+    testName: unary not found error
+    service: connectrpc.conformance.v1.ConformanceService
+    method: Unary
+    streamType: STREAM_TYPE_UNARY
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
+      responseDefinition:
+        error:
+          code: 5
+          message: "not found"
+- request:
+    testName: unary already exists error
+    service: connectrpc.conformance.v1.ConformanceService
+    method: Unary
+    streamType: STREAM_TYPE_UNARY
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
+      responseDefinition:
+        error:
+          code: 6
+          message: "already exists"
+- request:
+    testName: unary permission denied error
+    service: connectrpc.conformance.v1.ConformanceService
+    method: Unary
+    streamType: STREAM_TYPE_UNARY
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
+      responseDefinition:
+        error:
+          code: 7
+          message: "permission denied"
+- request:
+    testName: unary resource exhausted error
+    service: connectrpc.conformance.v1.ConformanceService
+    method: Unary
+    streamType: STREAM_TYPE_UNARY
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
+      responseDefinition:
+        error:
+          code: 8
+          message: "resource exhausted"
+- request:
+    testName: unary failed precondition error
+    service: connectrpc.conformance.v1.ConformanceService
+    method: Unary
+    streamType: STREAM_TYPE_UNARY
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
+      responseDefinition:
+        error:
+          code: 9
+          message: "failed precondition"
+- request:
+    testName: unary aborted error
+    service: connectrpc.conformance.v1.ConformanceService
+    method: Unary
+    streamType: STREAM_TYPE_UNARY
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
+      responseDefinition:
+        error:
+          code: 10
+          message: "aborted"
+- request:
+    testName: unary out of range error
+    service: connectrpc.conformance.v1.ConformanceService
+    method: Unary
+    streamType: STREAM_TYPE_UNARY
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
+      responseDefinition:
+        error:
+          code: 11
+          message: "out of range"
+- request:
+    testName: unary unimplemented error
+    service: connectrpc.conformance.v1.ConformanceService
+    method: Unary
+    streamType: STREAM_TYPE_UNARY
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
+      responseDefinition:
+        error:
+          code: 12
+          message: "unimplemented"
+- request:
+    testName: unary internal error
+    service: connectrpc.conformance.v1.ConformanceService
+    method: Unary
+    streamType: STREAM_TYPE_UNARY
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
+      responseDefinition:
+        error:
+          code: 13
+          message: "internal"
+- request:
+    testName: unary unavailable error
+    service: connectrpc.conformance.v1.ConformanceService
+    method: Unary
+    streamType: STREAM_TYPE_UNARY
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
+      responseDefinition:
+        error:
+          code: 14
+          message: "unavailable"
+- request:
+    testName: unary data loss error
+    service: connectrpc.conformance.v1.ConformanceService
+    method: Unary
+    streamType: STREAM_TYPE_UNARY
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
+      responseDefinition:
+        error:
+          code: 15
+          message: "data loss"
+- request:
+    testName: unary unauthenticated error
+    service: connectrpc.conformance.v1.ConformanceService
+    method: Unary
+    streamType: STREAM_TYPE_UNARY
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
+      responseDefinition:
+        error:
+          code: 16
+          message: "unauthenticated"
+- request:
+    testName: unary error sends headers and trailers
+    service: connectrpc.conformance.v1.ConformanceService
+    method: Unary
+    streamType: STREAM_TYPE_UNARY
+    requestHeaders:
+    - name: X-Conformance-Test
+      value: ["Value1","Value2"]
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
+      responseDefinition:
+        responseHeaders:
+        - name: x-custom-header
+          value: ["foo","bar","baz"]
+        error:
+          code: 13
+          message: "unary failed"
+        responseTrailers:
+        - name: x-custom-trailer
+          value: ["bing","quux"]
+- request:
+    testName: unary error unicode
+    service: connectrpc.conformance.v1.ConformanceService
+    method: Unary
+    streamType: STREAM_TYPE_UNARY
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
+      responseDefinition:
+        error:
+          code: 13
+          message: "\ntest with whitespace\r\nand Unicode BMP ☺ and non-BMP 😈\n"
+# Client Stream Tests ---------------------------------------------------------
+- request:
+    testName: client stream error sends headers and trailers
+    service: connectrpc.conformance.v1.ConformanceService
+    method: ClientStream
+    streamType: STREAM_TYPE_CLIENT_STREAM
+    requestHeaders:
+    - name: X-Conformance-Test
+      value: ["Value1","Value2"]
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.ClientStreamRequest
+      responseDefinition:
+        responseHeaders:
+        - name: x-custom-header
+          value: ["foo","bar","baz"]
+        error:
+          code: 13
+          message: "client stream failed"
+        responseTrailers:
+        - name: x-custom-trailer
+          value: ["bing","quux"]
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.ClientStreamRequest
+      requestData: "dGVzdCByZXNwb25zZQ=="
+# Server Stream Tests ---------------------------------------------------------
+- request:
+    testName: stream canceled error
+    service: connectrpc.conformance.v1.ConformanceService
+    method: ServerStream
+    streamType: STREAM_TYPE_SERVER_STREAM
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.ServerStreamRequest
+      responseDefinition:
+        error:
+          code: 1
+          message: "canceled"
+- request:
+    testName: stream unknown error
+    service: connectrpc.conformance.v1.ConformanceService
+    method: ServerStream
+    streamType: STREAM_TYPE_SERVER_STREAM
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.ServerStreamRequest
+      responseDefinition:
+        error:
+          code: 2
+          message: "unknown"
+- request:
+    testName: stream invalid argument error
+    service: connectrpc.conformance.v1.ConformanceService
+    method: ServerStream
+    streamType: STREAM_TYPE_SERVER_STREAM
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.ServerStreamRequest
+      responseDefinition:
+        error:
+          code: 3
+          message: "invalid argument"
+- request:
+    testName: stream deadline exceeded error
+    service: connectrpc.conformance.v1.ConformanceService
+    method: ServerStream
+    streamType: STREAM_TYPE_SERVER_STREAM
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.ServerStreamRequest
+      responseDefinition:
+        error:
+          code: 4
+          message: "deadline exceeded"
+- request:
+    testName: stream not found error
+    service: connectrpc.conformance.v1.ConformanceService
+    method: ServerStream
+    streamType: STREAM_TYPE_SERVER_STREAM
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.ServerStreamRequest
+      responseDefinition:
+        error:
+          code: 5
+          message: "not found"
+- request:
+    testName: stream already exists error
+    service: connectrpc.conformance.v1.ConformanceService
+    method: ServerStream
+    streamType: STREAM_TYPE_SERVER_STREAM
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.ServerStreamRequest
+      responseDefinition:
+        error:
+          code: 6
+          message: "already exists"
+- request:
+    testName: stream permission denied error
+    service: connectrpc.conformance.v1.ConformanceService
+    method: ServerStream
+    streamType: STREAM_TYPE_SERVER_STREAM
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.ServerStreamRequest
+      responseDefinition:
+        error:
+          code: 7
+          message: "permission denied"
+- request:
+    testName: stream resource exhausted error
+    service: connectrpc.conformance.v1.ConformanceService
+    method: ServerStream
+    streamType: STREAM_TYPE_SERVER_STREAM
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.ServerStreamRequest
+      responseDefinition:
+        error:
+          code: 8
+          message: "resource exhausted"
+- request:
+    testName: stream failed precondition error
+    service: connectrpc.conformance.v1.ConformanceService
+    method: ServerStream
+    streamType: STREAM_TYPE_SERVER_STREAM
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.ServerStreamRequest
+      responseDefinition:
+        error:
+          code: 9
+          message: "failed precondition"
+- request:
+    testName: stream aborted error
+    service: connectrpc.conformance.v1.ConformanceService
+    method: ServerStream
+    streamType: STREAM_TYPE_SERVER_STREAM
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.ServerStreamRequest
+      responseDefinition:
+        error:
+          code: 10
+          message: "aborted"
+- request:
+    testName: stream out of range error
+    service: connectrpc.conformance.v1.ConformanceService
+    method: ServerStream
+    streamType: STREAM_TYPE_SERVER_STREAM
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.ServerStreamRequest
+      responseDefinition:
+        error:
+          code: 11
+          message: "out of range"
+- request:
+    testName: stream unimplemented error
+    service: connectrpc.conformance.v1.ConformanceService
+    method: ServerStream
+    streamType: STREAM_TYPE_SERVER_STREAM
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.ServerStreamRequest
+      responseDefinition:
+        error:
+          code: 12
+          message: "unimplemented"
+- request:
+    testName: stream internal error
+    service: connectrpc.conformance.v1.ConformanceService
+    method: ServerStream
+    streamType: STREAM_TYPE_SERVER_STREAM
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.ServerStreamRequest
+      responseDefinition:
+        error:
+          code: 13
+          message: "internal"
+- request:
+    testName: stream unavailable error
+    service: connectrpc.conformance.v1.ConformanceService
+    method: ServerStream
+    streamType: STREAM_TYPE_SERVER_STREAM
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.ServerStreamRequest
+      responseDefinition:
+        error:
+          code: 14
+          message: "unavailable"
+- request:
+    testName: stream data loss error
+    service: connectrpc.conformance.v1.ConformanceService
+    method: ServerStream
+    streamType: STREAM_TYPE_SERVER_STREAM
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.ServerStreamRequest
+      responseDefinition:
+        error:
+          code: 15
+          message: "data loss"
+- request:
+    testName: stream unauthenticated error
+    service: connectrpc.conformance.v1.ConformanceService
+    method: ServerStream
+    streamType: STREAM_TYPE_SERVER_STREAM
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.ServerStreamRequest
+      responseDefinition:
+        error:
+          code: 16
+          message: "unauthenticated"
+- request:
+    testName: server stream error with responses
+    service: connectrpc.conformance.v1.ConformanceService
+    method: ServerStream
+    streamType: STREAM_TYPE_SERVER_STREAM
+    requestHeaders:
+    - name: X-Conformance-Test
+      value: ["Value1","Value2"]
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.ServerStreamRequest
+      responseDefinition:
+        responseHeaders:
+        - name: x-custom-header
+          value: ["foo","bar","baz"]
+        responseData:
+          - "dGVzdCByZXNwb25zZQ=="
+          - "dGVzdCByZXNwb25zZQ=="
+        error:
+          code: 13
+          message: "server stream failed"
+        responseTrailers:
+        - name: x-custom-trailer
+          value: ["bing","quux"]
+- request:
+    testName: server stream error with no responses
+    service: connectrpc.conformance.v1.ConformanceService
+    method: ServerStream
+    streamType: STREAM_TYPE_SERVER_STREAM
+    requestHeaders:
+    - name: X-Conformance-Test
+      value: ["Value1","Value2"]
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.ServerStreamRequest
+      responseDefinition:
+        responseHeaders:
+        - name: x-custom-header
+          value: ["foo","bar","baz"]
+        error:
+          code: 13
+          message: "server stream failed"
+        responseTrailers:
+        - name: x-custom-trailer
+          value: ["bing","quux"]
+# Bidi Stream Tests -----------------------------------------------------------
+- request:
+    testName: bidi full duplex stream error with responses
+    service: connectrpc.conformance.v1.ConformanceService
+    method: BidiStream
+    streamType: STREAM_TYPE_FULL_DUPLEX_BIDI_STREAM
+    requestHeaders:
+      - name: X-Conformance-Test
+        value: ["Value1","Value2"]
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.BidiStreamRequest
+      responseDefinition:
+        responseHeaders:
+          - name: x-custom-header
+            value: ["foo","bar","baz"]
+        responseData:
+          - "dGVzdCByZXNwb25zZQ=="
+          - "dGVzdCByZXNwb25zZQ=="
+        error:
+          code: 13
+          message: "bidi full duplex stream failed"
+        responseTrailers:
+        - name: x-custom-trailer
+          value: ["bing","quux"]
+      fullDuplex: true
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.BidiStreamRequest
+      requestData: "dGVzdCByZXNwb25zZQ=="
+- request:
+    testName: bidi full duplex stream error no responses
+    service: connectrpc.conformance.v1.ConformanceService
+    method: BidiStream
+    streamType: STREAM_TYPE_FULL_DUPLEX_BIDI_STREAM
+    requestHeaders:
+      - name: X-Conformance-Test
+        value: ["Value1","Value2"]
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.BidiStreamRequest
+      responseDefinition:
+        responseHeaders:
+          - name: x-custom-header
+            value: ["foo","bar","baz"]
+        error:
+          code: 13
+          message: "bidi full duplex stream failed"
+        responseTrailers:
+        - name: x-custom-trailer
+          value: ["bing","quux"]
+      fullDuplex: true
+- request:
+    testName: bidi half duplex stream error with responses
+    service: connectrpc.conformance.v1.ConformanceService
+    method: BidiStream
+    streamType: STREAM_TYPE_HALF_DUPLEX_BIDI_STREAM
+    requestHeaders:
+      - name: X-Conformance-Test
+        value: ["Value1","Value2"]
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.BidiStreamRequest
+      responseDefinition:
+        responseHeaders:
+          - name: x-custom-header
+            value: ["foo","bar","baz"]
+        responseData:
+          - "dGVzdCByZXNwb25zZQ=="
+          - "dGVzdCByZXNwb25zZQ=="
+        error:
+          code: 13
+          message: "bidi half duplex stream failed"
+        responseTrailers:
+        - name: x-custom-trailer
+          value: ["bing","quux"]
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.BidiStreamRequest
+      requestData: "dGVzdCByZXNwb25zZQ=="
+- request:
+    testName: bidi half duplex stream error with no responses
+    service: connectrpc.conformance.v1.ConformanceService
+    method: BidiStream
+    streamType: STREAM_TYPE_HALF_DUPLEX_BIDI_STREAM
+    requestHeaders:
+      - name: X-Conformance-Test
+        value: ["Value1","Value2"]
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.BidiStreamRequest
+      responseDefinition:
+        responseHeaders:
+          - name: x-custom-header
+            value: ["foo","bar","baz"]
+        error:
+          code: 13
+          message: "bidi half duplex stream failed"
+        responseTrailers:
+        - name: x-custom-trailer
+          value: ["bing","quux"]
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.BidiStreamRequest
+      requestData: "dGVzdCByZXNwb25zZQ=="


### PR DESCRIPTION
This adds new tests for each Connect error code for both unary and streaming responses, since errors are represented differently on the wire for each. The tests verify that each are able to be returned and that the client is able to determine the error.

To test unary responses, the `Unary` endpoint was used and for streaming responses, the `ServerStream` endpoint is used.

In addition, all the previous error test cases for specific RPC types were moved to the new `errors.yaml` file.