### PR TITLE
Prepare for v1.0.0-rc2

### DIFF
--- a/internal/version.go
+++ b/internal/version.go
@@ -17,7 +17,7 @@ package internal
 //nolint:gochecknoglobals
 var (
 	// NB: These are vars instead of consts so they can be changed via -X ldflags.
-	buildVersion       = "v1.0.0-rc2-dev"
+	buildVersion       = "v1.0.0-rc2"
 	buildVersionSuffix = ""
 
 	// Version is the version to report from all binaries.


### PR DESCRIPTION
We've got a lot of new stuff for this release candidate:

1. Newer version of connect-go fixes some bugs in the reference client related to Connect GET protocol and for interpreting errors as "deadline exceeded" for timeout cases.
2. Adds new reference server for validating gRPC-Web protocol, based on grpc/grpc-go + improbable-eng/grpc-web.
3. Adds new test cases for Connect GET(includes change to conformance service).
4. Reference client and server can support half-duplex bidi streams over HTTP 1.1.
5. Runs nearly all test cases using TLS, when client or server under test supports TLS. (Previously, only a handful of TLS-specific cases were run.)
6. Adds new test cases for cancellations (includes change to ClientCompatRequest, for how to instruct client to cancel).
7. Adds new test cases for limits on receiving large messages.
8. Adds more test cases for verifying all error codes.
9. Multiple servers are started in parallel. Reference client also runs multiple RPCs in parallel, greatly speeding up testing (especially since timeout tests are slow).
10. Adds new command-line flags to CLI for test runner: can now specify a particular YAML file with test cases to run, can specify a particular port and TLS cert for the reference server, can specify number of concurrent servers to run and parallelism of reference client when sending RPCs.
11. Reference client can send "raw requests" and reference server can send "raw responses", allowing ultimate control over on the wire request and response encoding, allowing testing of more edge cases than just what the connect-go framework will produce.