### PR TITLE
Add some test cases specific to gRPC-Web using raw requests

### DIFF
--- a/grpcwebclient/known_failing.txt
+++ b/grpcwebclient/known_failing.txt
@@ -1,29 +1,22 @@
-# The gRPC-web client only supports true server streaming when using mode=grpcwebtext, which Connect doesn't support. Server streaming is still possible but all responses are buffered and delivered at the same time
-# so we can't test cancellations after responses. In addition, even cancelling before receiving responses doesn't throw any sort of error, so we can't correctly verify a stream was canceled.
-Cancellation/HTTPVersion:1/Protocol:PROTOCOL_GRPC_WEB/Codec:CODEC_PROTO/Compression:COMPRESSION_IDENTITY/TLS:false/(grpc server impl)/server stream cancel after responses
-Cancellation/HTTPVersion:1/Protocol:PROTOCOL_GRPC_WEB/Codec:CODEC_PROTO/Compression:COMPRESSION_IDENTITY/TLS:false/(grpc server impl)/server stream cancel after zero responses
-Cancellation/HTTPVersion:1/Protocol:PROTOCOL_GRPC_WEB/Codec:CODEC_PROTO/Compression:COMPRESSION_IDENTITY/TLS:false/server stream cancel after responses
-Cancellation/HTTPVersion:1/Protocol:PROTOCOL_GRPC_WEB/Codec:CODEC_PROTO/Compression:COMPRESSION_IDENTITY/TLS:false/server stream cancel after zero responses
+# The gRPC-web client only supports true server streaming when using mode=grpcwebtext, which Connect doesn't
+# support. Server streaming is still possible but all responses are buffered and delivered at the same time so
+# we can't test cancellations after responses. In addition, even cancelling before receiving responses doesn't
+# throw any sort of error, so we can't correctly verify a stream was canceled.
+Cancellation/**/server stream cancel after responses
+Cancellation/**/server stream cancel after zero responses
 
