### PR TITLE
Relaxes assertions on query parameters

### DIFF
--- a/internal/app/connectconformance/results.go
+++ b/internal/app/connectconformance/results.go
@@ -159,6 +159,9 @@ func (r *testResults) failed(testCase string, err *conformancev1.ClientErrorResu
 func (r *testResults) assert(testCase string, expected, actual *conformancev1.ClientResponseResult) {
 	var errs multiErrors
 
+	errs = append(errs, checkError(expected.Error, actual.Error)...)
+	errs = append(errs, checkPayloads(expected.Payloads, actual.Payloads)...)
+
 	// TODO - This check is for trailers-only and should really only apply to gRPC and gRPC-Web protocols.
 	// Previously, it checked for error != nil, which is compliant with gRPC. But gRPC-Web does trailers-only
 	// responses with no errors also.
@@ -187,9 +190,6 @@ func (r *testResults) assert(testCase string, expected, actual *conformancev1.Cl
 		errs = append(errs, checkHeaders("response headers", expected.ResponseHeaders, actual.ResponseHeaders)...)
 		errs = append(errs, checkHeaders("response trailers", expected.ResponseTrailers, actual.ResponseTrailers)...)
 	}
-
-	errs = append(errs, checkPayloads(expected.Payloads, actual.Payloads)...)
-	errs = append(errs, checkError(expected.Error, actual.Error)...)
 
 	// If client didn't provide actual raw error, we skip this check.
 	if expected.ConnectErrorRaw != nil && actual.ConnectErrorRaw != nil {
@@ -403,12 +403,12 @@ func checkRequestInfo(expected, actual *conformancev1.ConformancePayload_Request
 			if actual == nil || actual.TimeoutMs == nil {
 				errs = append(errs, fmt.Errorf("server did not echo back a timeout but one was expected (%d ms)", expected.GetTimeoutMs()))
 			} else {
-				max := expected.GetTimeoutMs()
-				min := max - timeoutCheckGracePeriodMillis
-				if min < 0 {
-					min = 0
+				maxAllowed := expected.GetTimeoutMs()
+				minAllowed := maxAllowed - timeoutCheckGracePeriodMillis
+				if minAllowed < 0 {
+					minAllowed = 0
 				}
-				if actual.GetTimeoutMs() > max || actual.GetTimeoutMs() < min {
+				if actual.GetTimeoutMs() > maxAllowed || actual.GetTimeoutMs() < minAllowed {
 					errs = append(errs, fmt.Errorf("server echoed back a timeout (%d ms) that did not match expected (%d ms)", actual.GetTimeoutMs(), expected.GetTimeoutMs()))
 				}
 			}

--- a/internal/app/connectconformance/results_test.go
+++ b/internal/app/connectconformance/results_test.go
@@ -671,15 +671,15 @@ func TestResults_Assert_ReportsAllErrors(t *testing.T) {
 			}`,
 			// It tries to describe everything wrong, all in one shot.
 			expectedErrors: []string{
-				`actual response headers missing "abc"`,
-				`actual response trailers missing "xyz"`,
+				`expecting an error but received none`,
 				`expecting 3 response messages but instead got 1`,
 				`response #1: expecting data 69b71d79f821, got d76df8`,
 				`actual request headers missing "foo"`,
 				`server did not echo back a timeout but one was expected (12345 ms)`,
 				`expecting 1 request messages to be described but instead got 2`,
 				`request #1: did not survive round-trip`,
-				`expecting an error but received none`,
+				`actual response headers missing "abc"`,
+				`actual response trailers missing "xyz"`,
 			},
 		},
 	}

--- a/internal/app/connectconformance/test_case_library_test.go
+++ b/internal/app/connectconformance/test_case_library_test.go
@@ -15,11 +15,9 @@
 package connectconformance
 
 import (
-	"encoding/base64"
 	"sort"
 	"testing"
 
-	"connectrpc.com/conformance/internal"
 	"connectrpc.com/conformance/internal/app/connectconformance/testsuites"
 	conformancev1 "connectrpc.com/conformance/internal/gen/proto/go/connectrpc/conformance/v1"
 	"connectrpc.com/connect"
@@ -923,10 +921,6 @@ func TestPopulateExpectedResponse(t *testing.T) {
 							ConnectGetInfo: &conformancev1.ConformancePayload_ConnectGetInfo{
 								QueryParams: []*conformancev1.Header{
 									{
-										Name:  "message",
-										Value: []string{marshalToString(t, true, unarySuccessReq)},
-									},
-									{
 										Name:  "encoding",
 										Value: []string{"json"},
 									},
@@ -961,10 +955,6 @@ func TestPopulateExpectedResponse(t *testing.T) {
 							Requests:       asAnySlice(t, unarySuccessReq),
 							ConnectGetInfo: &conformancev1.ConformancePayload_ConnectGetInfo{
 								QueryParams: []*conformancev1.Header{
-									{
-										Name:  "message",
-										Value: []string{marshalToString(t, false, unarySuccessReq)},
-									},
 									{
 										Name:  "encoding",
 										Value: []string{"proto"},
@@ -1001,10 +991,6 @@ func TestPopulateExpectedResponse(t *testing.T) {
 						ConnectGetInfo: &conformancev1.ConformancePayload_ConnectGetInfo{
 							QueryParams: []*conformancev1.Header{
 								{
-									Name:  "message",
-									Value: []string{marshalToString(t, true, unaryErrorReq)},
-								},
-								{
 									Name:  "encoding",
 									Value: []string{"json"},
 								},
@@ -1038,10 +1024,6 @@ func TestPopulateExpectedResponse(t *testing.T) {
 						Requests:       asAnySlice(t, unaryErrorReq),
 						ConnectGetInfo: &conformancev1.ConformancePayload_ConnectGetInfo{
 							QueryParams: []*conformancev1.Header{
-								{
-									Name:  "message",
-									Value: []string{marshalToString(t, false, unaryErrorReq)},
-								},
 								{
 									Name:  "encoding",
 									Value: []string{"proto"},
@@ -1790,24 +1772,4 @@ func asAnySlice(t *testing.T, msgs ...proto.Message) []*anypb.Any {
 		arr = append(arr, asAny)
 	}
 	return arr
-}
-
-// marshalToString marshals the given proto message to a string mirroring the
-// logic that Connect specifies for GET requests.
-// If asJSON is true, the message is first marshalled to JSON and the bytes are
-// then converted to a string.
-// If asJSON is false, the message is marshalled to binary and the bytes are then
-// base64-encoded as a string.
-func marshalToString(t *testing.T, asJSON bool, msg proto.Message) string {
-	t.Helper()
-	codec := internal.NewCodec(asJSON)
-
-	bytes, err := codec.MarshalStable(msg)
-	require.NoError(t, err)
-
-	if asJSON {
-		return string(bytes)
-	}
-
-	return base64.RawURLEncoding.EncodeToString(bytes)
 }


### PR DESCRIPTION
Previously, this would add an expected query parameter for the `message` param, with an encoded value. But the problem is that not all clients would necessarily encode the message in exactly the same way, and that's fine. Some will choose to base64-encode (which is usually more efficient with binary payloads). Also, there's no _canonical_ protobuf binary format, so there could be subtle differences in the byte output, even for equivalent messages. Finally, there's no _canonical_ encoding for compressed payloads -- different default compression settings or other subtle differences in implementation can lead to more than one valid compressed encoding of the same data.