### PR TITLE
In referenceclient, inspecting wire details needs to support compressed error bodies

### DIFF
--- a/internal/app/connectconformance/testsuites/data/connect_client_compressed_error_endstream.yaml
+++ b/internal/app/connectconformance/testsuites/data/connect_client_compressed_error_endstream.yaml
@@ -1,0 +1,93 @@
+name: Connect Compressed Error and End-Stream
+mode: TEST_MODE_CLIENT
+relevantProtocols:
+  - PROTOCOL_CONNECT
+relevantCompressions:
+  # Ideally, we'd run this sort of test for any/all compression encodings
+  # supported by the client. But, since it uses a raw HTTP response, we
+  # have to hard-code the compression (raw response config doesn't allow
+  # parameterizing the encoding). So we test with the most likely encoding
+  # to be implemented.
+  - COMPRESSION_GZIP
+relevantCodecs:
+  - CODEC_PROTO
+testCases:
+  - request:
+      testName: error/compressed
+      service: connectrpc.conformance.v1.ConformanceService
+      method: Unary
+      streamType: STREAM_TYPE_UNARY
+      requestMessages:
+        - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
+          responseDefinition:
+            rawResponse:
+              statusCode: 422
+              headers:
+                - name: content-type
+                  value: [ "application/json" ]
+                - name: content-encoding
+                  value: [ "gzip" ]
+              unary:
+                text: |
+                  {
+                    "code": "out_of_range",
+                    "message": "oops",
+                    "details": [
+                      {
+                        "type": "google.protobuf.FileDescriptorProto",
+                        "value": "Cgp0ZXN0LnByb3Rv",
+                        "debug": { "name": "test.proto" }
+                      }
+                    ]
+                  }
+                compression: COMPRESSION_GZIP
+    expectedResponse:
+      error:
+        code: CODE_OUT_OF_RANGE
+        message: oops
+        details:
+          - "@type": type.googleapis.com/google.protobuf.FileDescriptorProto
+            name: "test.proto"
+
+  - request:
+      testName: end-stream/compressed
+      service: connectrpc.conformance.v1.ConformanceService
+      method: ServerStream
+      streamType: STREAM_TYPE_SERVER_STREAM
+      requestMessages:
+        - "@type": type.googleapis.com/connectrpc.conformance.v1.ServerStreamRequest
+          responseDefinition:
+            rawResponse:
+              statusCode: 200
+              headers:
+                - name: content-type
+                  value: [ "application/connect+proto" ]
+                - name: connect-content-encoding
+                  value: [ "gzip" ]
+              stream:
+                items:
+                  - flags: 3
+                    payload:
+                      text: |
+                        {
+                          "error": {
+                            "code": "out_of_range",
+                            "message": "oops",
+                            "foobar": "baz",
+                            "details": [
+                              {
+                                "type": "google.protobuf.FileDescriptorProto",
+                                "value": "Cgp0ZXN0LnByb3Rv",
+                                "debug": { "name": "test.proto" }
+                              }
+                            ]
+                          }
+                        }
+                      compression: COMPRESSION_GZIP
+    expectedResponse:
+      error:
+        code: CODE_OUT_OF_RANGE
+        message: oops
+        details:
+          - "@type": type.googleapis.com/google.protobuf.FileDescriptorProto
+            name: "test.proto"

--- a/internal/app/connectconformance/testsuites/data/grpc_web_client_compressed_trailers.yaml
+++ b/internal/app/connectconformance/testsuites/data/grpc_web_client_compressed_trailers.yaml
@@ -1,0 +1,49 @@
+name: gRPC-Web Compressed Trailers
+mode: TEST_MODE_CLIENT
+relevantProtocols:
+  - PROTOCOL_GRPC_WEB
+relevantCompressions:
+  # Ideally, we'd run this sort of test for any/all compression encodings
+  # supported by the client. But, since it uses a raw HTTP response, we
+  # have to hard-code the compression (raw response config doesn't allow
+  # parameterizing the encoding). So we test with the most likely encoding
+  # to be implemented.
+  - COMPRESSION_GZIP
+relevantCodecs:
+  - CODEC_PROTO
+testCases:
+  - request:
+      testName: trailers-in-body/compressed
+      streamType: STREAM_TYPE_UNARY
+      requestMessages:
+        - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
+          responseDefinition:
+            rawResponse:
+              status_code: 200
+              headers:
+                - name: "access-control-allow-origin"
+                  value: [ "*" ]
+                - name: "access-control-expose-headers"
+                  value: [ "*" ]
+                - name: content-type
+                  value: [ "application/grpc-web" ]
+                - name: grpc-encoding
+                  value: [ "gzip" ]
+                - name: x-custom-header
+                  value: [ "foo" ]
+              stream:
+                items:
+                  - flags: 129
+                    payload:
+                      text: "grpc-status: 9\r\ngrpc-message: error\r\nx-custom-trailer: bing\r\n"
+                      compression: COMPRESSION_GZIP
+    expectedResponse:
+      responseHeaders:
+        - name: x-custom-header
+          value: [ "foo" ]
+      error:
+        code: 9
+        message: error
+      responseTrailers:
+        - name: x-custom-trailer
+          value: [ "bing" ]

--- a/internal/app/connectconformance/testsuites/data/grpc_web_client_trailers.yaml
+++ b/internal/app/connectconformance/testsuites/data/grpc_web_client_trailers.yaml
@@ -4,8 +4,6 @@ relevantProtocols:
   - PROTOCOL_GRPC_WEB
 relevantCodecs:
   - CODEC_PROTO
-relevantCompressions:
-  - COMPRESSION_IDENTITY
 # These tests verify that a gRPC-Web client can handle trailers in the body with
 # no response, trailers-only responses (trailers in headers), and trailers with
 # different cases (in addition to the "standard" all lower-case).


### PR DESCRIPTION
This also adds test cases -- both for the reference client's wire details functionality and also conformance test cases, to verify correct support in RPC client implementations for compressed errors.

There's also a small unrelated change so we don't bother validating the "debug" key in JSON error detail if the "value" bytes aren't correctly decoded. (Otherwise, it just reports spurious nonsense.)

Fixes #809