-# There is a bug in the gRPC-web client with handling duplicate trailer metadata for unary success responses.
-# This is because with a regular success response, the trailers are sent as actual trailers, which parses the trailers using this code:
-# https://github.com/grpc/grpc-web/blob/83eec72cc3b6bb4c6d152ace7e246d98b808dd85/javascript/net/grpc/web/grpcwebclientreadablestream.js#L367
-# And since that uses an object keyed to trailer name, it will eliminate dupes.
-# The error responses correctly return duplicate trailer metadata because with errors, the trailers are
-# sent as response headers from the server and these headers are not run through the parseHttp1Headers
-# function linked above. They are instead just set directly onto the returned error's metadata as returned from the server.
-Duplicate Metadata/HTTPVersion:1/Protocol:PROTOCOL_GRPC_WEB/Codec:CODEC_PROTO/Compression:COMPRESSION_IDENTITY/TLS:false/(grpc server impl)/unary success with duplicates
-Duplicate Metadata/HTTPVersion:1/Protocol:PROTOCOL_GRPC_WEB/Codec:CODEC_PROTO/Compression:COMPRESSION_IDENTITY/TLS:false/unary success with duplicates
-
-# There is a bug in the gRPC-web client with handling duplicate trailer metadata for all server streaming responses.
-# This is because trailers are sent as actual trailers and which the client parses trailers using this code:
-# https://github.com/grpc/grpc-web/blob/83eec72cc3b6bb4c6d152ace7e246d98b808dd85/javascript/net/grpc/web/grpcwebclientreadablestream.js#L367
-# And since that uses an object keyed to trailer name, it will eliminate dupes.
-Duplicate Metadata/HTTPVersion:1/Protocol:PROTOCOL_GRPC_WEB/Codec:CODEC_PROTO/Compression:COMPRESSION_IDENTITY/TLS:false/(grpc server impl)/server stream error with no responses and duplicates
-Duplicate Metadata/HTTPVersion:1/Protocol:PROTOCOL_GRPC_WEB/Codec:CODEC_PROTO/Compression:COMPRESSION_IDENTITY/TLS:false/(grpc server impl)/server stream error with responses and duplicates
-Duplicate Metadata/HTTPVersion:1/Protocol:PROTOCOL_GRPC_WEB/Codec:CODEC_PROTO/Compression:COMPRESSION_IDENTITY/TLS:false/(grpc server impl)/server stream no response with duplicates
-Duplicate Metadata/HTTPVersion:1/Protocol:PROTOCOL_GRPC_WEB/Codec:CODEC_PROTO/Compression:COMPRESSION_IDENTITY/TLS:false/(grpc server impl)/server stream success with duplicates
-Duplicate Metadata/HTTPVersion:1/Protocol:PROTOCOL_GRPC_WEB/Codec:CODEC_PROTO/Compression:COMPRESSION_IDENTITY/TLS:false/server stream error with no responses and duplicates
-Duplicate Metadata/HTTPVersion:1/Protocol:PROTOCOL_GRPC_WEB/Codec:CODEC_PROTO/Compression:COMPRESSION_IDENTITY/TLS:false/server stream error with responses and duplicates
-Duplicate Metadata/HTTPVersion:1/Protocol:PROTOCOL_GRPC_WEB/Codec:CODEC_PROTO/Compression:COMPRESSION_IDENTITY/TLS:false/server stream no response with duplicates
-Duplicate Metadata/HTTPVersion:1/Protocol:PROTOCOL_GRPC_WEB/Codec:CODEC_PROTO/Compression:COMPRESSION_IDENTITY/TLS:false/server stream success with duplicates
+# There is a bug in the gRPC-web client with handling duplicate trailer metadata for responses where trailers
+# are encoded in the body, which are parsed using this code:
+#   https://github.com/grpc/grpc-web/blob/83eec72cc3b6bb4c6d152ace7e246d98b808dd85/javascript/net/grpc/web/grpcwebclientreadablestream.js#L367
+# And since that uses an object keyed to trailer name, it will eliminate dupes. Responses that use a
+# "trailers only" response can succeed, however, because those trailers are actually encoded as HTTP
+# headers, which are not parsed with the above code.
+Duplicate Metadata/**/unary success with duplicates
+Duplicate Metadata/**/server stream error with no responses and duplicates
+Duplicate Metadata/**/server stream error with responses and duplicates
+Duplicate Metadata/**/server stream no response with duplicates
+Duplicate Metadata/**/server stream success with duplicates
+gRPC Web Client/**/unary trailers in body, duplicates
+gRPC Web Client/**/server stream trailers in body, duplicates
+gRPC Web Client/**/unary trailers in body, mixed case
+gRPC Web Client/**/server stream trailers in body, mixed case

--- a/internal/app/connectconformance/test_case_library.go
+++ b/internal/app/connectconformance/test_case_library.go
@@ -756,6 +756,13 @@ func filterGRPCImplTestCases(testCases []*conformancev1.TestCase, clientIsGRPCIm
 			continue
 		}
 
+		if testCase.Request.RawRequest != nil && clientIsGRPCImpl {
+			continue
+		}
+		if hasRawResponse(testCase.Request.RequestMessages) && serverIsGRPCImpl {
+			continue
+		}
+
 		filteredCase := proto.Clone(testCase).(*conformancev1.TestCase) //nolint:errcheck,forcetypeassert
 		// Insert a path in the test name to indicate that this is against the gRPC impl.
 		dir, base := path.Dir(filteredCase.Request.TestName), path.Base(filteredCase.Request.TestName)

