### PR TITLE
Support sending raw HTTP request in reference client

### DIFF
--- a/internal/app/referenceclient/client.go
+++ b/internal/app/referenceclient/client.go
@@ -204,6 +204,10 @@ func invoke(ctx context.Context, req *v1.ClientCompatRequest) (*v1.ClientRespons
 		return nil, errors.New("an HTTP version must be specified")
 	}
 
+	if req.RawRequest != nil {
+		transport = &rawRequestSender{transport: transport, rawRequest: req.RawRequest}
+	}
+
 	// Create client options based on protocol of the implementation
 	clientOptions := []connect.ClientOption{connect.WithHTTPGet()}
 	switch req.Protocol {

--- a/internal/app/referenceclient/raw_request.go
+++ b/internal/app/referenceclient/raw_request.go
@@ -1,0 +1,110 @@
+// Copyright 2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package referenceclient
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"connectrpc.com/conformance/internal"
+	conformancev1 "connectrpc.com/conformance/internal/gen/proto/go/connectrpc/conformance/v1"
+)
+
+type rawRequestSender struct {
+	transport  http.RoundTripper
+	rawRequest *conformancev1.RawHTTPRequest
+}
+
+func (r *rawRequestSender) RoundTrip(orig *http.Request) (*http.Response, error) {
+	switch r.rawRequest.Body.(type) {
+	case *conformancev1.RawHTTPRequest_Unary, *conformancev1.RawHTTPRequest_Stream, nil:
+	default:
+		return nil, fmt.Errorf("raw request has invalid body definition: %T", r.rawRequest.Body)
+	}
+
+	uri := r.rawRequest.Uri
+	if len(r.rawRequest.RawQueryParams) > 0 || len(r.rawRequest.EncodedQueryParams) > 0 {
+		reqURL, err := url.Parse(r.rawRequest.Uri)
+		if err != nil {
+			return nil, fmt.Errorf("raw request has invalid URI: %s: %w", r.rawRequest.Uri, err)
+		}
+		vals := reqURL.Query()
+		for _, param := range r.rawRequest.RawQueryParams {
+			vals[param.Name] = append(vals[param.Name], param.Value...)
+		}
+		for _, param := range r.rawRequest.EncodedQueryParams {
+			var buf bytes.Buffer
+			if err := internal.WriteRawMessageContents(param.Value, &buf); err != nil {
+				return nil, fmt.Errorf("raw request has invalid encoded query param %s: %w", param.Name, err)
+			}
+			var paramVal string
+			if param.Base64Encode {
+				paramVal = base64.URLEncoding.EncodeToString(buf.Bytes())
+			} else {
+				paramVal = buf.String()
+			}
+			vals[param.Name] = append(vals[param.Name], paramVal)
+		}
+		reqURL.RawQuery = vals.Encode()
+		uri = reqURL.String()
+	}
+
+	pipeReader, pipeWriter := io.Pipe()
+	req, err := http.NewRequestWithContext(
+		orig.Context(),
+		r.rawRequest.Verb,
+		fmt.Sprintf("%s://%s%s", orig.URL.Scheme, orig.URL.Host, uri),
+		pipeReader,
+	)
+	if err != nil {
+		if orig.Body != nil {
+			_ = orig.Body.Close()
+		}
+		return nil, err
+	}
+
+	internal.AddHeaders(r.rawRequest.Headers, req.Header)
+	if length, err := strconv.Atoi(req.Header.Get("Content-Length")); err == nil {
+		req.ContentLength = int64(length)
+	}
+
+	// Write the request body to the pipe.
+	go func() {
+		defer func() {
+			_ = pipeWriter.Close()
+		}()
+		switch contents := r.rawRequest.Body.(type) {
+		case *conformancev1.RawHTTPRequest_Unary:
+			_ = internal.WriteRawMessageContents(contents.Unary, pipeWriter)
+		case *conformancev1.RawHTTPRequest_Stream:
+			_ = internal.WriteRawStreamContents(contents.Stream, pipeWriter)
+		}
+	}()
+
+	// Drain the original request body and close it.
+	go func() {
+		defer func() {
+			_ = orig.Body.Close()
+		}()
+		_, _ = io.Copy(io.Discard, orig.Body)
+	}()
+
+	return r.transport.RoundTrip(req)
+}

