### PR TITLE
Update version constant to rc3

### DIFF
--- a/internal/version.go
+++ b/internal/version.go
@@ -17,7 +17,7 @@ package internal
 //nolint:gochecknoglobals
 var (
 	// NB: These are vars instead of consts so they can be changed via -X ldflags.
-	buildVersion       = "v1.0.0-rc3-dev"
+	buildVersion       = "v1.0.0-rc3"
 	buildVersionSuffix = ""
 
 	// Version is the version to report from all binaries.


### PR DESCRIPTION
When merged, the resulting commit on main will be the one tagged as "v1.0.0-rc3".