--- a/internal/app/connectconformance/testsuites/grpc_web_client.yaml
+++ b/internal/app/connectconformance/testsuites/grpc_web_client.yaml
@@ -1,0 +1,362 @@
+name: gRPC Web Client
+mode: TEST_MODE_CLIENT
+relevantProtocols:
+  - PROTOCOL_GRPC_WEB
+relevantCodecs:
+  - CODEC_PROTO
+relevantCompressions:
+  - COMPRESSION_IDENTITY
+# These tests verify that a gRPC-Web client can handle trailers in the body with
+# no response, trailers-only responses (trailers in headers), and trailers with
+# different cases (in addition to the "standard" all lower-case).
+testCases:
+
+# Trailers and status are in body (no other response messages)
+  - request:
+      testName: unary trailers in body
+      service: connectrpc.conformance.v1.ConformanceService
+      method: Unary
+      streamType: STREAM_TYPE_UNARY
+      requestMessages:
+        - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
+          responseDefinition:
+            rawResponse:
+              status_code: 200
+              headers:
+                - name: "access-control-allow-origin"
+                  value: [ "*" ]
+                - name: "access-control-expose-headers"
+                  value: [ "*" ]
+                - name: content-type
+                  value: [ "application/grpc-web" ]
+                - name: x-custom-header
+                  value: [ "foo" ]
+              stream:
+                items:
+                  - flags: 128
+                    payload:
+                      text: "grpc-status: 9\r\ngrpc-message: error\r\nx-custom-trailer: bing\r\n"
+    expectedResponse:
+      responseHeaders:
+        - name: x-custom-header
+          value: [ "foo" ]
+      error:
+        code: 9
+        message: error
+      responseTrailers:
+        - name: x-custom-trailer
+          value: [ "bing" ]
+  - request:
+      testName: unary trailers in body, mixed case
+      service: connectrpc.conformance.v1.ConformanceService
+      method: Unary
+      streamType: STREAM_TYPE_UNARY
+      requestMessages:
+        - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
+          responseDefinition:
+            rawResponse:
+              status_code: 200
+              headers:
+                - name: "access-control-allow-origin"
+                  value: [ "*" ]
+                - name: "access-control-expose-headers"
+                  value: [ "*" ]
+                - name: content-type
+                  value: [ "application/grpc-web" ]
+                - name: x-custom-header
+                  value: [ "foo" ]
+              stream:
+                items:
+                  - flags: 128
+                    payload:
+                      text: "Grpc-Status: 9\r\ngRPC-Message: error\r\nx-Custom-Trailer: bing\r\n"
+    expectedResponse:
+      responseHeaders:
+        - name: x-custom-header
+          value: [ "foo" ]
+      error:
+        code: 9
+        message: error
+      responseTrailers:
+        - name: x-custom-trailer
+          value: [ "bing" ]
+  - request:
+      testName: unary trailers in body, duplicates
+      service: connectrpc.conformance.v1.ConformanceService
+      method: Unary
+      streamType: STREAM_TYPE_UNARY
+      requestMessages:
+        - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
+          responseDefinition:
+            rawResponse:
+              status_code: 200
+              headers:
+                - name: "access-control-allow-origin"
+                  value: [ "*" ]
+                - name: "access-control-expose-headers"
+                  value: [ "*" ]
+                - name: content-type
+                  value: [ "application/grpc-web" ]
+                - name: x-custom-header
+                  value: [ "foo", "bar", "baz" ]
+              stream:
+                items:
+                  - flags: 128
+                    payload:
+                      text: "grpc-status: 9\r\ngrpc-message: error\r\nx-custom-trailer: bing\r\nx-custom-trailer: quuz\r\n"
+    expectedResponse:
+      responseHeaders:
+      - name: x-custom-header
+        value: [ "foo", "bar", "baz" ]
+      error:
+        code: 9
+        message: error
+      responseTrailers:
+      - name: x-custom-trailer
+        value: [ "bing", "quuz" ]
+
+  - request:
+      testName: server stream trailers in body
+      service: connectrpc.conformance.v1.ConformanceService
+      method: ServerStream
+      streamType: STREAM_TYPE_SERVER_STREAM
+      requestMessages:
+        - "@type": type.googleapis.com/connectrpc.conformance.v1.ServerStreamRequest
+          responseDefinition:
+            rawResponse:
+              status_code: 200
+              headers:
+                - name: "access-control-allow-origin"
+                  value: [ "*" ]
+                - name: "access-control-expose-headers"
+                  value: [ "*" ]
+                - name: content-type
+                  value: [ "application/grpc-web" ]
+                - name: x-custom-header
+                  value: [ "foo" ]
+              stream:
+                items:
+                  - flags: 128
+                    payload:
+                      text: "grpc-status: 9\r\ngrpc-message: error\r\nx-custom-trailer: bing\r\n"
+    expectedResponse:
+      responseHeaders:
+        - name: x-custom-header
+          value: [ "foo" ]
+      error:
+        code: 9
+        message: error
+      responseTrailers:
+        - name: x-custom-trailer
+          value: [ "bing" ]
+  - request:
+      testName: server stream trailers in body, mixed case
+      service: connectrpc.conformance.v1.ConformanceService
+      method: ServerStream
+      streamType: STREAM_TYPE_SERVER_STREAM
+      requestMessages:
+        - "@type": type.googleapis.com/connectrpc.conformance.v1.ServerStreamRequest
+          responseDefinition:
+            rawResponse:
+              status_code: 200
+              headers:
+                - name: "access-control-allow-origin"
+                  value: [ "*" ]
+                - name: "access-control-expose-headers"
+                  value: [ "*" ]
+                - name: content-type
+                  value: [ "application/grpc-web" ]
+                - name: x-custom-header
+                  value: [ "foo" ]
+              stream:
+                items:
+                  - flags: 128
+                    payload:
+                      text: "grpc-status: 9\r\ngRPC-Message: error\r\nx-Custom-Trailer: bing\r\n"
+    expectedResponse:
+      responseHeaders:
+        - name: x-custom-header
+          value: [ "foo" ]
+      error:
+        code: 9
+        message: error
+      responseTrailers:
+        - name: x-custom-trailer
+          value: [ "bing" ]
+  - request:
+      testName: server stream trailers in body, duplicates
+      service: connectrpc.conformance.v1.ConformanceService
+      method: ServerStream
+      streamType: STREAM_TYPE_SERVER_STREAM
+      requestMessages:
+        - "@type": type.googleapis.com/connectrpc.conformance.v1.ServerStreamRequest
+          responseDefinition:
+            rawResponse:
+              status_code: 200
+              headers:
+                - name: "access-control-allow-origin"
+                  value: [ "*" ]
+                - name: "access-control-expose-headers"
+                  value: [ "*" ]
+                - name: content-type
+                  value: [ "application/grpc-web" ]
+                - name: x-custom-header
+                  value: [ "foo", "bar", "baz" ]
+              stream:
+                items:
+                  - flags: 128
+                    payload:
+                      text: "grpc-status: 9\r\ngrpc-message: error\r\nx-custom-trailer: bing\r\nx-custom-trailer: quuz\r\n"
+    expectedResponse:
+      responseHeaders:
+        - name: x-custom-header
+          value: [ "foo", "bar", "baz" ]
+      error:
+        code: 9
+        message: error
+      responseTrailers:
+        - name: x-custom-trailer
+          value: [ "bing", "quuz" ]
+
+# Trailers-only responses, where status and trailers are in HTTP headers
+  - request:
+      testName: unary trailers in headers
+      service: connectrpc.conformance.v1.ConformanceService
+      method: Unary
+      streamType: STREAM_TYPE_UNARY
+      requestMessages:
+        - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
+          responseDefinition:
+            rawResponse:
+              status_code: 200
+              headers:
+                - name: "access-control-allow-origin"
+                  value: [ "*" ]
+                - name: "access-control-expose-headers"
+                  value: [ "*" ]
+                - name: content-type
+                  value: [ "application/grpc-web" ]
+                - name: x-custom-header
+                  value: [ "foo" ]
+                - name: x-custom-trailer
+                  value: [ "bing" ]
+                - name: grpc-status
+                  value: [ "9" ]
+                - name: grpc-message
+                  value: [ "error" ]
+    expectedResponse:
+      responseHeaders:
+        - name: x-custom-header
+          value: [ "foo" ]
+      error:
+        code: 9
+        message: error
+      responseTrailers:
+        - name: x-custom-trailer
+          value: [ "bing" ]
+  - request:
+      testName: unary trailers in headers, duplicates
+      service: connectrpc.conformance.v1.ConformanceService
+      method: Unary
+      streamType: STREAM_TYPE_UNARY
+      requestMessages:
+        - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
+          responseDefinition:
+            rawResponse:
+              status_code: 200
+              headers:
+                - name: "access-control-allow-origin"
+                  value: [ "*" ]
+                - name: "access-control-expose-headers"
+                  value: [ "*" ]
+                - name: content-type
+                  value: [ "application/grpc-web" ]
+                - name: x-custom-header
+                  value: [ "foo", "bar", "baz" ]
+                - name: x-custom-trailer
+                  value: [ "bing", "quuz" ]
+                - name: grpc-status
+                  value: [ "9" ]
+                - name: grpc-message
+                  value: [ "error" ]
+    expectedResponse:
+      responseHeaders:
+        - name: x-custom-header
+          value: [ "foo", "bar", "baz" ]
+      error:
+        code: 9
+        message: error
+      responseTrailers:
+        - name: x-custom-trailer
+          value: [ "bing", "quuz" ]
+
+  - request:
+      testName: server stream trailers in headers
+      service: connectrpc.conformance.v1.ConformanceService
+      method: ServerStream
+      streamType: STREAM_TYPE_SERVER_STREAM
+      requestMessages:
+        - "@type": type.googleapis.com/connectrpc.conformance.v1.ServerStreamRequest
+          responseDefinition:
+            rawResponse:
+              status_code: 200
+              headers:
+                - name: "access-control-allow-origin"
+                  value: [ "*" ]
+                - name: "access-control-expose-headers"
+                  value: [ "*" ]
+                - name: content-type
+                  value: [ "application/grpc-web" ]
+                - name: x-custom-header
+                  value: [ "foo" ]
+                - name: x-custom-trailer
+                  value: [ "bing" ]
+                - name: grpc-status
+                  value: [ "9" ]
+                - name: grpc-message
+                  value: [ "error" ]
+    expectedResponse:
+      responseHeaders:
+        - name: x-custom-header
+          value: [ "foo" ]
+      error:
+        code: 9
+        message: error
+      responseTrailers:
+        - name: x-custom-trailer
+          value: [ "bing" ]
+  - request:
+      testName: server stream trailers in headers, duplicates
+      service: connectrpc.conformance.v1.ConformanceService
+      method: ServerStream
+      streamType: STREAM_TYPE_SERVER_STREAM
+      requestMessages:
+        - "@type": type.googleapis.com/connectrpc.conformance.v1.ServerStreamRequest
+          responseDefinition:
+            rawResponse:
+              status_code: 200
+              headers:
+                - name: "access-control-allow-origin"
+                  value: [ "*" ]
+                - name: "access-control-expose-headers"
+                  value: [ "*" ]
+                - name: content-type
+                  value: [ "application/grpc-web" ]
+                - name: x-custom-header
+                  value: [ "foo", "bar", "baz" ]
+                - name: x-custom-trailer
+                  value: [ "bing", "quuz" ]
+                - name: grpc-status
+                  value: [ "9" ]
+                - name: grpc-message
+                  value: [ "error" ]
+    expectedResponse:
+      responseHeaders:
+        - name: x-custom-header
+          value: [ "foo", "bar", "baz" ]
+      error:
+        code: 9
+        message: error
+      responseTrailers:
+        - name: x-custom-trailer
+          value: [ "bing", "quuz" ]


### PR DESCRIPTION
This also includes a bug fix, to skip the grpc-go reference implementations when using a raw request or response, since those implementations don't understand those fields.

These are _sort of_ covered in other test cases, but these provide explicit control over the shape of the response (i.e. using either trailers in the body or trailers-only response where trailers are in headers) since they use a raw request.