### PR TITLE
Add strict checks to reference client to validate a server's connect error and end stream JSON

### DIFF
--- a/internal/app/referenceclient/wire_details.go
+++ b/internal/app/referenceclient/wire_details.go
@@ -17,18 +17,27 @@ package referenceclient
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
 	"connectrpc.com/conformance/internal"
 	"connectrpc.com/conformance/internal/tracer"
+	"connectrpc.com/connect"
+	"github.com/google/go-cmp/cmp"
+	"golang.org/x/exp/constraints"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/anypb"
 )
-
-// The key associated with the wire details information stored in context.
-type wireCtxKey struct{}
 
 type wireCaptureTransport struct {
 	Transport http.RoundTripper
@@ -88,6 +97,26 @@ type wireWrapper struct {
 	buf *bytes.Buffer
 }
 
+type connectError struct {
+	Code    *string           `json:"code"`
+	Message *string           `json:"message"`
+	Details []json.RawMessage `json:"details"`
+}
+
+type connectErrorDetail struct {
+	Type  *string         `json:"type"`
+	Value *string         `json:"value"`
+	Debug json.RawMessage `json:"debug"`
+}
+
+type connectEndStream struct {
+	Error    json.RawMessage     `json:"error"`
+	Metadata map[string][]string `json:"metadata"`
+}
+
+// The key associated with the wire details information stored in context.
+type wireCtxKey struct{}
+
 // withWireCapture returns a new context which will contain wire details during
 // a roundtrip. Use examineWireDetails to extract the details after the operation
 // completes.
@@ -141,7 +170,7 @@ func examineWireDetails(ctx context.Context, printer internal.Printer) (statusCo
 	// Check end-stream and/or error JSON data in the response.
 	contentType := trace.Response.Header.Get("content-type")
 	switch {
-	case isUnaryJSONError(contentType, statusCode):
+	case isUnaryJSONError(contentType, trace.Response.StatusCode):
 		// If this is a unary request that returned an error, then use the entire
 		// response body as the wire error details.
 		examineConnectError(wrapper.buf.Bytes(), printer)
@@ -189,7 +218,7 @@ func (t *wireTracer) Complete(trace tracer.Trace) {
 // isUnaryJSONError returns whether the given content type and HTTP status code
 // represents a unary JSON error.
 func isUnaryJSONError(contentType string, statusCode int) bool {
-	return contentType == "application/json" && statusCode != 200
+	return contentType == "application/json" && statusCode != http.StatusOK
 }
 
 // getBodyEndStream returns the contents of any end-stream message in the trace.
@@ -206,12 +235,255 @@ func getBodyEndStream(trace tracer.Trace) (string, bool) {
 	return "", false
 }
 
-func examineConnectError(_ json.RawMessage, _ internal.Printer) {
-	// TODO
+func examineConnectError(errJSON json.RawMessage, printer internal.Printer) {
+	var connErr *connectError
+	if err := json.Unmarshal(errJSON, &connErr); err != nil {
+		printer.Printf("connect error JSON is malformed: %v", err)
+		return
+	}
+	if connErr == nil {
+		printer.Printf("connect error JSON: expecting an object but got <nil>")
+		return
+	}
+	// Extra checks, since encoding/json above is lenient.
+	if _, err := checkNoDuplicateKeys("", json.NewDecoder(bytes.NewReader(errJSON))); err != nil {
+		printer.Printf("connect error JSON: %v", err)
+		return
+	}
+	var asAny map[string]any
+	if err := json.Unmarshal(errJSON, &asAny); err != nil {
+		// note: since above unmarshal step succeeded, this should never fail
+		printer.Printf("connect error JSON is malformed: %v", err)
+		return
+	}
+	var hasCode, hasDetails bool
+	for _, key := range sortedKeys(asAny) {
+		val := asAny[key]
+		switch key {
+		case "code":
+			hasCode = true
+			strVal, ok := val.(string)
+			if !ok {
+				printer.Printf(`connect error JSON: value for key "code" is a %T instead of a string`, val)
+				break
+			}
+			var found bool
+			// Valid RPC codes range from 1 to 16. (Zero means no an error; negative and >16 are illegal values.)
+			for code := connect.Code(1); code <= 16; code++ {
+				if strVal == code.String() {
+					found = true
+					break
+				}
+			}
+			if !found {
+				printer.Printf(`connect error JSON: value for key "code" is not a recognized error code name: %q`, val)
+			}
+		case "message":
+			if _, isStr := val.(string); !isStr {
+				printer.Printf(`connect error JSON: value for key "message" is a %T instead of a string`, val)
+			}
+		case "details":
+			hasDetails = true
+			if _, isSlice := val.([]any); !isSlice {
+				printer.Printf(`connect error JSON: value for key "details" is a %T instead of a slice`, val)
+			}
+		default:
+			printer.Printf("connect error JSON: invalid key %q", key)
+		}
+	}
+	// There is one required field.
+	if !hasCode {
+		printer.Printf(`connect error JSON: missing required key "code"`)
+	}
+	// Also check enclosed details.
+	if hasDetails {
+		for i, detail := range connErr.Details {
+			examineConnectErrorDetail(i, detail, printer)
+		}
+	}
 }
 
-func examineConnectEndStream(_ json.RawMessage, _ internal.Printer) {
-	// TODO
+func examineConnectErrorDetail(i int, detailJSON json.RawMessage, printer internal.Printer) {
+	var detail *connectErrorDetail
+	if err := json.Unmarshal(detailJSON, &detail); err != nil {
+		printer.Printf("connect error JSON: details[%d] is malformed: %v", i, err)
+		return
+	}
+	if detail == nil {
+		printer.Printf("connect error JSON: details[%d]: expecting an object but got <nil>", i)
+		return
+	}
+	// Extra checks, since encoding/json above is lenient.
+	var asAny map[string]any
+	if err := json.Unmarshal(detailJSON, &asAny); err != nil {
+		// note: since above unmarshal step succeeded, this should never fail
+		printer.Printf("connect error JSON: details[%d] is malformed: %v", i, err)
+		return
+	}
+	var decodedVal []byte
+	var hasType, hasValue, hasDebug bool
+	for _, key := range sortedKeys(asAny) {
+		val := asAny[key]
+		switch key {
+		case "type":
+			hasType = true
+			str, ok := val.(string)
+			if !ok {
+				printer.Printf(`connect error JSON: details[%d]: value for key "type" is a %T instead of a string`, i, val)
+				break
+			}
+			if !protoreflect.FullName(str).IsValid() {
+				printer.Printf(`connect error JSON: details[%d]: value for key "type", %q, is not a valid type name`, i, val)
+				break
+			}
+		case "value":
+			hasValue = true
+			str, ok := val.(string)
+			if !ok {
+				printer.Printf(`connect error JSON: details[%d]: value for key "value" is a %T instead of a string`, i, val)
+				break
+			}
+			decoded, err := base64.RawStdEncoding.DecodeString(str)
+			if err != nil {
+				printer.Printf(`connect error JSON: details[%d]: value for key "value", %q, is not valid unpadded base64-encoding: %v`, i, val, err)
+				break
+			}
+			decodedVal = decoded
+		case "debug":
+			hasDebug = len(detail.Debug) > 0
+			// Since a detail message could be a google.protobuf.Value, it
+			// could technically be *any* kind of JSON value here. So no
+			// further checks here. We'll check below that the debug field
+			// (if present) actually agrees with the value field.
+		default:
+			printer.Printf("connect error JSON: details[%d]: invalid key %q", i, key)
+		}
+	}
+	// Two required fields:
+	if !hasType {
+		printer.Printf(`connect error JSON: details[%d]: missing required key "type"`, i)
+	}
+	if !hasValue {
+		printer.Printf(`connect error JSON: details[%d]: missing required key "value"`, i)
+	}
+	if detail.Type != nil && detail.Value != nil && hasDebug {
+		// Let's check the debug data by using it as JSON to unmarshal a message, and
+		// then also unmarshal the bytes in value. If they are not equal messages,
+		// there is an issues with the debug JSON data.
+		examineConnectErrorDetailDebugData(i, *detail.Type, decodedVal, detail.Debug, printer)
+	}
+}
+
+func examineConnectErrorDetailDebugData(i int, msgName string, data []byte, debugJSON []byte, printer internal.Printer) {
+	msgType, err := protoregistry.GlobalTypes.FindMessageByName(protoreflect.FullName(msgName))
+	if err != nil {
+		printer.Printf("connect error JSON: details[%d]: could not check debug data because message type %q could not be resolved: %v", i, msgName, err)
+		return
+	}
+	msgFromValue := msgType.New()
+	if err := proto.Unmarshal(data, msgFromValue.Interface()); err != nil {
+		printer.Printf("connect error JSON: details[%d]: could not unmarshal message %q from value: %v", i, msgName, err)
+		return
+	}
+	msgFromDebug := msgType.New()
+	if err := protojson.Unmarshal(debugJSON, msgFromDebug.Interface()); err != nil {
+		// It is possible that the debug data is actually a google.protobuf.Any, and the "@type" property
+		// is causing the above unmarshal step to fail. So we'll try unmarshaling from Any next to see
+		// if that is successful.
+		//
+		// NOTE: this fallback logic doesn't really work if the actual message type is a
+		// google.protobuf.Value or google.protobuf.Struct. These types allow arbitrary JSON and will
+		// accept the data in the above step, even if it has the extra "@type" property. Luckily, that
+		// is not an issue since none of the conformance test cases try to use these types as error
+		// details.
+		//
+		// TODO: This fallback is mainly to accommodate the current connect-go implementation, which
+		//       includes the "@type" attribute because it just marshals the Any error detail message
+		//       for the debug value. But we'd prefer that attribute NOT be in the debug value, in which
+		//       case we could remove this fallback from here and let these checks be a bit more strict.
+		var anyMsg anypb.Any
+		if anyErr := protojson.Unmarshal(debugJSON, &anyMsg); anyErr != nil {
+			// It's not a valid Any either. So report the original error
+			printer.Printf("connect error JSON: details[%d]: could not unmarshal message %q from debug JSON: %v", i, msgName, err)
+			return
+		}
+		typeNameFromAny := anyMsg.TypeUrl[strings.LastIndexByte(anyMsg.TypeUrl, '/')+1:]
+		if typeNameFromAny != msgName {
+			printer.Printf("connect error JSON: details[%d]: debug data indicates type %q but should indicate type %q", i, typeNameFromAny, msgName)
+			return
+		}
+		msgFromAny, err := anyMsg.UnmarshalNew()
+		if err != nil {
+			printer.Printf("connect error JSON: details[%d]: could not unmarshal message %q from debug JSON: %v", i, msgName, err)
+			return
+		}
+		msgFromDebug = msgFromAny.ProtoReflect()
+	}
+	diff := cmp.Diff(msgFromValue.Interface(), msgFromDebug.Interface(), protocmp.Transform())
+	if diff != "" {
+		printer.Printf("connect error JSON: details[%d]: debug data does not match value: - value, + debug\n%s", i, diff)
+	}
+}
+
+func examineConnectEndStream(endStreamJSON json.RawMessage, printer internal.Printer) {
+	var endStream connectEndStream
+	if err := json.Unmarshal(endStreamJSON, &endStream); err != nil {
+		printer.Printf("connect end stream JSON is malformed: %v", err)
+		return
+	}
+	// Extra checks, since encoding/json above is lenient.
+	if _, err := checkNoDuplicateKeys("", json.NewDecoder(bytes.NewReader(endStreamJSON))); err != nil {
+		printer.Printf("connect end stream JSON: %v", err)
+		return
+	}
+	var asAny map[string]any
+	if err := json.Unmarshal(endStreamJSON, &asAny); err != nil {
+		// note: since above unmarshal step succeeded, this should never fail
+		printer.Printf("connect end stream JSON is malformed: %v", err)
+		return
+	}
+	var hasError bool
+	for _, key := range sortedKeys(asAny) {
+		val := asAny[key]
+		switch key {
+		case "error":
+			if _, isObj := val.(map[string]any); !isObj {
+				printer.Printf(`connect end stream JSON: value for key "error" is a %T instead of a map/object`, val)
+				break
+			}
+			hasError = true
+		case "metadata":
+			mapVal, ok := val.(map[string]any)
+			if !ok {
+				printer.Printf(`connect end stream JSON: value for key "metadata" is a %T instead of a map/object`, val)
+			}
+			for name, values := range mapVal {
+				if !isValidHTTPFieldName(name) {
+					printer.Printf(`connect end stream JSON: metadata[%q]: entry key is not a valid HTTP field name`, name)
+				}
+				valSlice, ok := values.([]any)
+				if !ok {
+					printer.Printf(`connect end stream JSON: metadata[%q]: value is a %T instead of an array of strings`, name, values)
+					continue
+				}
+				for i, val := range valSlice {
+					valStr, ok := val.(string)
+					if !ok {
+						printer.Printf(`connect end stream JSON: metadata[%q]: value #%d is a %T instead of a string`, name, i+1, val)
+						continue
+					}
+					if !isValidHTTPFieldValue(valStr) {
+						printer.Printf(`connect end stream JSON: metadata[%q]: value #%d is not a valid HTTP field value: %q`, name, i+1, val)
+					}
+				}
+			}
+		default:
+			printer.Printf("connect end stream JSON: invalid key %q", key)
+		}
+	}
+	if hasError {
+		examineConnectError(endStream.Error, printer)
+	}
 }
 
 func examineGRPCEndStream(endStream string, printer internal.Printer) {
@@ -335,4 +607,79 @@ func isValidHTTPFieldName(s string) bool {
 		}
 	}
 	return true
+}
+
+func sortedKeys[K constraints.Ordered, V any](m map[K]V) []K {
+	keys := make([]K, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return keys[i] < keys[j]
+	})
+	return keys
+}
+
+// checkNoDuplicateKeys checks that the data read by the given decoder does
+// not contain any JSON objects/maps that have duplicate keys. The "encoding/json"
+// package does not check and will simply overwrite earlier values with later ones.
+func checkNoDuplicateKeys(what string, dec *json.Decoder) (json.Token, error) {
+	tok, err := dec.Token()
+	if err != nil {
+		return nil, err
+	}
+	if tok != json.Delim('{') { //nolint:nestif
+		if tok == json.Delim('[') {
+			// consume entire array, checking each element
+			var i int
+			for {
+				elemWhat := fmt.Sprintf("%s[%d]", what, i)
+				tok, err := checkNoDuplicateKeys(elemWhat, dec)
+				if err != nil {
+					return nil, err
+				}
+				if tok == json.Delim(']') {
+					break
+				}
+				i++
+			}
+		}
+		// Not an object, so it's now fully consumed.
+		return tok, nil
+	}
+	// The value must be an object. So look at all keys to make sure there are no duplicates.
+	var prefix string
+	if what != "" {
+		prefix = what + ": "
+	}
+	keys := map[string]struct{}{}
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		if tok == json.Delim('}') {
+			return tok, nil // done
+		}
+		key, ok := tok.(string)
+		if !ok {
+			// This should not be possible since the encoding/json package handles
+			// validating this aspect of JSON structure.
+			return nil, fmt.Errorf("%stoken for object key has type %T instead of string", prefix, tok)
+		}
+		if _, exists := keys[key]; exists {
+			return nil, fmt.Errorf("%scontains duplicate key %q", prefix, key)
+		}
+		keys[key] = struct{}{}
+		// recursively check the field value
+		var elemWhat string
+		if what == "" {
+			elemWhat = key
+		} else {
+			elemWhat = fmt.Sprintf("%s.%s", what, key)
+		}
+		if _, err := checkNoDuplicateKeys(elemWhat, dec); err != nil {
+			return nil, err
+		}
+	}
 }

--- a/internal/app/referenceclient/wire_details_test.go
+++ b/internal/app/referenceclient/wire_details_test.go
@@ -17,6 +17,7 @@ package referenceclient
 import (
 	"context"
 	"encoding/binary"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -30,6 +31,438 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestExamineConnectError(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name             string
+		endStream        string
+		expectedFeedback []string
+	}{
+		{
+			name: "minimal",
+			endStream: `
+				{
+					"code": "internal"
+				}`,
+		},
+		{
+			name: "with message",
+			endStream: `
+				{
+					"code": "internal",
+					"message": "blah blah blah"
+				}`,
+		},
+		{
+			name: "with details",
+			endStream: `
+				{
+					"code": "internal",
+					"details": [
+						{
+							"type": "blah.blah.Blah",
+							"value": "abcdefgh"
+						}
+					]
+				}`,
+		},
+		{
+			name: "complete",
+			endStream: `
+				{
+					"code": "internal",
+					"message": "blah blah blah",
+					"details": [
+						{
+							"type": "blah.blah.Blah",
+							"value": "abcdefgh"
+						}
+					]
+				}`,
+		},
+		{
+			name:      "empty",
+			endStream: `{}`,
+			expectedFeedback: []string{
+				`connect error JSON: missing required key "code"`,
+			},
+		},
+		{
+			name:      "only message",
+			endStream: `{"message": "abc"}`,
+			expectedFeedback: []string{
+				`connect error JSON: missing required key "code"`,
+			},
+		},
+		{
+			name:      "incorrect type for code",
+			endStream: `{"code": 1, "message": "abc"}`,
+			expectedFeedback: []string{
+				`connect error JSON is malformed: json: cannot unmarshal number into Go struct field connectError.code of type string`,
+			},
+		},
+		{
+			name:      "incorrect type for message",
+			endStream: `{"code": "unavailable", "message": 12345}`,
+			expectedFeedback: []string{
+				`connect error JSON is malformed: json: cannot unmarshal number into Go struct field connectError.message of type string`,
+			},
+		},
+		{
+			name: "incorrect type for details",
+			endStream: `
+				{
+					"code": "unavailable",
+					"details": {
+						"type": "blah.blah.Blah",
+						"value": "abcdefgh"
+					}
+				}`,
+			expectedFeedback: []string{
+				`connect error JSON is malformed: json: cannot unmarshal object into Go struct field connectError.details of type []json.RawMessage`,
+			},
+		},
+		{
+			name:      "unrecognized code",
+			endStream: `{"code": "abc"}`,
+			expectedFeedback: []string{
+				`connect error JSON: value for key "code" is not a recognized error code name: "abc"`,
+			},
+		},
+		{
+			name: "incorrect case",
+			endStream: `
+				{
+					"Code": "unavailable",
+					"Message": "abc",
+					"Details": [
+						{
+							"Type": "google.protobuf.Empty",
+							"Value": "",
+							"Debug": {}
+						}
+					]
+				}`,
+			expectedFeedback: []string{
+				`connect error JSON: invalid key "Code"`,
+				`connect error JSON: invalid key "Details"`,
+				`connect error JSON: invalid key "Message"`,
+				`connect error JSON: missing required key "code"`,
+			},
+		},
+		{
+			name: "incorrect detail type", // uses type URL instead of type name
+			endStream: `
+				{
+					"code": "internal",
+					"details": [
+						{
+							"type": "foo.com/blah.blah.Blah",
+							"value": "abcdefgh"
+						}
+					]
+				}`,
+			expectedFeedback: []string{
+				`connect error JSON: details[0]: value for key "type", "foo.com/blah.blah.Blah", is not a valid type name`,
+			},
+		},
+		{
+			name: "nulls",
+			endStream: `
+				{
+					"code": null,
+					"message": null,
+					"details": null
+				}`,
+			expectedFeedback: []string{
+				`connect error JSON: value for key "code" is a <nil> instead of a string`,
+				`connect error JSON: value for key "details" is a <nil> instead of a slice`,
+				`connect error JSON: value for key "message" is a <nil> instead of a string`,
+			},
+		},
+		{
+			name: "null in details",
+			endStream: `
+				{
+					"code": "already_exists",
+					"message": "abc",
+					"details": [null]
+				}`,
+			expectedFeedback: []string{
+				`connect error JSON: details[0]: expecting an object but got <nil>`,
+			},
+		},
+		{
+			name: "empty detail",
+			endStream: `
+				{
+					"code": "already_exists",
+					"message": "abc",
+					"details": [{}]
+				}`,
+			expectedFeedback: []string{
+				`connect error JSON: details[0]: missing required key "type"`,
+				`connect error JSON: details[0]: missing required key "value"`,
+			},
+		},
+		{
+			name: "detail has invalid value",
+			endStream: `
+				{
+					"code": "already_exists",
+					"message": "abc",
+					"details": [{
+						"type": "foo.bar.Baz",
+						"value": "><@#$%^"
+					}]
+				}`,
+			expectedFeedback: []string{
+				`connect error JSON: details[0]: value for key "value", "><@#$%^", is not valid unpadded base64-encoding: illegal base64 data at input byte 0`,
+			},
+		},
+		{
+			name: "detail uses wrong base64 alphabet",
+			endStream: `
+				{
+					"code": "already_exists",
+					"message": "abc",
+					"details": [{
+						"type": "foo.bar.Baz",
+						"value": "abc-efg"
+					}]
+				}`,
+			expectedFeedback: []string{
+				`connect error JSON: details[0]: value for key "value", "abc-efg", is not valid unpadded base64-encoding: illegal base64 data at input byte 3`,
+			},
+		},
+		{
+			name: "detail uses padding",
+			endStream: `
+				{
+					"code": "already_exists",
+					"message": "abc",
+					"details": [{
+						"type": "foo.bar.Baz",
+						"value": "abcdef="
+					}]
+				}`,
+			expectedFeedback: []string{
+				`connect error JSON: details[0]: value for key "value", "abcdef=", is not valid unpadded base64-encoding: illegal base64 data at input byte 6`,
+			},
+		},
+		{
+			name: "detail debug disagrees with value",
+			// value encoding has a file with path "bar/foo.proto"
+			endStream: `
+				{
+					"code": "already_exists",
+					"message": "abc",
+					"details": [
+						{
+							"type": "google.protobuf.FileDescriptorSet",
+							"value": "Cg8KDWJhci9mb28ucHJvdG8",
+							"debug": {"file": [{"name": "foo.proto"}]}
+						}
+					]
+				}`,
+			expectedFeedback: []string{
+				`connect error JSON: details[0]: debug data does not match value: - value, + debug
+  (*descriptorpb.FileDescriptorSet)(Inverse(protocmp.Transform, protocmp.Message{
+  	"@type": s"google.protobuf.FileDescriptorSet",
+  	"file": []protocmp.Message{
+  		{
+  			"@type": s"google.protobuf.FileDescriptorProto",
+- 			"name":  string("bar/foo.proto"),
++ 			"name":  string("foo.proto"),
+  		},
+  	},
+  }))`,
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			svr := httptest.NewServer(http.HandlerFunc(func(respWriter http.ResponseWriter, req *http.Request) {
+				respWriter.Header().Set("Content-Type", "application/json")
+				respWriter.WriteHeader(http.StatusBadRequest)
+				_, _ = respWriter.Write([]byte(testCase.endStream))
+			}))
+			t.Cleanup(svr.Close)
+			client := conformancev1connect.NewConformanceServiceClient(
+				&http.Client{Transport: newWireCaptureTransport(svr.Client().Transport, nil)},
+				svr.URL,
+			)
+			ctx := withWireCapture(context.Background())
+			req := connect.NewRequest(&conformancev1.UnaryRequest{})
+			req.Header().Set("x-test-case-name", "foo") // needed to enable tracing
+			_, err := client.Unary(ctx, req)
+			require.Error(t, err)
+			printer := &internal.SimplePrinter{}
+			examineWireDetails(ctx, printer)
+			if len(testCase.expectedFeedback) == 0 {
+				assert.Empty(t, printer.Messages)
+			} else {
+				for i := range printer.Messages {
+					// Printer output keeps trailing newlines. And some messages come
+					// from using cmp.Diff, which uses non-breaking spaces for formatting
+					// instead of regular spaces. So we "clean up" the messages so we can
+					// easily compare them to the expectations above.
+					printer.Messages[i] = strings.ReplaceAll(
+						strings.TrimSuffix(printer.Messages[i], "\n"),
+						"\u00a0", // non-breaking space
+						" ",      // regular space
+					)
+				}
+				assert.Empty(t, cmp.Diff(testCase.expectedFeedback, printer.Messages))
+			}
+		})
+	}
+}
+
+func TestExamineConnectEndStream(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name             string
+		endStream        string
+		expectedFeedback []string
+	}{
+		{
+			name: "minimal",
+			endStream: `
+				{}`,
+		},
+		{
+			name: "minimal with metadata",
+			endStream: `
+				{"metadata":{}}`,
+		},
+		{
+			name: "minimal with error",
+			endStream: `
+				{"error":{"code":"canceled"}}`,
+		},
+		{
+			name: "nulls",
+			endStream: `
+				{"error":null, "metadata":null}`,
+			expectedFeedback: []string{
+				`connect end stream JSON: value for key "error" is a <nil> instead of a map/object`,
+				`connect end stream JSON: value for key "metadata" is a <nil> instead of a map/object`,
+			},
+		},
+		{
+			name: "empty error",
+			endStream: `
+				{"error":{}}`,
+			expectedFeedback: []string{
+				`connect error JSON: missing required key "code"`,
+			},
+		},
+		{
+			name: "invalid error", // verifies use of examineConnectError (see above for more test cases of that)
+			endStream: `
+				{"error":{"code": null}}`,
+			expectedFeedback: []string{
+				`connect error JSON: value for key "code" is a <nil> instead of a string`,
+			},
+		},
+		{
+			name: "invalid metadata",
+			endStream: `
+				{"metadata":[{"key": "header", "value": "abc"}, {"key": "header", "value": "abc"}]}`,
+			expectedFeedback: []string{
+				`connect end stream JSON is malformed: json: cannot unmarshal array into Go struct field connectEndStream.metadata of type map[string][]string`,
+			},
+		},
+		{
+			name: "duplicate metadata key",
+			endStream: `
+				{"metadata":{
+					"header": ["abc", "def"],
+					"header": ["xyz"]
+				}}`,
+			expectedFeedback: []string{
+				`connect end stream JSON: metadata: contains duplicate key "header"`,
+			},
+		},
+		{
+			name: "invalid metadata key",
+			endStream: `
+				{"metadata":{
+					"abc{'-|-'}def": ["abc", "def"]
+				}}`,
+			expectedFeedback: []string{
+				`connect end stream JSON: metadata["abc{'-|-'}def"]: entry key is not a valid HTTP field name`,
+			},
+		},
+		{
+			name: "invalid metadata value type",
+			endStream: `
+				{"metadata":{
+					"abc-def": ["abc", null]
+				}}`,
+			expectedFeedback: []string{
+				`connect end stream JSON: metadata["abc-def"]: value #2 is a <nil> instead of a string`,
+			},
+		},
+		{
+			name: "invalid metadata value",
+			endStream: `
+				{"metadata":{
+					"abc-def": ["abc", "def", "abc\u0000def\rxyz"]
+				}}`,
+			expectedFeedback: []string{
+				// strange that it reports the type of the null as []any instead of <nil>...
+				`connect end stream JSON: metadata["abc-def"]: value #3 is not a valid HTTP field value: "abc\x00def\rxyz"`,
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			svr := httptest.NewServer(http.HandlerFunc(func(respWriter http.ResponseWriter, req *http.Request) {
+				respWriter.Header().Set("Content-Type", "application/connect+proto")
+				_, _ = respWriter.Write([]byte{2}) // just the end-stream flag
+				var size [4]byte
+				binary.BigEndian.PutUint32(size[:], uint32(len(testCase.endStream)))
+				_, _ = respWriter.Write(size[:])
+				_, _ = respWriter.Write([]byte(testCase.endStream))
+			}))
+			t.Cleanup(svr.Close)
+			client := conformancev1connect.NewConformanceServiceClient(
+				&http.Client{Transport: newWireCaptureTransport(svr.Client().Transport, nil)},
+				svr.URL,
+			)
+			ctx := withWireCapture(context.Background())
+			stream := client.ClientStream(ctx)
+			stream.RequestHeader().Set("x-test-case-name", "foo") // needed to enable tracing
+			_, err := stream.CloseAndReceive()
+			require.Error(t, err)
+			printer := &internal.SimplePrinter{}
+			examineWireDetails(ctx, printer)
+			if len(testCase.expectedFeedback) == 0 {
+				assert.Empty(t, printer.Messages)
+			} else {
+				for i := range printer.Messages {
+					// Printer output keeps trailing newlines. And some messages come
+					// from using cmp.Diff, which uses non-breaking spaces for formatting
+					// instead of regular spaces. So we "clean up" the messages so we can
+					// easily compare them to the expectations above.
+					printer.Messages[i] = strings.ReplaceAll(
+						strings.TrimSuffix(printer.Messages[i], "\n"),
+						"\u00a0", // non-breaking space
+						" ",      // regular space
+					)
+				}
+				assert.Empty(t, cmp.Diff(testCase.expectedFeedback, printer.Messages))
+			}
+		})
+	}
+}
 
 func TestExamineGRPCEndStream(t *testing.T) {
 	t.Parallel()
@@ -183,6 +616,68 @@ func TestExamineGRPCEndStream(t *testing.T) {
 					printer.Messages[i] = strings.TrimSuffix(printer.Messages[i], "\n")
 				}
 				assert.Empty(t, cmp.Diff(testCase.expectedFeedback, printer.Messages))
+			}
+		})
+	}
+}
+
+func TestCheckNoDuplicateKeys(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name        string
+		input       string
+		expectedErr string
+	}{
+		{
+			name:  "okay",
+			input: `{ "a": true, "b": false }`,
+		},
+		{
+			name:        "duplicate key",
+			input:       `{ "a": true, "a": false }`,
+			expectedErr: `contains duplicate key "a"`,
+		},
+		{
+			name:  "top-level scalar",
+			input: `123.456`,
+		},
+		{
+			name:  "top-level array",
+			input: `[1, 2, 3, 4]`,
+		},
+		{
+			name:        "top-level array, interior duplicates",
+			input:       `[1, 2, {"a": 1, "b": 2, "c": 3, "b": 4}, 4]`,
+			expectedErr: `[2]: contains duplicate key "b"`,
+		},
+		{
+			name:  "nested arrays, okay",
+			input: `{ "a": [ [ [ "a", "b" ] ], 123 ], "b": false }`,
+		},
+		{
+			name:        "nested arrays, interior duplicate",
+			input:       `{ "a": [ [ [ "a", "b" ], {"foo": "bar", "foo": "baz"} ], 123 ], "b": false }`,
+			expectedErr: `a[0][1]: contains duplicate key "foo"`,
+		},
+		{
+			name:  "nested objects, okay",
+			input: `{ "a": { "b": { "c": { "d": { }, "e": ["foo", "bar"] } } } }`,
+		},
+		{
+			name:        "nested objects, interior duplicate",
+			input:       `{ "a": { "b": { "c": { "d": { }, "d": "foobar" } } } }`,
+			expectedErr: `a.b.c: contains duplicate key "d"`,
+		},
+	}
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := checkNoDuplicateKeys("", json.NewDecoder(strings.NewReader(testCase.input)))
+			if testCase.expectedErr == "" {
+				require.NoError(t, err, "expected input to succeed: %q", testCase.input)
+			} else {
+				require.ErrorContains(t, err, testCase.expectedErr, "expected input to fail with particular error: %q", testCase.input)
 			}
 		})
 	}

