### PR TITLE
More tracer improvements

### DIFF
--- a/internal/app/connectconformance/connectconformance_test.go
+++ b/internal/app/connectconformance/connectconformance_test.go
@@ -64,8 +64,8 @@ func TestRun(t *testing.T) {
 	allPermutations := testCaseLib.allPermutations(true, true)
 	expectedNumCases := len(allPermutations)
 
-	// 19 test cases as of this writing, but we will likely add more
-	require.GreaterOrEqual(t, expectedNumCases, 40)
+	// 53 test cases as of this writing, but we will likely add more
+	require.GreaterOrEqual(t, expectedNumCases, 53)
 
 	logger := &testPrinter{t}
 	results, err := run(

--- a/internal/app/connectconformance/results.go
+++ b/internal/app/connectconformance/results.go
@@ -90,6 +90,14 @@ func (r *testResults) fetchTrace(testCase string) {
 	if r.tracer == nil {
 		return
 	}
+	if strings.Contains(testCase, grpcImplMarker) ||
+		strings.Contains(testCase, grpcClientImplMarker) ||
+		strings.Contains(testCase, grpcServerImplMarker) {
+		// No trace coming from the grpc-go impls.
+		r.tracer.Clear(testCase)
+		return
+	}
+
 	r.traceWaitGroup.Add(1)
 	go func() {
 		defer r.traceWaitGroup.Done()

--- a/internal/app/connectconformance/test_case_library.go
+++ b/internal/app/connectconformance/test_case_library.go
@@ -37,6 +37,13 @@ const (
 	// response (which echoes back the request data) won't exceed client limit.
 	clientReceiveLimit = 1024 * 1024 // 1 MB
 	serverReceiveLimit = 200 * 1024  // 200 KB
+
+	// these are inserted into test case permutation names for the permutations
+	// of a test case that use the grpc-go implementation of a reference client
+	// or server.
+	grpcImplMarker       = "(grpc impls)"
+	grpcClientImplMarker = "(grpc client impl)"
+	grpcServerImplMarker = "(grpc server impl)"
 )
 
 //nolint:gochecknoglobals
@@ -703,6 +710,64 @@ func generateTestCasePrefix(suite *conformancev1.TestSuite, cfgCase configCase) 
 		components = append(components, fmt.Sprintf("TLS:%v", cfgCase.UseTLS))
 	}
 	return components
+}
+
+func filterGRPCImplTestCases(testCases []*conformancev1.TestCase, clientIsGRPCImpl, serverIsGRPCImpl bool) []*conformancev1.TestCase {
+	if !clientIsGRPCImpl && !serverIsGRPCImpl {
+		return testCases
+	}
+
+	// The gRPC reference impls do not support everything that the main reference impls do.
+	// So we must filter away any test cases that aren't applicable to the gRPC impls.
+
+	filtered := make([]*conformancev1.TestCase, 0, len(testCases))
+	for _, testCase := range testCases {
+		// Client only supports gRPC protocol. Server also supports gRPC-Web.
+		if clientIsGRPCImpl && testCase.Request.Protocol != conformancev1.Protocol_PROTOCOL_GRPC ||
+			testCase.Request.Protocol == conformancev1.Protocol_PROTOCOL_CONNECT {
+			continue
+		}
+
+		if testCase.Request.Protocol == conformancev1.Protocol_PROTOCOL_GRPC_WEB {
+			// grpc-web supports HTTP/1 and HTTP/2
+			switch testCase.Request.HttpVersion {
+			case conformancev1.HTTPVersion_HTTP_VERSION_1, conformancev1.HTTPVersion_HTTP_VERSION_2:
+			default:
+				continue
+			}
+		} else if testCase.Request.HttpVersion != conformancev1.HTTPVersion_HTTP_VERSION_2 {
+			// but grpc only supports HTTP/2
+			continue
+		}
+
+		if testCase.Request.Codec != conformancev1.Codec_CODEC_PROTO {
+			continue
+		}
+		if testCase.Request.Compression != conformancev1.Compression_COMPRESSION_IDENTITY &&
+			testCase.Request.Compression != conformancev1.Compression_COMPRESSION_GZIP {
+			continue
+		}
+
+		if len(testCase.Request.ServerTlsCert) > 0 {
+			continue
+		}
+
+		filteredCase := proto.Clone(testCase).(*conformancev1.TestCase) //nolint:errcheck,forcetypeassert
+		// Insert a path in the test name to indicate that this is against the gRPC impl.
+		dir, base := path.Dir(filteredCase.Request.TestName), path.Base(filteredCase.Request.TestName)
+		var elem string
+		switch {
+		case clientIsGRPCImpl && serverIsGRPCImpl:
+			elem = grpcImplMarker
+		case clientIsGRPCImpl:
+			elem = grpcClientImplMarker
+		case serverIsGRPCImpl:
+			elem = grpcServerImplMarker
+		}
+		filteredCase.Request.TestName = path.Join(dir, elem, base)
+		filtered = append(filtered, filteredCase)
+	}
+	return filtered
 }
 
 func allValues[T ~int32](m map[int32]string) []T {

--- a/internal/app/connectconformance/testsuites/cancellation.yaml
+++ b/internal/app/connectconformance/testsuites/cancellation.yaml
@@ -202,7 +202,9 @@ testCases:
     requestMessages:
     - "@type": type.googleapis.com/connectrpc.conformance.v1.BidiStreamRequest
       responseDefinition:
+        responseDelayMs: 200
         responseData:
+          - "dGVzdCByZXNwb25zZQ=="
           - "dGVzdCByZXNwb25zZQ=="
           - "dGVzdCByZXNwb25zZQ=="
       fullDuplex: true
@@ -216,7 +218,9 @@ testCases:
           requests:
             - "@type": type.googleapis.com/connectrpc.conformance.v1.BidiStreamRequest
               responseDefinition:
+                responseDelayMs: 200
                 responseData:
+                  - "dGVzdCByZXNwb25zZQ=="
                   - "dGVzdCByZXNwb25zZQ=="
                   - "dGVzdCByZXNwb25zZQ=="
               fullDuplex: true

--- a/internal/app/referenceserver/checks.go
+++ b/internal/app/referenceserver/checks.go
@@ -58,13 +58,11 @@ func referenceServerChecks(handler http.Handler, errPrinter internal.Printer) ht
 
 		callsMu.Lock()
 		count := calls[testCaseName]
+		calls[testCaseName] = count + 1
 		callsMu.Unlock()
 		if count > 0 {
 			feedback.Printf("client sent another request (#%d) for the same test case", count+1)
 		}
-		callsMu.Lock()
-		calls[testCaseName] = count + 1
-		callsMu.Unlock()
 
 		if httpVersion, ok := enumValue("x-expect-http-version", req.Header, v1.HTTPVersion(0), feedback); ok {
 			checkHTTPVersion(httpVersion, req, feedback)

--- a/internal/app/referenceserver/checks.go
+++ b/internal/app/referenceserver/checks.go
@@ -44,7 +44,7 @@ const (
 )
 
 func referenceServerChecks(handler http.Handler, errPrinter internal.Printer) http.HandlerFunc {
-	var callsMu sync.Mutex{}
+	var callsMu sync.Mutex
 	calls := map[string]int{}
 	return func(respWriter http.ResponseWriter, req *http.Request) {
 		testCaseName := req.Header.Get("x-test-case-name")

--- a/internal/app/referenceserver/checks.go
+++ b/internal/app/referenceserver/checks.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 
 	"connectrpc.com/conformance/internal"
 	"connectrpc.com/conformance/internal/compression"
@@ -43,6 +44,7 @@ const (
 )
 
 func referenceServerChecks(handler http.Handler, errPrinter internal.Printer) http.HandlerFunc {
+	var callsMu sync.Mutex{}
 	calls := map[string]int{}
 	return func(respWriter http.ResponseWriter, req *http.Request) {
 		testCaseName := req.Header.Get("x-test-case-name")
@@ -54,11 +56,15 @@ func referenceServerChecks(handler http.Handler, errPrinter internal.Printer) ht
 		}
 		feedback := &feedbackPrinter{p: errPrinter, testCaseName: testCaseName}
 
+		callsMu.Lock()
 		count := calls[testCaseName]
+		callsMu.Unlock()
 		if count > 0 {
 			feedback.Printf("client sent another request (#%d) for the same test case", count+1)
 		}
+		callsMu.Lock()
 		calls[testCaseName] = count + 1
+		callsMu.Unlock()
 
 		if httpVersion, ok := enumValue("x-expect-http-version", req.Header, v1.HTTPVersion(0), feedback); ok {
 			checkHTTPVersion(httpVersion, req, feedback)

--- a/internal/tracer/tracer.go
+++ b/internal/tracer/tracer.go
@@ -183,7 +183,7 @@ func (r *RequestStart) print(printer internal.Printer) {
 	}
 	printer.Printf("%s %9.3fms %s %s %s", requestPrefix, r.offsetMillis(), r.Request.Method, urlClone.String(), r.Request.Proto)
 	printHeaders(requestPrefix, r.Request.Header, printer)
-	if r.Request.ContentLength != -1 {
+	if r.Request.ContentLength != -1 && len(r.Request.Header.Values("Content-Length")) == 0 {
 		printer.Printf("%s %11s Content-Length: %d", requestPrefix, "", r.Request.ContentLength)
 	}
 	printer.Printf(requestPrefix)
@@ -253,7 +253,7 @@ func (r *ResponseStart) print(printer internal.Printer) {
 	printer.Printf("%s %9.3fms %s", responsePrefix, r.offsetMillis(), r.Response.Status)
 	printHeaders(responsePrefix, r.Response.Header, printer)
 	if r.Response.ContentLength != -1 && len(r.Response.Header.Values("Content-Length")) == 0 {
-		printer.Printf("%s %11s Content-Length: %d", requestPrefix, "", r.Response.ContentLength)
+		printer.Printf("%s %11s Content-Length: %d", responsePrefix, "", r.Response.ContentLength)
 	}
 	printer.Printf(responsePrefix)
 }


### PR DESCRIPTION
This contains a few fixes/improvements to the tracing stuff:
* Previously, the round tripper would not print the `Content-Length` header. This is because the `net/http` framework removes it from the request/response headers and instead populates the `ContentLength` field (of `http.Request` or `http.Response`). So now, the code will look at the `ContentLength` field and decide if it needs to emit another header line for it in the trace output.
* Previously, after an operation was cancelled, it could still show events that didn't _really_ happen. When the operation is cancelled, either the HTTP/2 stream has been cancelled or the HTTP 1.1 connection has been terminated. Either way, there is no other activity. But the `http.ResponseWriter` that captures trace events would keep trying to add events to the trace anyway.
* In the `testResults` type in the conformance runner, it would wait for all traces to be available (up to 5 seconds) before reporting results (so the printed results can include trace details). But some operations will never have a trace coming -- in particular, the ones that interact with the grpc-go reference client or server. So now the runner is updated so that it won't bother waiting for those traces, since they aren't coming. When running just a few test cases, that include the grpc-go impls, this makes the tests run faster since there's no longer a pause of a few seconds right before reporting results.


This also includes an unrelated change to the cancellation test cases. The "full duplex cancel after close send" case was racy: when the client closed-send, the server would see that, try to complete the RPC, and return the result, all concurrently with the client subsequently trying to cancel the operation. So if the client cancellation is slow enough, the client could get back the RPC result before it send (and the server saw) the cancellation signal. This was happening pretty regularly with the connect-kotlin client. So now, the test case includes some delay, and the server will try to send one more response before completing the RPC. That gives a nice 200 millisecond cushion so that the client should always successfully cancel before the server can finish the RPC.