### PR TITLE
Support sending raw HTTP response in reference server

### DIFF
--- a/internal/app/referenceserver/raw_response.go
+++ b/internal/app/referenceserver/raw_response.go
@@ -1,0 +1,264 @@
+// Copyright 2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package referenceserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+
+	"connectrpc.com/conformance/internal"
+	v1 "connectrpc.com/conformance/internal/gen/proto/go/connectrpc/conformance/v1"
+	connectv1 "connectrpc.com/conformance/internal/gen/proto/go/connectrpc/conformance/v1/conformancev1connect"
+	"connectrpc.com/connect"
+	"google.golang.org/protobuf/proto"
+)
+
+// rawResponseKey is used to store the raw response that the server
+// should send in the context. The value type will be **v1.RawHTTPResponse.
+type rawResponseKey struct{}
+
+// rawResponder is HTTP middleware that can send back a raw HTTP response
+// if so directed. The handler directs it to do so by storing a raw response
+// in a placeholder context value before otherwise interacting with the
+// response writer. (If response writer interactions and no raw response has
+// been stored, those response writer interactions take precedence and no
+// raw response can be sent.)
+func rawResponder(handler http.Handler, errPrinter internal.Printer) http.Handler {
+	return http.HandlerFunc(func(respWriter http.ResponseWriter, req *http.Request) {
+		testCaseName := req.Header.Get("x-test-case-name")
+		if testCaseName == "" {
+			// This is the only hard failure. Without it, we cannot provide feedback.
+			// All other checks below write to stderr to provide feedback.
+			http.Error(respWriter, "missing x-test-case-name header", http.StatusBadRequest)
+			return
+		}
+		feedback := &feedbackPrinter{p: errPrinter, testCaseName: testCaseName}
+
+		// We stash this placeholder into context so the rawResponseRecorder
+		// interceptor can populate it and then abort the handler and let us
+		// take over the response.
+		var rawResponse *v1.RawHTTPResponse
+		ctx := context.WithValue(req.Context(), rawResponseKey{}, &rawResponse)
+		req = req.WithContext(ctx)
+		rawResponder := &rawResponseWriter{respWriter: respWriter, rawResp: &rawResponse}
+		handler.ServeHTTP(rawResponder, req)
+		rawResponder.finish(feedback)
+	})
+}
+
+type rawResponseWriter struct {
+	respWriter      http.ResponseWriter
+	mu              sync.Mutex
+	rawResp         **v1.RawHTTPResponse
+	startedResponse bool
+}
+
+// canSendResponse returns true if the server handler can use the
+// http.ResponseWriter methods to send a response. This returns false
+// if we will instead be finishing the call with a raw response.
+func (r *rawResponseWriter) canSendResponse() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.startedResponse {
+		return true
+	}
+	if *r.rawResp == nil {
+		r.startedResponse = true
+		return true
+	}
+	return false
+}
+
+// rawResponse returns non-nil if the call will be finished with a
+// raw response. If it returns nil, nothing need be done to finish
+// the call; the server handler was already allowed to send it.
+func (r *rawResponseWriter) rawResponse(feedback *feedbackPrinter) *v1.RawHTTPResponse {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.startedResponse {
+		if *r.rawResp != nil {
+			// Oops. There's a raw response, but it was set too late.
+			feedback.Printf("Could not send raw response; handler sent response too soon")
+		}
+		return nil
+	}
+	return *r.rawResp
+}
+
+func (r *rawResponseWriter) Header() http.Header {
+	return r.respWriter.Header()
+}
+
+func (r *rawResponseWriter) Write(bytes []byte) (int, error) {
+	if r.canSendResponse() {
+		return r.respWriter.Write(bytes)
+	}
+	return len(bytes), nil
+}
+
+func (r *rawResponseWriter) WriteHeader(statusCode int) {
+	if r.canSendResponse() {
+		r.respWriter.WriteHeader(statusCode)
+	}
+}
+
+func (r *rawResponseWriter) Flush() {
+	if r.canSendResponse() {
+		if flusher, ok := r.respWriter.(http.Flusher); ok {
+			flusher.Flush()
+		}
+	}
+}
+
+func (r *rawResponseWriter) Unwrap() http.ResponseWriter {
+	return r.respWriter
+}
+
+func (r *rawResponseWriter) finish(feedback *feedbackPrinter) {
+	resp := r.rawResponse(feedback)
+	if resp == nil {
+		return
+	}
+
+	// clean any headers that may have been set by the handler
+	for k := range r.respWriter.Header() {
+		delete(r.respWriter.Header(), k)
+	}
+	internal.AddHeaders(resp.Headers, r.respWriter.Header())
+	r.respWriter.Header()["Content-Length"] = nil // force chunked encoding, so we can send trailers
+	r.respWriter.Header()["Date"] = nil           // suppress automatic date header
+	r.respWriter.WriteHeader(int(resp.StatusCode))
+	switch contents := resp.Body.(type) {
+	case *v1.RawHTTPResponse_Unary:
+		_ = internal.WriteRawMessageContents(contents.Unary, r.respWriter)
+	case *v1.RawHTTPResponse_Stream:
+		_ = internal.WriteRawStreamContents(contents.Stream, r.respWriter)
+	}
+	internal.AddTrailers(resp.Trailers, r.respWriter.Header())
+}
+
+type rawResponseRecorder struct{}
+
+func (r rawResponseRecorder) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
+	return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+		if msg, ok := req.Any().(*v1.UnaryRequest); ok {
+			rawResponse := msg.GetResponseDefinition().GetRawResponse()
+			if rawResponse != nil {
+				respPtr, ok := ctx.Value(rawResponseKey{}).(**v1.RawHTTPResponse)
+				if !ok {
+					return nil, errors.New("request contains raw response definition but no RawHTTPResponse holder in context")
+				}
+				*respPtr = rawResponse
+				return nil, connect.NewError(connect.CodeAborted, errors.New("use raw response instead"))
+			}
+		}
+		return next(ctx, req)
+	}
+}
+
+func (r rawResponseRecorder) WrapStreamingClient(next connect.StreamingClientFunc) connect.StreamingClientFunc {
+	return next
+}
+
+func (r rawResponseRecorder) WrapStreamingHandler(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
+	return func(ctx context.Context, stream connect.StreamingHandlerConn) error {
+		var req proto.Message
+		var rawResponseFunc func() *v1.RawHTTPResponse
+		switch stream.Spec().Procedure {
+		case connectv1.ConformanceServiceClientStreamProcedure:
+			streamReq := &v1.ClientStreamRequest{}
+			rawResponseFunc = func() *v1.RawHTTPResponse {
+				return streamReq.GetResponseDefinition().GetRawResponse()
+			}
+			req = streamReq
+		case connectv1.ConformanceServiceServerStreamProcedure:
+			streamReq := &v1.ServerStreamRequest{}
+			rawResponseFunc = func() *v1.RawHTTPResponse {
+				return streamReq.GetResponseDefinition().GetRawResponse()
+			}
+			req = streamReq
+		case connectv1.ConformanceServiceBidiStreamProcedure:
+			streamReq := &v1.BidiStreamRequest{}
+			rawResponseFunc = func() *v1.RawHTTPResponse {
+				return streamReq.GetResponseDefinition().GetRawResponse()
+			}
+			req = streamReq
+		}
+		var reqErr error
+		if req == nil {
+			return next(ctx, stream)
+		}
+		reqErr = stream.Receive(req)
+		if reqErr == nil { //nolint:nestif
+			rawResponse := rawResponseFunc()
+			if rawResponse != nil {
+				respPtr, ok := ctx.Value(rawResponseKey{}).(**v1.RawHTTPResponse)
+				if !ok {
+					return errors.New("request contains raw response definition but no RawHTTPResponse holder in context")
+				}
+				*respPtr = rawResponse
+				// If we have a raw response, go ahead and drain the request stream
+				// before sending back the raw response.
+				// NOTE: This means that raw responses cannot be used with full-duplex
+				//       request definitions.
+				for {
+					if err := stream.Receive(req); err != nil {
+						break
+					}
+				}
+				return connect.NewError(connect.CodeAborted, errors.New("use raw response instead"))
+			}
+		}
+		return next(ctx, &firstReqCachingStream{
+			StreamingHandlerConn: stream,
+			request:              req,
+			recvErr:              reqErr,
+		})
+	}
+}
+
+type firstReqCachingStream struct {
+	connect.StreamingHandlerConn
+	request any
+	recvErr error
+}
+
+func (str *firstReqCachingStream) Receive(dest any) error {
+	if str.recvErr != nil {
+		err := str.recvErr
+		str.request, str.recvErr = nil, nil
+		return err
+	}
+	if str.request != nil {
+		destMsg, ok := dest.(proto.Message)
+		if !ok {
+			return fmt.Errorf("%T does not implement proto.Message", dest)
+		}
+		srcMsg, ok := str.request.(proto.Message)
+		if !ok {
+			return fmt.Errorf("%T does not implement proto.Message", dest)
+		}
+		proto.Reset(destMsg)
+		proto.Merge(destMsg, srcMsg)
+		str.request, str.recvErr = nil, nil
+		return nil
+	}
+	// Otherwise, we've already provided the cached first request.
+	// So all subsequent receives use the underlying stream.
+	return str.StreamingHandlerConn.Receive(dest)
+}

