### PR TITLE
Reference client and server should support half-duplex bidi over HTTP 1.1

### DIFF
--- a/internal/app/referenceclient/raw_request_test.go
+++ b/internal/app/referenceclient/raw_request_test.go
@@ -433,9 +433,3 @@ func TestRawRequestSender(t *testing.T) {
 		})
 	}
 }
-
-type roundTripperFunc func(*http.Request) (*http.Response, error)
-
-func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
-	return f(req)
-}

--- a/internal/app/referenceserver/impl.go
+++ b/internal/app/referenceserver/impl.go
@@ -268,7 +268,7 @@ func (s *conformanceServer) BidiStream(
 
 		// If this is the first message in the stream, save off the total responses we need to send
 		// plus whether this should be full or half duplex
-		if firstRecv {
+		if firstRecv { //nolint:nestif
 			responseDefinition = req.ResponseDefinition
 			fullDuplex = req.FullDuplex
 			firstRecv = false

--- a/internal/app/referenceserver/impl.go
+++ b/internal/app/referenceserver/impl.go
@@ -277,9 +277,14 @@ func (s *conformanceServer) BidiStream(
 			if responseDefinition != nil {
 				internal.AddHeaders(responseDefinition.ResponseHeaders, stream.ResponseHeader())
 				internal.AddHeaders(responseDefinition.ResponseTrailers, stream.ResponseTrailer())
-				// Immediately send the headers on the stream so that they can be read by the client
-				if err := stream.Send(nil); err != nil {
-					return connect.NewError(connect.CodeInternal, fmt.Errorf("error sending on stream: %w", err))
+
+				if fullDuplex {
+					// Immediately send the headers on the stream so that they can be read by the client.
+					// We can only do this for full-duplex. For half-duplex operation, we must let client
+					// complete its upload before trying to send anything.
+					if err := stream.Send(nil); err != nil {
+						return connect.NewError(connect.CodeInternal, fmt.Errorf("error sending on stream: %w", err))
+					}
 				}
 
 				// Calculate a response delay if specified
@@ -323,6 +328,13 @@ func (s *conformanceServer) BidiStream(
 			}
 			respNum++
 			reqs = nil
+		}
+	}
+
+	if !fullDuplex {
+		// Now that upload is complete, we can immediately send headers for half-duplex calls.
+		if err := stream.Send(nil); err != nil {
+			return connect.NewError(connect.CodeInternal, fmt.Errorf("error sending on stream: %w", err))
 		}
 	}
 

--- a/internal/app/referenceserver/server.go
+++ b/internal/app/referenceserver/server.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"connectrpc.com/conformance/internal"
@@ -180,7 +181,16 @@ func createServer(req *v1.ServerCompatRequest, listenAddr, tlsCertFile, tlsKeyFi
 		&conformanceServer{},
 		opts...,
 	))
-	handler := http.Handler(mux)
+	handler := http.Handler(http.HandlerFunc(func(respWriter http.ResponseWriter, req *http.Request) {
+		if strings.HasSuffix(req.URL.Path, conformancev1connect.ConformanceServiceBidiStreamProcedure) &&
+			req.ProtoMajor == 1 {
+			// To force support for bidirectional RPC over HTTP 1.1 (for half-duplex testing),
+			// we "trick" the handler into thinking this is HTTP/2. We have to do this because
+			// otherwise, connect-go refuses to handle bidi streams over HTTP 1.1.
+			req.ProtoMajor, req.ProtoMinor = 2, 0
+		}
+		mux.ServeHTTP(respWriter, req)
+	}))
 	if referenceMode {
 		handler = referenceServerChecks(handler, errPrinter)
 	}

--- a/testdata/reference-impls-config.yaml
+++ b/testdata/reference-impls-config.yaml
@@ -19,3 +19,4 @@ features:
   - COMPRESSION_DEFLATE
   - COMPRESSION_SNAPPY
   supportsTlsClientCerts: true
+  supportsHalfDuplexBidiOverHttp1: true


### PR DESCRIPTION
If some other implementation under test wants to enable half-duplex bidi over HTTP 1.1. (which is ostensibly supported by the configuration flags), then we need the reference client and server to actually work that way, too.

Out of the box, connect-go refuses to support bidi streams over HTTP 1.1, because they _might_ be full-duplex, which can't work over HTTP 1.1 (and otherwise can result in inexplicable errors that may look like network partitions or other connection stability issues since they manifest as the client's upload being cancelled as soon as the server starts its reply). So we have to "trick" the connect-go runtime in order to support this. Also, it means that the actual bidi stream handler in the server impl cannot send back headers immediately since, in half-duplex operation, that immediately cancels the client's upload.