--- a/internal/app/referenceclient/raw_request_test.go
+++ b/internal/app/referenceclient/raw_request_test.go
@@ -1,0 +1,441 @@
+// Copyright 2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package referenceclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"connectrpc.com/conformance/internal"
+	conformancev1 "connectrpc.com/conformance/internal/gen/proto/go/connectrpc/conformance/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func TestRawRequestSender(t *testing.T) {
+	t.Parallel()
+
+	val, err := structpb.NewValue(map[string]any{
+		"abc": "xyz",
+		"def": []any{
+			1.0, 123, "foo", false,
+		},
+		"ghi": map[string]any{
+			"foo": "bar",
+			"baz": -99,
+		},
+	})
+	require.NoError(t, err)
+	msgPayload := &anypb.Any{}
+	err = anypb.MarshalFrom(msgPayload, val, proto.MarshalOptions{})
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name string
+		req  *conformancev1.RawHTTPRequest
+	}{
+		{
+			name: "basic",
+			req: &conformancev1.RawHTTPRequest{
+				Verb: http.MethodPost,
+				Uri:  "/foo/bar.baz",
+				Body: &conformancev1.RawHTTPRequest_Unary{
+					Unary: &conformancev1.MessageContents{
+						Data: &conformancev1.MessageContents_Binary{
+							Binary: []byte{0, 1, 2, 3, 4, 5, 6, 7},
+						},
+					},
+				},
+				Headers: []*conformancev1.Header{
+					{
+						Name:  "Content-Type",
+						Value: []string{"foo/bar"},
+					},
+					{
+						Name:  "Content-Length",
+						Value: []string{"8"},
+					},
+				},
+			},
+		},
+		{
+			name: "get-with-query-params",
+			req: &conformancev1.RawHTTPRequest{
+				Verb: http.MethodGet,
+				Uri:  "/foo/bar.baz",
+				RawQueryParams: []*conformancev1.Header{
+					{
+						Name:  "q",
+						Value: []string{"a", "b", "c"},
+					},
+					{
+						Name:  "x",
+						Value: []string{"123"},
+					},
+				},
+				Body: &conformancev1.RawHTTPRequest_Unary{
+					Unary: &conformancev1.MessageContents{
+						Data: &conformancev1.MessageContents_Text{
+							Text: `{"foo": "bar", "baz": [0,1,2,3]}`,
+						},
+					},
+				},
+				Headers: []*conformancev1.Header{
+					{
+						Name:  "Content-Type",
+						Value: []string{"foo/bar"},
+					},
+					{
+						Name:  "X-Custom-Header",
+						Value: []string{"abc", "def", "xyz"},
+					},
+				},
+			},
+		},
+		{
+			name: "encoded-query-params",
+			req: &conformancev1.RawHTTPRequest{
+				Verb: http.MethodPut,
+				Uri:  "/foo/bar.baz",
+				EncodedQueryParams: []*conformancev1.RawHTTPRequest_EncodedQueryParam{
+					{
+						Name: "q",
+						Value: &conformancev1.MessageContents{
+							Data: &conformancev1.MessageContents_Binary{
+								Binary: []byte{0, 1, 2, 3, 4, 5, 6, 7},
+							},
+							Compression: conformancev1.Compression_COMPRESSION_GZIP,
+						},
+						Base64Encode: true,
+					},
+					{
+						Name: "x",
+						Value: &conformancev1.MessageContents{
+							Data: &conformancev1.MessageContents_Text{
+								Text: `{"foo": "bar"}`,
+							},
+						},
+					},
+				},
+				Body: &conformancev1.RawHTTPRequest_Unary{
+					Unary: &conformancev1.MessageContents{
+						Data: &conformancev1.MessageContents_Text{
+							Text: `{"foo": "bar", "baz": [0,1,2,3]}`,
+						},
+					},
+				},
+				Headers: []*conformancev1.Header{
+					{
+						Name:  "Content-Type",
+						Value: []string{"foo/bar"},
+					},
+					{
+						Name:  "X-Custom-Header",
+						Value: []string{"abc", "def", "xyz"},
+					},
+				},
+			},
+		},
+		{
+			name: "mix-of-query-params",
+			req: &conformancev1.RawHTTPRequest{
+				Verb: http.MethodGet,
+				Uri:  "/foo/bar.baz?q=q&x=456",
+				RawQueryParams: []*conformancev1.Header{
+					{
+						Name:  "q",
+						Value: []string{"a", "b", "c"},
+					},
+					{
+						Name:  "x",
+						Value: []string{"123"},
+					},
+				},
+				EncodedQueryParams: []*conformancev1.RawHTTPRequest_EncodedQueryParam{
+					{
+						Name: "q",
+						Value: &conformancev1.MessageContents{
+							Data: &conformancev1.MessageContents_Binary{
+								Binary: []byte{0, 1, 2, 3, 4, 5, 6, 7},
+							},
+							Compression: conformancev1.Compression_COMPRESSION_GZIP,
+						},
+						Base64Encode: true,
+					},
+					{
+						Name: "x",
+						Value: &conformancev1.MessageContents{
+							Data: &conformancev1.MessageContents_Text{
+								Text: `{"foo": "bar"}`,
+							},
+						},
+					},
+				},
+				Body: &conformancev1.RawHTTPRequest_Unary{
+					Unary: &conformancev1.MessageContents{
+						Data: &conformancev1.MessageContents_Text{
+							Text: `{"foo": "bar", "baz": [0,1,2,3]}`,
+						},
+					},
+				},
+				Headers: []*conformancev1.Header{
+					{
+						Name:  "Content-Type",
+						Value: []string{"application/json"},
+					},
+				},
+			},
+		},
+		{
+			name: "empty-body",
+			req: &conformancev1.RawHTTPRequest{
+				Verb: http.MethodGet,
+				Uri:  "/foo/bar.baz",
+			},
+		},
+		{
+			name: "stream-body",
+			req: &conformancev1.RawHTTPRequest{
+				Verb: http.MethodGet,
+				Uri:  "/foo/bar.baz",
+				RawQueryParams: []*conformancev1.Header{
+					{
+						Name:  "q",
+						Value: []string{"a", "b", "c"},
+					},
+					{
+						Name:  "x",
+						Value: []string{"123"},
+					},
+				},
+				Body: &conformancev1.RawHTTPRequest_Stream{
+					Stream: &conformancev1.StreamContents{
+						Items: []*conformancev1.StreamContents_StreamItem{
+							{
+								Payload: &conformancev1.MessageContents{
+									Data: &conformancev1.MessageContents_Text{
+										Text: `{"foo": "bar", "baz": [0,1,2,3]}`,
+									},
+								},
+							},
+							{
+								Flags: 0x01,
+								Payload: &conformancev1.MessageContents{
+									Data: &conformancev1.MessageContents_BinaryMessage{
+										BinaryMessage: msgPayload,
+									},
+									Compression: conformancev1.Compression_COMPRESSION_DEFLATE,
+								},
+							},
+							{
+								Flags:  0x3,
+								Length: proto.Uint32(8),
+								Payload: &conformancev1.MessageContents{
+									Data: &conformancev1.MessageContents_Binary{
+										Binary: []byte{0, 1, 2, 3, 4, 5, 6, 7},
+									},
+								},
+							},
+						},
+					},
+				},
+				Headers: []*conformancev1.Header{
+					{
+						Name:  "Content-Type",
+						Value: []string{"foo/bar"},
+					},
+					{
+						Name:  "X-Custom-Header",
+						Value: []string{"abc", "def", "xyz"},
+					},
+				},
+			},
+		},
+	}
+
+	var requests sync.Map // map[string]chan *http.Request
+	svr := httptest.NewServer(http.HandlerFunc(func(respWriter http.ResponseWriter, req *http.Request) {
+		testCaseName := req.Header.Get("test-case-name")
+		val, ok := requests.Load(testCaseName)
+		reqChan, isChan := val.(chan *http.Request)
+		if !ok || !isChan {
+			respWriter.WriteHeader(http.StatusBadRequest)
+		}
+		reqCopy := req.Clone(req.Context())
+		var data bytes.Buffer
+		_, err := data.ReadFrom(req.Body)
+		if err != nil {
+			respWriter.WriteHeader(http.StatusInternalServerError)
+		}
+		reqCopy.Body = io.NopCloser(&data)
+		reqChan <- reqCopy
+		// no response means implicit 200 okay w/ no body
+	}))
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			reqChan := make(chan *http.Request, 1)
+			testCaseName := t.Name()
+			requests.Store(testCaseName, reqChan)
+
+			sender := &rawRequestSender{
+				transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+					req.Header.Set("test-case-name", testCaseName)
+					transport := &http.Transport{DisableCompression: true}
+
+					return transport.RoundTrip(req)
+				}),
+				rawRequest: testCase.req,
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, svr.URL+"/some.random.endpoint/", strings.NewReader("foobar"))
+			require.NoError(t, err)
+			resp, err := sender.RoundTrip(req)
+			require.NoError(t, err)
+			defer func() {
+				_ = resp.Body.Close()
+			}()
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+
+			requests.Delete(testCaseName)
+			select {
+			case req = <-reqChan:
+			default:
+				t.Fatal("server did not send request to channel")
+			}
+
+			// First we check the URI path
+			expectedURL, err := url.ParseRequestURI(testCase.req.Uri)
+			require.NoError(t, err)
+			assert.Equal(t, expectedURL.Path, req.URL.Path)
+
+			// Then query params
+			expectedInitialQueryParams := expectedURL.Query()
+			expectedQueryParamCounts := map[string]int{}
+			for k, v := range expectedInitialQueryParams {
+				expectedQueryParamCounts[k] = len(v)
+			}
+			for _, param := range testCase.req.RawQueryParams {
+				expectedQueryParamCounts[param.Name] += len(param.Value)
+			}
+			for _, param := range testCase.req.EncodedQueryParams {
+				expectedQueryParamCounts[param.Name]++
+			}
+
+			actualQueryParams := req.URL.Query()
+			actualQueryParamCounts := map[string]int{}
+			for k, v := range actualQueryParams {
+				actualQueryParamCounts[k] = len(v)
+			}
+
+			assert.Equal(t, expectedQueryParamCounts, actualQueryParamCounts)
+			for k, expectedVals := range expectedInitialQueryParams {
+				actualVals := actualQueryParams[k]
+				if len(actualVals) > len(expectedVals) {
+					actualVals = actualVals[:len(expectedVals)]
+				}
+				assert.Equal(t, expectedVals, actualVals, "inline query param values for %q", k)
+			}
+			rawParams := make(map[string][]string, len(testCase.req.RawQueryParams))
+			for _, param := range testCase.req.RawQueryParams {
+				rawParams[param.Name] = param.Value
+				actualVals := actualQueryParams[param.Name]
+				// remove any initial expected values that were in the URI string
+				initVals := expectedInitialQueryParams[param.Name]
+				if len(actualVals) > len(initVals) {
+					actualVals = actualVals[len(initVals):]
+				} else {
+					actualVals = nil
+				}
+				if len(actualVals) > len(param.Value) {
+					actualVals = actualVals[:len(param.Value)]
+				}
+				assert.Equal(t, param.Value, actualVals, "raw query param values for %q", param.Name)
+			}
+			for _, param := range testCase.req.EncodedQueryParams {
+				actualVals := actualQueryParams[param.Name]
+				// remove any initial expected values that were in the URI string
+				initVals := expectedInitialQueryParams[param.Name]
+				if len(actualVals) > len(initVals) {
+					actualVals = actualVals[len(initVals):]
+				} else {
+					actualVals = nil
+				}
+				rawVals := rawParams[param.Name]
+				if len(actualVals) > len(rawVals) {
+					actualVals = actualVals[len(rawVals):]
+				} else {
+					actualVals = nil
+				}
+				var buf bytes.Buffer
+				err := internal.WriteRawMessageContents(param.Value, &buf)
+				require.NoError(t, err)
+				var expectedVals []string
+				if param.Base64Encode {
+					expectedVals = []string{base64.URLEncoding.EncodeToString(buf.Bytes())}
+				} else {
+					expectedVals = []string{buf.String()}
+				}
+				assert.Equal(t, expectedVals, actualVals, "encoded query param values for %q", param.Name)
+			}
+
+			// Then HTTP method/verb
+			assert.Equal(t, testCase.req.Verb, req.Method)
+
+			// Then headers
+			req.Header.Del("test-case-name") // added by the round tripper above; not in raw request
+			req.Header.Del("user-agent")     // added by http.Transport
+			expectedHeaders := http.Header{}
+			internal.AddHeaders(testCase.req.Headers, expectedHeaders)
+			assert.Equal(t, expectedHeaders, req.Header)
+
+			// Finally, the body
+			var expected, actual bytes.Buffer
+			_, err = io.Copy(&actual, req.Body)
+			require.NoError(t, err)
+			switch contents := testCase.req.Body.(type) {
+			case *conformancev1.RawHTTPRequest_Unary:
+				err = internal.WriteRawMessageContents(contents.Unary, &expected)
+			case *conformancev1.RawHTTPRequest_Stream:
+				err = internal.WriteRawStreamContents(contents.Stream, &expected)
+			}
+			require.NoError(t, err)
+			assert.Equal(t, expected.Bytes(), actual.Bytes())
+		})
+	}
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}