--- a/internal/app/referenceserver/raw_response_test.go
+++ b/internal/app/referenceserver/raw_response_test.go
@@ -1,0 +1,345 @@
+// Copyright 2023 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package referenceserver
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"connectrpc.com/conformance/internal"
+	conformancev1 "connectrpc.com/conformance/internal/gen/proto/go/connectrpc/conformance/v1"
+	"connectrpc.com/conformance/internal/gen/proto/go/connectrpc/conformance/v1/conformancev1connect"
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func TestRawResponseRecorder(t *testing.T) {
+	t.Parallel()
+
+	_, handler := conformancev1connect.NewConformanceServiceHandler(
+		conformancev1connect.UnimplementedConformanceServiceHandler{},
+		connect.WithInterceptors(rawResponseRecorder{}),
+	)
+	svr := httptest.NewUnstartedServer(rawResponder(handler, internal.NewPrinter(&bytes.Buffer{})))
+	svr.EnableHTTP2 = true // so we can test bidi stream
+	svr.StartTLS()
+	t.Cleanup(svr.Close)
+
+	invokeUnary := func(ctx context.Context, rawResponse *conformancev1.RawHTTPResponse, client conformancev1connect.ConformanceServiceClient) {
+		_, _ = client.Unary(ctx, connect.NewRequest(&conformancev1.UnaryRequest{
+			RequestData: []byte{0, 1, 2, 3, 4},
+			ResponseDefinition: &conformancev1.UnaryResponseDefinition{
+				Response: &conformancev1.UnaryResponseDefinition_ResponseData{
+					ResponseData: []byte{4, 3, 2, 1, 0},
+				},
+				RawResponse: rawResponse,
+			},
+		}))
+	}
+	invokeClientStream := func(ctx context.Context, rawResponse *conformancev1.RawHTTPResponse, client conformancev1connect.ConformanceServiceClient) {
+		stream := client.ClientStream(ctx)
+		_ = stream.Send(&conformancev1.ClientStreamRequest{
+			RequestData: []byte{0, 1, 2, 3, 4},
+			ResponseDefinition: &conformancev1.UnaryResponseDefinition{
+				Response: &conformancev1.UnaryResponseDefinition_ResponseData{
+					ResponseData: []byte{4, 3, 2, 1, 0},
+				},
+				RawResponse: rawResponse,
+			},
+		})
+		_ = stream.Send(&conformancev1.ClientStreamRequest{
+			RequestData: []byte{5, 6, 7, 8, 9},
+		})
+		_ = stream.Send(&conformancev1.ClientStreamRequest{
+			RequestData: []byte{0, 1, 2, 3, 4},
+		})
+		_, _ = stream.CloseAndReceive()
+	}
+	invokeServerStream := func(ctx context.Context, rawResponse *conformancev1.RawHTTPResponse, client conformancev1connect.ConformanceServiceClient) {
+		stream, err := client.ServerStream(ctx, connect.NewRequest(&conformancev1.ServerStreamRequest{
+			RequestData: []byte{0, 1, 2, 3, 4},
+			ResponseDefinition: &conformancev1.StreamResponseDefinition{
+				ResponseData: [][]byte{
+					{0, 1, 2, 3},
+					{4, 5, 6, 7},
+					{8, 9, 0, 1},
+				},
+				RawResponse: rawResponse,
+			},
+		}))
+		if err != nil {
+			return
+		}
+		defer func() {
+			_ = stream.Close()
+		}()
+		for stream.Receive() {
+			// exhaust stream
+		}
+	}
+	invokeBidiStream := func(ctx context.Context, rawResponse *conformancev1.RawHTTPResponse, client conformancev1connect.ConformanceServiceClient) {
+		stream := client.BidiStream(ctx)
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			defer func() {
+				_ = stream.CloseResponse()
+			}()
+			for {
+				// exhaust stream
+				_, err := stream.Receive()
+				if err != nil {
+					return
+				}
+			}
+		}()
+		_ = stream.Send(&conformancev1.BidiStreamRequest{
+			RequestData: []byte{0, 1, 2, 3, 4},
+			ResponseDefinition: &conformancev1.StreamResponseDefinition{
+				ResponseData: [][]byte{
+					{0, 1, 2, 3},
+					{4, 5, 6, 7},
+					{8, 9, 0, 1},
+				},
+				RawResponse: rawResponse,
+			},
+		})
+		_ = stream.Send(&conformancev1.BidiStreamRequest{
+			RequestData: []byte{5, 6, 7, 8, 9},
+		})
+		_ = stream.Send(&conformancev1.BidiStreamRequest{
+			RequestData: []byte{0, 1, 2, 3, 4},
+		})
+		_ = stream.CloseRequest()
+		<-done // make sure we've finished exhausting response stream
+	}
+
+	val, err := structpb.NewValue(map[string]any{
+		"abc": "xyz",
+		"def": []any{
+			1.0, 123, "foo", false,
+		},
+		"ghi": map[string]any{
+			"foo": "bar",
+			"baz": -99,
+		},
+	})
+	require.NoError(t, err)
+	msgPayload := &anypb.Any{}
+	err = anypb.MarshalFrom(msgPayload, val, proto.MarshalOptions{})
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name string
+		resp *conformancev1.RawHTTPResponse
+	}{
+		{
+			name: "simple",
+			resp: &conformancev1.RawHTTPResponse{
+				StatusCode: 200,
+				Headers: []*conformancev1.Header{
+					{
+						Name:  "foo",
+						Value: []string{"bar", "baz"},
+					},
+					{
+						Name:  "content-type",
+						Value: []string{"foo/bar"},
+					},
+				},
+				Body: &conformancev1.RawHTTPResponse_Unary{
+					Unary: &conformancev1.MessageContents{
+						Data: &conformancev1.MessageContents_Text{
+							Text: `{"foo":"bar"}`,
+						},
+					},
+				},
+				Trailers: []*conformancev1.Header{
+					{
+						Name:  "x",
+						Value: []string{"123", "456"},
+					},
+				},
+			},
+		},
+		{
+			name: "empty",
+			resp: &conformancev1.RawHTTPResponse{
+				StatusCode: 404,
+			},
+		},
+		{
+			name: "stream body",
+			resp: &conformancev1.RawHTTPResponse{
+				StatusCode: 505,
+				Headers: []*conformancev1.Header{
+					{
+						Name:  "foo",
+						Value: []string{"bar", "baz"},
+					},
+					{
+						Name:  "content-type",
+						Value: []string{"foo/bar"},
+					},
+				},
+				Body: &conformancev1.RawHTTPResponse_Stream{
+					Stream: &conformancev1.StreamContents{
+						Items: []*conformancev1.StreamContents_StreamItem{
+							{
+								Length: proto.Uint32(10),
+								Payload: &conformancev1.MessageContents{
+									Data: &conformancev1.MessageContents_Binary{
+										Binary: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+									},
+								},
+							},
+							{
+								Flags: 1,
+								Payload: &conformancev1.MessageContents{
+									Data: &conformancev1.MessageContents_BinaryMessage{
+										BinaryMessage: msgPayload,
+									},
+									Compression: conformancev1.Compression_COMPRESSION_SNAPPY,
+								},
+							},
+							{
+								Flags: 0x80,
+								Payload: &conformancev1.MessageContents{
+									Data: &conformancev1.MessageContents_Text{
+										Text: `{"error": "not_found", "trailers": {"a": ["1", "2", "3"], "b": ["xyz"]}}"`,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	invokers := []struct {
+		name   string
+		invoke func(ctx context.Context, rawResponse *conformancev1.RawHTTPResponse, client conformancev1connect.ConformanceServiceClient)
+	}{
+		{
+			name:   "unary",
+			invoke: invokeUnary,
+		},
+		{
+			name:   "client stream",
+			invoke: invokeClientStream,
+		},
+		{
+			name:   "server stream",
+			invoke: invokeServerStream,
+		},
+		{
+			name:   "bidi stream",
+			invoke: invokeBidiStream,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			for _, invoker := range invokers {
+				invoker := invoker
+				t.Run(invoker.name, func(t *testing.T) {
+					t.Parallel()
+
+					var err error
+					var resp *http.Response
+					var body bytes.Buffer
+					testCaseName := t.Name()
+					transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+						req.Header.Set("x-test-case-name", testCaseName)
+						resp, err = svr.Client().Transport.RoundTrip(req)
+						if err != nil {
+							return nil, err
+						}
+						resp.Body = &captureBody{buf: &body, r: resp.Body}
+						return resp, nil
+					})
+
+					client := conformancev1connect.NewConformanceServiceClient(&http.Client{Transport: transport}, svr.URL)
+					invoker.invoke(context.Background(), testCase.resp, client)
+
+					require.NoError(t, err)
+
+					// First we check the status code
+					assert.Equal(t, int(testCase.resp.StatusCode), resp.StatusCode)
+
+					// Then headers and trailers
+					expectedHeaders := http.Header{}
+					internal.AddHeaders(testCase.resp.Headers, expectedHeaders)
+					assert.Equal(t, expectedHeaders, resp.Header)
+
+					expectedTrailers := http.Header{}
+					if resp.Trailer == nil {
+						assert.Empty(t, testCase.resp.Trailers)
+					} else {
+						internal.AddHeaders(testCase.resp.Trailers, expectedTrailers)
+						assert.Equal(t, expectedTrailers, resp.Trailer)
+					}
+
+					// Finally, the body
+					expectedBody := bytes.NewBuffer([]byte{})
+					switch contents := testCase.resp.Body.(type) {
+					case *conformancev1.RawHTTPResponse_Unary:
+						err = internal.WriteRawMessageContents(contents.Unary, expectedBody)
+					case *conformancev1.RawHTTPResponse_Stream:
+						err = internal.WriteRawStreamContents(contents.Stream, expectedBody)
+					}
+					require.NoError(t, err)
+					assert.Equal(t, expectedBody.Bytes(), body.Bytes())
+				})
+			}
+		})
+	}
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type captureBody struct {
+	buf *bytes.Buffer
+	r   io.ReadCloser
+}
+
+func (c *captureBody) Read(data []byte) (n int, err error) {
+	n, err = c.r.Read(data)
+	// save all bytes read to c.buf
+	c.buf.Write(data[:n])
+	return n, err
+}
+
+func (c *captureBody) Close() error {
+	// make sure reader is drained before closing
+	// so that we capture entire body into c.buf
+	_, _ = io.Copy(c.buf, c.r)
+	return c.r.Close()
+}

--- a/internal/app/referenceserver/raw_response_test.go
+++ b/internal/app/referenceserver/raw_response_test.go
@@ -292,6 +292,8 @@ func TestRawResponseRecorder(t *testing.T) {
 
 					// Then headers and trailers
 					expectedHeaders := http.Header{}
+					resp.Header.Del("Content-Length") // may be added automatically by server
+					resp.Header.Del("Trailer")        // added by handler to ensure trailers can be sent
 					internal.AddHeaders(testCase.resp.Headers, expectedHeaders)
 					assert.Equal(t, expectedHeaders, resp.Header)
 

--- a/internal/app/referenceserver/server.go
+++ b/internal/app/referenceserver/server.go
@@ -170,7 +170,7 @@ func createServer(req *v1.ServerCompatRequest, listenAddr, tlsCertFile, tlsKeyFi
 		connect.WithCompression(compression.Snappy, compression.NewSnappyDecompressor, compression.NewSnappyCompressor),
 		connect.WithCompression(compression.Zstd, compression.NewZstdDecompressor, compression.NewZstdCompressor),
 		connect.WithCodec(&internal.TextConnectCodec{}),
-		connect.WithInterceptors(serverNameHandlerInterceptor{}),
+		connect.WithInterceptors(serverNameHandlerInterceptor{}, rawResponseRecorder{}),
 	}
 	if req.MessageReceiveLimit > 0 {
 		opts = append(opts, connect.WithReadMaxBytes(int(req.MessageReceiveLimit)))
@@ -183,6 +183,7 @@ func createServer(req *v1.ServerCompatRequest, listenAddr, tlsCertFile, tlsKeyFi
 	handler := http.Handler(mux)
 	if referenceMode {
 		handler = referenceServerChecks(handler, errPrinter)
+		handler = rawResponder(handler, errPrinter)
 	}
 	// The server needs a lenient cors setup so that it can handle testing
 	// browser clients.


### PR DESCRIPTION
This one's a little more confusing the client side because of how we to hook into the HTTP framework's response writer. We basically override the response writer to _maybe_ ignore all calls to it (made by the handler to send its "normal" HTTP response) and, at the end, instead send the raw response. Because it waits until the end to send the raw response, we can't test full-duplex bidi stuff with it. But it does work fine with half-duplex bidi operations.

The "maybe" when ignoring calls is whether there is a raw response or not. So there's a connect interceptor that examines the request as the first thing and, if it contains a raw response, stashes it away so the overridden response writer knows about it. This "stashing away" uses a placeholder address in a context value.