### PR TITLE
Reference server checks that there are no request trailers

### DIFF
--- a/internal/app/referenceserver/checks.go
+++ b/internal/app/referenceserver/checks.go
@@ -84,6 +84,13 @@ func referenceServerChecks(handler http.Handler, errPrinter internal.Printer) ht
 		}
 
 		handler.ServeHTTP(respWriter, req)
+
+		// Make sure request body is drained so we can look for any trailers.
+		// This is just best effort since the operation could have already been canceled.
+		_, _ = io.Copy(io.Discard, req.Body)
+		if len(req.Trailer) > 0 {
+			feedback.Printf("request should NOT include any HTTP trailers (%d trailer keys found)", len(req.Trailer))
+		}
 	}
 }
 


### PR DESCRIPTION
While trailers are present in gRPC responses, they should not be present in any _requests_. So this just adds a small check to the reference server so that it can complain and fail a test case if request trailers were observed.