### PR TITLE
Test runner needs to add synthetic headers to raw request, too

### DIFF
--- a/internal/app/connectconformance/server_runner_test.go
+++ b/internal/app/connectconformance/server_runner_test.go
@@ -223,14 +223,19 @@ func TestRunTestCasesForServer(t *testing.T) {
 				client.requestHookCount = testCase.svrKillAfter
 				expectedRequests = requests[:testCase.svrKillAfter]
 			}
-			if testCase.isReferenceServer {
-				copyOfRequests := make([]*conformancev1.ClientCompatRequest, len(expectedRequests))
-				// runner adds headers for the reference server
-				for i, req := range expectedRequests {
-					req = proto.Clone(req).(*conformancev1.ClientCompatRequest) //nolint:errcheck,forcetypeassert
-					req.RequestHeaders = append(req.RequestHeaders,
-						&conformancev1.Header{Name: "x-test-case-name", Value: []string{req.TestName}},
-						// we didn't set this above, so they're all zero/unspecified
+			// runner adds headers
+			copyOfRequests := make([]*conformancev1.ClientCompatRequest, len(expectedRequests))
+			for i, req := range expectedRequests {
+				req = proto.Clone(req).(*conformancev1.ClientCompatRequest) //nolint:errcheck,forcetypeassert
+				req.RequestHeaders = append(
+					req.RequestHeaders,
+					&conformancev1.Header{Name: "x-test-case-name", Value: []string{req.TestName}},
+				)
+				// more are set for reference server
+				if testCase.isReferenceServer {
+					// we didn't set these above in request definition, so they're all zero/unspecified
+					req.RequestHeaders = append(
+						req.RequestHeaders,
 						&conformancev1.Header{Name: "x-expect-http-version", Value: []string{"0"}},
 						&conformancev1.Header{Name: "x-expect-http-method", Value: []string{"POST"}},
 						&conformancev1.Header{Name: "x-expect-protocol", Value: []string{"0"}},
@@ -238,10 +243,10 @@ func TestRunTestCasesForServer(t *testing.T) {
 						&conformancev1.Header{Name: "x-expect-compression", Value: []string{"0"}},
 						&conformancev1.Header{Name: "x-expect-tls", Value: []string{"false"}},
 					)
-					copyOfRequests[i] = req
 				}
-				expectedRequests = copyOfRequests
+				copyOfRequests[i] = req
 			}
+			expectedRequests = copyOfRequests
 
 			responsesToSend := responses
 			if testCase.clientCloseAfter > 0 {


### PR DESCRIPTION
These are extra headers used by the reference server, to verify that the client created the request in the expected way. They were previously only added to the structured request that normal clients use. But it also needs to be included in the raw request, for test cases that use raw requests with the reference client.

This also makes it so that the test case name header is _always_ added, even when not running against the reference server. This is useful if tracing through and debugging an implementation -- you can easily tell which test case the request is for because it is always in the request headers.