--- a/internal/app/referenceclient/wire_details_test.go
+++ b/internal/app/referenceclient/wire_details_test.go
@@ -99,14 +99,14 @@ func TestExamineConnectError(t *testing.T) {
 			name:      "incorrect type for code",
 			endStream: `{"code": 1, "message": "abc"}`,
 			expectedFeedback: []string{
-				`connect error JSON is malformed: json: cannot unmarshal number into Go struct field connectError.code of type string`,
+				`connect error JSON: json: cannot unmarshal number into Go struct field connectError.code of type string`,
 			},
 		},
 		{
 			name:      "incorrect type for message",
 			endStream: `{"code": "unavailable", "message": 12345}`,
 			expectedFeedback: []string{
-				`connect error JSON is malformed: json: cannot unmarshal number into Go struct field connectError.message of type string`,
+				`connect error JSON: json: cannot unmarshal number into Go struct field connectError.message of type string`,
 			},
 		},
 		{
@@ -120,7 +120,7 @@ func TestExamineConnectError(t *testing.T) {
 					}
 				}`,
 			expectedFeedback: []string{
-				`connect error JSON is malformed: json: cannot unmarshal object into Go struct field connectError.details of type []json.RawMessage`,
+				`connect error JSON: json: cannot unmarshal object into Go struct field connectError.details of type []json.RawMessage`,
 			},
 		},
 		{
@@ -374,7 +374,7 @@ func TestExamineConnectEndStream(t *testing.T) {
 			endStream: `
 				{"metadata":[{"key": "header", "value": "abc"}, {"key": "header", "value": "abc"}]}`,
 			expectedFeedback: []string{
-				`connect end stream JSON is malformed: json: cannot unmarshal array into Go struct field connectEndStream.metadata of type map[string][]string`,
+				`connect end stream JSON: json: cannot unmarshal array into Go struct field connectEndStream.metadata of type map[string][]string`,
 			},
 		},
 		{


### PR DESCRIPTION
This makes the checks significantly more strict than the base connect-go implementation, in order to report a number of possible issues in server JSON responses:
1. This will detect duplicate keys in JSON objects/maps. Without an explicit check, "encoding/json" ignores duplicate keys, letting later values for the same key overwrite earlier ones. Sadly, there's no configuration to set this uniformly, so it had to be done by overriding the `UnmarshalJSON` behavior of each type to explicitly check. 😦 
2. This ensures that all keys use the correct case. Sadly, even with explicit field names in struct tags, "encoding/json" is still lenient and uses a case-insensitive match for field names. 😢 
3. This double-checks the JSON type of each value. There are a few ways in which "encoding/json" sometimes allows undesired types -- mainly with the use of a JSON null for map, slice, and pointer fields. So this performs an extra check of the actual types in the raw JSON.
4. This makes sure that the keys and values in the end-stream "metadata" map are valid HTTP header names and values.
5. This also makes sure that if a "debug" key is present in an error detail, that the message it describes actually matches the message described in the binary data of the "value" key.
