### PR TITLE
Tighten up when response can combine headers and trailers; add check for unsent requests

### DIFF
--- a/internal/app/connectconformance/results_test.go
+++ b/internal/app/connectconformance/results_test.go
@@ -121,14 +121,20 @@ func TestResults_Assert(t *testing.T) {
 			{Data: []byte{0, 1, 2, 3, 4}},
 		},
 	}
-	testCase1 := &conformancev1.TestCase{ExpectedResponse: payload1}
+	testCase1 := &conformancev1.TestCase{
+		Request:          &conformancev1.ClientCompatRequest{TestName: "abc1"},
+		ExpectedResponse: payload1,
+	}
 	payload2 := &conformancev1.ClientResponseResult{
 		Error: &conformancev1.Error{
 			Code:    conformancev1.Code_CODE_ABORTED,
 			Message: proto.String("oops"),
 		},
 	}
-	testCase2 := &conformancev1.TestCase{ExpectedResponse: payload2}
+	testCase2 := &conformancev1.TestCase{
+		Request:          &conformancev1.ClientCompatRequest{TestName: "abc2"},
+		ExpectedResponse: payload2,
+	}
 	results.assert("foo/bar/1", testCase1, payload2)
 	results.assert("foo/bar/2", testCase2, payload1)
 	results.assert("foo/bar/3", testCase1, payload1)
