### PR TITLE
Minor improvements related to populating expected responses

### DIFF
--- a/internal/app/connectconformance/connectconformance.go
+++ b/internal/app/connectconformance/connectconformance.go
@@ -117,7 +117,6 @@ func Run(flags *Flags, logPrinter internal.Printer, errPrinter internal.Printer)
 	return results.report(logPrinter), nil
 }
 
-//nolint:gocyclo
 func run(
 	configCases []configCase,
 	knownFailing *knownFailingTrie,
@@ -153,14 +152,8 @@ func run(
 
 	// Validate keys in knownFailing, to make sure they match actual test names
 	// (to prevent accidental typos and inadvertently ignored entries)
-	for name, testCase := range testCaseLib.testCases {
+	for name := range testCaseLib.testCases {
 		knownFailing.match(strings.Split(name, "/"))
-
-		// Set the expected responses
-		if err := populateExpectedResponse(testCase); err != nil {
-			return nil, fmt.Errorf("failed to compute expected response for test case %q: %w",
-				testCase.Request.TestName, err)
-		}
 	}
 	unmatched := map[string]struct{}{}
 	knownFailing.findUnmatched("", unmatched)


### PR DESCRIPTION
Populating expected responses in test cases should be the responsibility of the test case library. So instead of making the caller do this, it's now done as part of computing the test cases.

Also, this allows the automatic population of expected responses, even if a raw request or response is used. This is because the normal request and response definition will also be used alongside the raw request or response. So if the expected response from that is still correct, just auto-populate with that. So we only need to provide an explicit expected response if the raw request or response causes the server to behave differently.
