### PR TITLE
Verify deadlines are correctly propagated

### DIFF
--- a/internal/app/connectconformance/results.go
+++ b/internal/app/connectconformance/results.go
@@ -36,7 +36,7 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
-const timeoutCheckGracePeriodMillis = 500
+const timeoutCheckGracePeriodMillis = 100
 
 // testResults represents the results of running conformance tests. It accumulates
 // the state of passed and failed test cases and also reports failures to a given

--- a/internal/app/connectconformance/testsuites/deadline-propagation.yaml
+++ b/internal/app/connectconformance/testsuites/deadline-propagation.yaml
@@ -1,0 +1,55 @@
+name: Deadline Propagation
+# These are similar to the timeout tests except that they do not actually
+# timeout. Instead these verify that the RPCs complete so that we can check
+# (in the server responses) that the deadline was correctly propagated to
+# the backend via header metadata.
+testCases:
+  - request:
+      testName: unary
+      service: connectrpc.conformance.v1.ConformanceService
+      method: Unary
+      streamType: STREAM_TYPE_UNARY
+      timeoutMs: 2000
+      requestMessages:
+        - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
+          responseDefinition:
+            responseData: "dGVzdCByZXNwb25zZQ=="
+  - request:
+      testName: client stream
+      service: connectrpc.conformance.v1.ConformanceService
+      method: ClientStream
+      streamType: STREAM_TYPE_CLIENT_STREAM
+      timeoutMs: 2000
+      requestMessages:
+        - "@type": type.googleapis.com/connectrpc.conformance.v1.ClientStreamRequest
+          responseDefinition:
+            responseData: "dGVzdCByZXNwb25zZQ=="
+        - "@type": type.googleapis.com/connectrpc.conformance.v1.ClientStreamRequest
+          requestData: "dGVzdCByZXNwb25zZQ=="
+  - request:
+      testName: server stream
+      service: connectrpc.conformance.v1.ConformanceService
+      method: ServerStream
+      streamType: STREAM_TYPE_SERVER_STREAM
+      timeoutMs: 2000
+      requestMessages:
+        - "@type": type.googleapis.com/connectrpc.conformance.v1.ServerStreamRequest
+          responseDefinition:
+            responseData:
+              - "dGVzdCByZXNwb25zZQ=="
+              - "dGVzdCByZXNwb25zZQ=="
+  - request:
+      testName: bidi stream
+      service: connectrpc.conformance.v1.ConformanceService
+      method: BidiStream
+      streamType: STREAM_TYPE_FULL_DUPLEX_BIDI_STREAM
+      timeoutMs: 2000
+      requestMessages:
+        - "@type": type.googleapis.com/connectrpc.conformance.v1.BidiStreamRequest
+          responseDefinition:
+            responseData:
+              - "dGVzdCByZXNwb25zZQ=="
+              - "dGVzdCByZXNwb25zZQ=="
+          fullDuplex: true
+        - "@type": type.googleapis.com/connectrpc.conformance.v1.BidiStreamRequest
+          requestData: "dGVzdCByZXNwb25zZQ=="


### PR DESCRIPTION
I noticed in the code the other day that we _do_ verify the timeout, by having the server echo back the timeout it observed and then having the test runner check that against the timeout that the client should have sent.

So I was surprised that this didn't manifest as failed tests in connect-kotlin, which I now know (from getting pretty deep into the code) does not work -- it simply never tried to set deadline headers. (And it's not easy to add with it's current implementation structure, so I'll probably leave it as "known failing" until we can fix other problems with timeouts.)

Anyhow, when digging into why this didn't tickle any failure in connect-kotlin, it's because the only test cases that actually set the timeout always fail with a timeout error (so the client never gets back a response and cannot see the timeout that the server observed).

So this adds a new test suite to verify deadlines are correctly propagated. And it also required some fixes in the grpc-go server implementation in this repo, which was not reporting them correctly, which caused failures in the `make runservertests` target.