@@ -288,28 +294,7 @@ func TestResults_Assert_ReportsAllErrors(t *testing.T) {
 			},
 		},
 		{
-			name: "response meta misattributed allowed for trailers-only response (all in headers)",
-			expected: `{
-				"error": {"code": 5},
-				"response_headers": [
-					{"name": "abc", "value": ["xyz", "123"]},
-					{"name": "xyz", "value": ["value1"]}
-				],
-				"response_trailers": [
-					{"name": "Case-Does-Not-Matter-For-Name", "value": ["value2"]}
-				]
-			}`,
-			actual: `{
-				"error": {"code": 5},
-				"response_headers": [
-					{"name": "abc", "value": ["xyz", "123"]},
-					{"name": "xyz", "value": ["value1"]},
-					{"name": "Case-Does-Not-Matter-For-Name", "value": ["value2"]}
-				]
-			}`,
-		},
-		{
-			name: "response meta misattributed allowed for trailers-only response (all in trailers)",
+			name: "response meta all in trailers allowed for error with trailers-only response",
 			expected: `{
 				"error": {"code": 5},
 				"response_headers": [
@@ -694,7 +679,10 @@ func TestResults_Assert_ReportsAllErrors(t *testing.T) {
 			t.Parallel()
 			results := newResults(&testTrie{}, &testTrie{}, nil)
 
-			expected := &conformancev1.TestCase{ExpectedResponse: &conformancev1.ClientResponseResult{}}
+			expected := &conformancev1.TestCase{
+				Request:          &conformancev1.ClientCompatRequest{StreamType: conformancev1.StreamType_STREAM_TYPE_UNARY},
+				ExpectedResponse: &conformancev1.ClientResponseResult{},
+			}
 			err := protojson.Unmarshal(([]byte)(testCase.expected), expected.ExpectedResponse)
 			require.NoError(t, err)
 

--- a/internal/app/connectconformance/testsuites/data/server_message_size.yaml
+++ b/internal/app/connectconformance/testsuites/data/server_message_size.yaml
@@ -43,6 +43,7 @@ testCases:
 - request:
     testName: client-stream/first-request-exceeds-server-limit
     streamType: STREAM_TYPE_CLIENT_STREAM
+    requestDelayMs: 50 # give server enough time to reject message and client to notice
     requestMessages:
     - "@type": type.googleapis.com/connectrpc.conformance.v1.ClientStreamRequest
       responseDefinition:
@@ -56,9 +57,11 @@ testCases:
   expectedResponse:
     error:
       code: CODE_RESOURCE_EXHAUSTED
+    numUnsentRequests: 2
 - request:
     testName: client-stream/subsequent-request-exceeds-server-limit
     streamType: STREAM_TYPE_CLIENT_STREAM
+    requestDelayMs: 50
     requestMessages:
     - "@type": type.googleapis.com/connectrpc.conformance.v1.ClientStreamRequest
       responseDefinition:
@@ -72,6 +75,7 @@ testCases:
   expectedResponse:
     error:
       code: CODE_RESOURCE_EXHAUSTED
+    numUnsentRequests: 1
 # Server Stream Tests ---------------------------------------------------------
 - request:
     testName: server-stream/request-equal-to-server-limit
@@ -99,6 +103,7 @@ testCases:
   expectedResponse:
     error:
       code: CODE_RESOURCE_EXHAUSTED
+    numUnsentRequests: 1
 # Bidi Stream Tests -----------------------------------------------------------
 - request:
     testName: bidi-stream/half-duplex/all-requests-equal-to-server-limit
@@ -117,6 +122,7 @@ testCases:
 - request:
     testName: bidi-stream/half-duplex/first-request-exceeds-server-limit
     streamType: STREAM_TYPE_HALF_DUPLEX_BIDI_STREAM
+    requestDelayMs: 50
     requestMessages:
     - "@type": type.googleapis.com/connectrpc.conformance.v1.BidiStreamRequest
       responseDefinition:
@@ -134,9 +140,11 @@ testCases:
   expectedResponse:
     error:
       code: CODE_RESOURCE_EXHAUSTED
+    numUnsentRequests: 2
 - request:
     testName: bidi-stream/half-duplex/subsequent-request-exceeds-server-limit
     streamType: STREAM_TYPE_HALF_DUPLEX_BIDI_STREAM
+    requestDelayMs: 50
     requestMessages:
     - "@type": type.googleapis.com/connectrpc.conformance.v1.BidiStreamRequest
       responseDefinition:
@@ -154,6 +162,7 @@ testCases:
   expectedResponse:
     error:
       code: CODE_RESOURCE_EXHAUSTED
+    numUnsentRequests: 1
 - request:
     testName: bidi-stream/full-duplex/all-requests-equal-to-server-limit
     streamType: STREAM_TYPE_FULL_DUPLEX_BIDI_STREAM
@@ -181,6 +190,7 @@ testCases:
       fullDuplex: true
     - "@type": type.googleapis.com/connectrpc.conformance.v1.BidiStreamRequest
       requestData: "dGVzdCByZXNwb25zZQ=="
+    requestDelayMs: 50
   expandRequests:
     - sizeRelativeToLimit: 10
     - sizeRelativeToLimit: 0
@@ -189,11 +199,13 @@ testCases:
   expectedResponse:
     error:
       code: CODE_RESOURCE_EXHAUSTED
+    numUnsentRequests: 2
 # TODO - Need a way to populate the expected response payload because the test
 # library padded it with size and we don't know what it looks like here.
 # - request:
 #     testName: bidi-stream/full-duplex/subsequent-request-exceeds-server-limit
 #     streamType: STREAM_TYPE_FULL_DUPLEX_BIDI_STREAM
+#    requestDelayMs: 50
 #     requestMessages:
 #     - "@type": type.googleapis.com/connectrpc.conformance.v1.BidiStreamRequest
 #       responseDefinition:
@@ -222,3 +234,4 @@ testCases:
 #               requestData: "dGVzdCByZXNwb25zZQ=="
 #     error:
 #       code: CODE_RESOURCE_EXHAUSTED
+#     numUnsentRequests: 1

--- a/internal/app/referenceclient/impl.go
+++ b/internal/app/referenceclient/impl.go
@@ -358,7 +358,7 @@ func (i *invoker) clientStream(
 	resp, err := stream.CloseAndReceive()
 	if err != nil {
 		// If an error was returned, first convert it to a Connect error
-		// so that we can get the headers from the Meta property. Then,
+		// so that we can get the trailers from the Meta property. Then,
 		// convert _that_ to a proto Error so we can set it in the response.
 		connectErr := internal.ConvertErrorToConnectError(err)
 		trailers = internal.ConvertToProtoHeader(connectErr.Meta())

--- a/internal/app/referenceclient/impl.go
+++ b/internal/app/referenceclient/impl.go
@@ -140,10 +140,10 @@ func (i *invoker) unary(
 
 	if err != nil {
 		// If an error was returned, first convert it to a Connect error
-		// so that we can get the headers from the Meta property. Then,
+		// so that we can get the trailers from the Meta property. Then,
 		// convert _that_ to a proto Error so we can set it in the response.
 		connectErr := internal.ConvertErrorToConnectError(err)
-		headers = internal.ConvertToProtoHeader(connectErr.Meta())
+		trailers = internal.ConvertToProtoHeader(connectErr.Meta())
 		protoErr = internal.ConvertConnectToProtoError(connectErr)
 	} else {
 		// If the call was successful, get the headers and trailers
@@ -318,11 +318,11 @@ func (i *invoker) clientStream(
 
 	ctx = i.withWireCapture(ctx)
 	stream := i.client.ClientStream(ctx)
-
+	var numUnsent int
 	// Add the specified request headers to the request
 	internal.AddHeaders(req.RequestHeaders, stream.RequestHeader())
 
-	for _, msg := range req.RequestMessages {
+	for i, msg := range req.RequestMessages {
 		csr := &conformancev1.ClientStreamRequest{}
 		if err := msg.UnmarshalTo(csr); err != nil {
 			return nil, err
@@ -332,6 +332,7 @@ func (i *invoker) clientStream(
 		time.Sleep(time.Duration(req.RequestDelayMs) * time.Millisecond)
 
 		if err := stream.Send(csr); err != nil && errors.Is(err, io.EOF) {
+			numUnsent = len(req.RequestMessages) - i
 			break
 		}
 	}
@@ -360,7 +361,7 @@ func (i *invoker) clientStream(
 		// so that we can get the headers from the Meta property. Then,
 		// convert _that_ to a proto Error so we can set it in the response.
 		connectErr := internal.ConvertErrorToConnectError(err)
-		headers = internal.ConvertToProtoHeader(connectErr.Meta())
+		trailers = internal.ConvertToProtoHeader(connectErr.Meta())
 		protoErr = internal.ConvertConnectToProtoError(connectErr)
 	} else {
 		// If the call was successful, get the returned payloads
@@ -373,12 +374,13 @@ func (i *invoker) clientStream(
 	statusCode, feedback := i.examineWireDetails(ctx)
 
 	return &conformancev1.ClientResponseResult{
-		ResponseHeaders:  headers,
-		ResponseTrailers: trailers,
-		Payloads:         payloads,
-		Error:            protoErr,
-		HttpStatusCode:   statusCode,
-		Feedback:         feedback,
+		ResponseHeaders:   headers,
+		ResponseTrailers:  trailers,
+		Payloads:          payloads,
+		NumUnsentRequests: int32(numUnsent),
+		Error:             protoErr,
+		HttpStatusCode:    statusCode,
+		Feedback:          feedback,
 	}, nil
 }
 
@@ -424,13 +426,17 @@ func (i *invoker) bidiStream(
 
 	var protoErr *conformancev1.Error
 	totalRcvd := 0
-	for _, msg := range req.RequestMessages {
+	for i, msg := range req.RequestMessages {
 		bsr := &conformancev1.BidiStreamRequest{}
 		if err := msg.UnmarshalTo(bsr); err != nil {
 			// Return the error and nil result because this is an
 			// unmarshalling error unrelated to the RPC
 			return nil, err
 		}
+
+		// Sleep for any specified delay
+		time.Sleep(time.Duration(req.RequestDelayMs) * time.Millisecond)
+
 		if err := stream.Send(bsr); err != nil && errors.Is(err, io.EOF) {
 			// Call receive to get the error and convert it to a proto error
 			if _, recvErr := stream.Receive(); recvErr != nil {
@@ -442,6 +448,7 @@ func (i *invoker) bidiStream(
 				protoErr = internal.ConvertErrorToProtoError(err)
 			}
 			// Break the send loop
+			result.NumUnsentRequests = int32(len(req.RequestMessages) - i)
 			break
 		}
 		if fullDuplex {


### PR DESCRIPTION
Doh! I made all these changes a while ago and was waiting on the connect-go release (since the tests don't pass without some of the latest changes/fixes).

I had intended to include this in rc3. Oh well... maybe in an rc4 or maybe in a final v1.0.0.
