### PR TITLE
Fix tracing round-tripper

### DIFF
--- a/internal/tracer/middleware.go
+++ b/internal/tracer/middleware.go
@@ -43,9 +43,8 @@ func TracingRoundTripper(transport http.RoundTripper, collector Collector) http.
 			return nil, err
 		}
 		builder.add(&ResponseStart{Response: resp})
-		respClone := *resp
-		respClone.Body = newReader(resp.Header, resp.Body, false, builder, cancel)
-		return &respClone, nil
+		resp.Body = newReader(resp.Header, resp.Body, false, builder, cancel)
+		return resp, nil
 	})
 }
 


### PR DESCRIPTION
Oops. Client middleware can't return a _copy_ of the response because then caller won't get any trailers. They get set on the _original_ response object, when the underlying body reaches EOF. So this broke gRPC protocol (but worked with Connect and gRPC-Web).