--- a/internal/compression/compression.go
+++ b/internal/compression/compression.go
@@ -14,6 +14,15 @@
 
 package compression
 
+import (
+	"compress/gzip"
+	"fmt"
+	"io"
+
+	conformancev1 "connectrpc.com/conformance/internal/gen/proto/go/connectrpc/conformance/v1"
+	"connectrpc.com/connect"
+)
+
 // The IANA names for supported compression algorithms.
 const (
 	Identity = "identity"
@@ -23,3 +32,76 @@ const (
 	Snappy   = "snappy"
 	Zstd     = "zstd"
 )
+
+// GetCompressor returns a compressor for the given compression algorithm.
+func GetCompressor(compression conformancev1.Compression) (connect.Compressor, error) {
+	switch compression {
+	case conformancev1.Compression_COMPRESSION_UNSPECIFIED, conformancev1.Compression_COMPRESSION_IDENTITY:
+		return &noOpCompressor{}, nil
+	case conformancev1.Compression_COMPRESSION_GZIP:
+		return gzip.NewWriter(nil), nil
+	case conformancev1.Compression_COMPRESSION_BR:
+		return NewBrotliCompressor(), nil
+	case conformancev1.Compression_COMPRESSION_ZSTD:
+		return NewZstdCompressor(), nil
+	case conformancev1.Compression_COMPRESSION_DEFLATE:
+		return NewDeflateCompressor(), nil
+	case conformancev1.Compression_COMPRESSION_SNAPPY:
+		return NewSnappyCompressor(), nil
+	default:
+		return nil, fmt.Errorf("unsupported compression scheme %v", compression)
+	}
+}
+
+// GetDecompressor returns a decompressor for the given compression algorithm.
+func GetDecompressor(compression conformancev1.Compression) (connect.Decompressor, error) {
+	switch compression {
+	case conformancev1.Compression_COMPRESSION_UNSPECIFIED, conformancev1.Compression_COMPRESSION_IDENTITY:
+		return &noOpDecompressor{}, nil
+	case conformancev1.Compression_COMPRESSION_GZIP:
+		return &gzip.Reader{}, nil
+	case conformancev1.Compression_COMPRESSION_BR:
+		return NewBrotliDecompressor(), nil
+	case conformancev1.Compression_COMPRESSION_ZSTD:
+		return NewZstdDecompressor(), nil
+	case conformancev1.Compression_COMPRESSION_DEFLATE:
+		return NewDeflateDecompressor(), nil
+	case conformancev1.Compression_COMPRESSION_SNAPPY:
+		return NewSnappyDecompressor(), nil
+	default:
+		return nil, fmt.Errorf("unsupported compression scheme %v", compression)
+	}
+}
+
+type noOpCompressor struct {
+	io.WriteCloser
+}
+
+func (c *noOpCompressor) Reset(writer io.Writer) {
+	wc, ok := writer.(io.WriteCloser)
+	if !ok {
+		wc = &noOpCloser{writer}
+	}
+	c.WriteCloser = wc
+}
+
+type noOpDecompressor struct {
+	io.ReadCloser
+}
+
+func (c *noOpDecompressor) Reset(reader io.Reader) error {
+	rc, ok := reader.(io.ReadCloser)
+	if !ok {
+		rc = io.NopCloser(reader)
+	}
+	c.ReadCloser = rc
+	return nil
+}
+
+type noOpCloser struct {
+	io.Writer
+}
+
+func (n *noOpCloser) Close() error {
+	return nil
+}

--- a/internal/raw_http_body_test.go
+++ b/internal/raw_http_body_test.go
@@ -1,0 +1,225 @@
+// Copyright 2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"connectrpc.com/conformance/internal/compression"
+	conformancev1 "connectrpc.com/conformance/internal/gen/proto/go/connectrpc/conformance/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func TestWriteRawMessageContents(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		data *conformancev1.MessageContents
+	}{
+		{
+			name: "binary",
+			data: &conformancev1.MessageContents{
+				Data: &conformancev1.MessageContents_Binary{
+					Binary: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+				},
+			},
+		},
+		{
+			name: "text",
+			data: &conformancev1.MessageContents{
+				Data: &conformancev1.MessageContents_Text{
+					Text: `Law Blog of Bob Loblaw, Attorney at Law`,
+				},
+			},
+		},
+		{
+			name: "message",
+			data: &conformancev1.MessageContents{
+				Data: &conformancev1.MessageContents_BinaryMessage{
+					BinaryMessage: messageValue(t),
+				},
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			// try all flavors of compression
+			for compressInt, compressName := range conformancev1.Compression_name {
+				compressionType := conformancev1.Compression(compressInt)
+				t.Run(compressName, func(t *testing.T) {
+					t.Parallel()
+
+					data := proto.Clone(testCase.data).(*conformancev1.MessageContents) //nolint:errcheck,forcetypeassert
+					data.Compression = compressionType
+
+					var buf bytes.Buffer
+					err := WriteRawMessageContents(data, &buf)
+					require.NoError(t, err)
+
+					checkMessageContents(t, data, buf.Bytes())
+				})
+			}
+		})
+	}
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		err := WriteRawMessageContents(&conformancev1.MessageContents{}, &buf)
+		require.NoError(t, err)
+		require.Zero(t, buf.Len())
+	})
+}
+
+func TestWriteRawStreamContents(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		data []*conformancev1.StreamContents_StreamItem
+	}{
+		{
+			name: "empty",
+			data: nil,
+		},
+		{
+			name: "simple",
+			data: []*conformancev1.StreamContents_StreamItem{
+				{
+					Flags:  0,
+					Length: proto.Uint32(10),
+					Payload: &conformancev1.MessageContents{
+						Data: &conformancev1.MessageContents_Binary{
+							Binary: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "longer",
+			data: []*conformancev1.StreamContents_StreamItem{
+				{
+					Flags: 123,
+					Payload: &conformancev1.MessageContents{
+						Data: &conformancev1.MessageContents_Binary{
+							Binary: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+						},
+						Compression: conformancev1.Compression_COMPRESSION_BR,
+					},
+				},
+				{
+					Flags: 22,
+					Payload: &conformancev1.MessageContents{
+						Data: &conformancev1.MessageContents_Text{
+							Text: `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.`,
+						},
+					},
+				},
+				{
+					Flags: 1,
+					Payload: &conformancev1.MessageContents{
+						Data: &conformancev1.MessageContents_BinaryMessage{
+							BinaryMessage: messageValue(t),
+						},
+						Compression: conformancev1.Compression_COMPRESSION_ZSTD,
+					},
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			err := WriteRawStreamContents(&conformancev1.StreamContents{Items: testCase.data}, &buf)
+			require.NoError(t, err)
+
+			checkStreamContents(t, testCase.data, buf.Bytes())
+		})
+	}
+}
+
+func messageValue(t *testing.T) *anypb.Any {
+	t.Helper()
+	val, err := structpb.NewValue(map[string]any{
+		"abc": "xyz",
+		"def": []any{
+			1.0, 123, "foo", false,
+		},
+		"ghi": map[string]any{
+			"foo": "bar",
+			"baz": -99,
+		},
+	})
+	require.NoError(t, err)
+	msgPayload := &anypb.Any{}
+	err = anypb.MarshalFrom(msgPayload, val, proto.MarshalOptions{})
+	require.NoError(t, err)
+	return msgPayload
+}
+
+func checkMessageContents(t *testing.T, msg *conformancev1.MessageContents, data []byte) {
+	t.Helper()
+	decompressor, err := compression.GetDecompressor(msg.Compression)
+	require.NoError(t, err)
+	err = decompressor.Reset(bytes.NewReader(data))
+	require.NoError(t, err)
+	var decompressed bytes.Buffer
+	_, err = decompressed.ReadFrom(decompressor)
+	require.NoError(t, err)
+	switch msgData := msg.Data.(type) {
+	case *conformancev1.MessageContents_Binary:
+		assert.Equal(t, msgData.Binary, decompressed.Bytes())
+	case *conformancev1.MessageContents_Text:
+		assert.Equal(t, msgData.Text, decompressed.String())
+	case *conformancev1.MessageContents_BinaryMessage:
+		assert.Equal(t, msgData.BinaryMessage.Value, decompressed.Bytes())
+	case nil:
+		assert.Zero(t, decompressed.Len())
+	default:
+		t.Fatalf("unknown type of contents: %T", msg.Data)
+	}
+}
+
+func checkStreamContents(t *testing.T, items []*conformancev1.StreamContents_StreamItem, data []byte) {
+	t.Helper()
+	for _, item := range items {
+		require.GreaterOrEqual(t, len(data), 5)
+		assert.Equal(t, byte(item.Flags), data[0])
+		length := binary.BigEndian.Uint32(data[1:5])
+		if item.Length != nil {
+			assert.Equal(t, item.GetLength(), length)
+		}
+		data = data[5:]
+		require.GreaterOrEqual(t, len(data), int(length))
+		msg := data[:length]
+		checkMessageContents(t, item.Payload, msg)
+		data = data[length:]
+	}
+	assert.Empty(t, data)
+}


### PR DESCRIPTION
This still expects the test case to include a normal request, too. That allows us to continue using the "expected response" computation, based on the request. But we can then override the actual HTTP request, to simulate some behavior (mainly around on-the-wire encoding) that the reference client doesn't usually exhibit. The main things that are _not_ possible with raw requests are the ability to do cancellations or to introduce delays between writes.