### PR TITLE
Fix naming and filtering of test cases with gRPC impls

### DIFF
--- a/cmd/connectconformance/main.go
+++ b/cmd/connectconformance/main.go
@@ -39,6 +39,7 @@ const (
 	skipFlagName          = "skip"
 	verboseFlagName       = "verbose"
 	verboseFlagShortName  = "v"
+	veryVerboseFlagName   = "vvv"
 	versionFlagName       = "version"
 	maxServersFlagName    = "max-servers"
 	parallelFlagName      = "parallel"
@@ -59,6 +60,7 @@ type flags struct {
 	knownFailingPatterns []string
 	knownFlakyPatterns   []string
 	verbose              bool
+	veryVerbose          bool
 	version              bool
 	maxServers           uint
 	parallel             uint
@@ -145,6 +147,8 @@ func bind(cmd *cobra.Command, flags *flags) {
 		"a pattern indicating the name of test cases that are flaky; these test cases are allowed (but not required) to fail; can be specified more than once")
 	cmd.Flags().BoolVarP(&flags.verbose, verboseFlagName, verboseFlagShortName, false,
 		"enables verbose output")
+	cmd.Flags().BoolVar(&flags.veryVerbose, veryVerboseFlagName, false,
+		"enables even more verbose output")
 	cmd.Flags().BoolVar(&flags.version, versionFlagName, false,
 		"print version and exit")
 	cmd.Flags().UintVar(&flags.maxServers, maxServersFlagName, 4,
@@ -293,7 +297,8 @@ func run(flags *flags, cobraFlags *pflag.FlagSet, command []string) { //nolint:g
 			KnownFailingPatterns: knownFailingPatterns,
 			KnownFlakyPatterns:   knownFlakyPatterns,
 			TestFiles:            flags.testFiles,
-			Verbose:              flags.verbose,
+			Verbose:              flags.verbose || flags.veryVerbose,
+			VeryVerbose:          flags.veryVerbose,
 			ClientCommand:        clientCommand,
 			ServerCommand:        serverCommand,
 			MaxServers:           flags.maxServers,

--- a/cmd/connectconformance/main.go
+++ b/cmd/connectconformance/main.go
@@ -39,7 +39,7 @@ const (
 	skipFlagName          = "skip"
 	verboseFlagName       = "verbose"
 	verboseFlagShortName  = "v"
-	veryVerboseFlagName   = "vvv"
+	veryVerboseFlagName   = "vv"
 	versionFlagName       = "version"
 	maxServersFlagName    = "max-servers"
 	parallelFlagName      = "parallel"

--- a/internal/app/connectconformance/config.go
+++ b/internal/app/connectconformance/config.go
@@ -58,7 +58,7 @@ type supportedFeatures struct {
 }
 
 // parseConfig loads all config cases from the given file name. If the given
-// file name is blank, it returns all config cases based on default features.
+// file data is empty, it returns all config cases based on default features.
 func parseConfig(configFileName string, data []byte) ([]configCase, error) {
 	var config conformancev1.Config
 	if len(data) > 0 {

--- a/internal/app/connectconformance/connectconformance.go
+++ b/internal/app/connectconformance/connectconformance.go
@@ -204,20 +204,20 @@ func run( //nolint:gocyclo
 	}
 
 	filter := newFilter(run, skip)
-	if flags.Verbose {
+	if flags.Verbose { //nolint:nestif
 		logPrinter.Printf("Computed %d test case permutation(s) across %d server configuration(s).",
 			len(allPermutations), len(testCaseLib.casesByServer))
 		if filter != nil {
 			var count int
 			filteredServerInstances := map[serverInstance]struct{}{}
-			for _, tc := range allPermutations {
-				if filter.accept(tc) {
+			for _, testCase := range allPermutations {
+				if filter.accept(testCase) {
 					count++
 					filteredServerInstances[serverInstance{
-						protocol:          tc.Request.Protocol,
-						httpVersion:       tc.Request.HttpVersion,
-						useTLS:            len(tc.Request.ServerTlsCert) > 0,
-						useTLSClientCerts: tc.Request.ClientTlsCreds != nil,
+						protocol:          testCase.Request.Protocol,
+						httpVersion:       testCase.Request.HttpVersion,
+						useTLS:            len(testCase.Request.ServerTlsCert) > 0,
+						useTLSClientCerts: testCase.Request.ClientTlsCreds != nil,
 					}] = struct{}{}
 				}
 			}

--- a/internal/app/connectconformance/connectconformance_test.go
+++ b/internal/app/connectconformance/connectconformance_test.go
@@ -101,7 +101,7 @@ func TestRun(t *testing.T) {
 		allSuites,
 		logger,
 		logger,
-		&Flags{Verbose: true, MaxServers: 2, Parallelism: 4, ServerBind: "127.0.0.1"},
+		&Flags{Verbose: true, VeryVerbose: true, MaxServers: 2, Parallelism: 4, ServerBind: "127.0.0.1"},
 	)
 
 	require.NoError(t, err)

--- a/internal/app/connectconformance/server_runner.go
+++ b/internal/app/connectconformance/server_runner.go
@@ -41,6 +41,8 @@ import (
 //
 // If isReferenceServer is true, then the server's stderr will be examined as well, to
 // record out-of-band feedback about the client requests.
+//
+//nolint:gocyclo
 func runTestCasesForServer(
 	ctx context.Context,
 	isReferenceClient bool,

--- a/internal/app/connectconformance/server_runner.go
+++ b/internal/app/connectconformance/server_runner.go
@@ -49,10 +49,12 @@ func runTestCasesForServer(
 	testCases []*conformancev1.TestCase,
 	clientCreds *conformancev1.ClientCompatRequest_TLSCreds,
 	startServer processStarter,
+	logPrinter internal.Printer,
 	errPrinter internal.Printer,
 	results *testResults,
 	client clientRunner,
 	tracer *tracer.Tracer,
+	logEach bool,
 ) {
 	testCaseNameSet := make(map[string]struct{}, len(testCases))
 	for _, testCase := range testCases {
@@ -186,8 +188,14 @@ func runTestCasesForServer(
 
 		tracer.Init(req.TestName)
 		wg.Add(1)
+		if logEach {
+			logPrinter.Printf("Sending request for %q...", req.TestName)
+		}
 		err := client.sendRequest(req, func(name string, resp *conformancev1.ClientCompatResponse, err error) {
 			defer wg.Done()
+			if logEach {
+				logPrinter.Printf("Received response for %q...", req.TestName)
+			}
 			switch {
 			case err != nil:
 				results.setOutcome(name, true, err)

--- a/internal/app/connectconformance/server_runner_test.go
+++ b/internal/app/connectconformance/server_runner_test.go
@@ -271,9 +271,11 @@ func TestRunTestCasesForServer(t *testing.T) {
 				nil, // TODO: client cert
 				hookedProcess,
 				discardPrinter{},
+				discardPrinter{},
 				results,
 				&client,
 				nil,
+				false,
 			)
 
 			if testCase.svrFailsToStart {


### PR DESCRIPTION
This fixes #812. The issue was that we were filtering test case names _before_ computing the gRPC-specific versions. So we would translate a single filtered test case into potentially two test cases.

When Dan was encountering this issue, he asked if there was a way to see both test names -- since the test runner only reports failed test cases. So to address that, as well as other input from @srikrsna-buf and @rebello95 about wanting to see what test cases are being written to the conformance client, there is now a `--vv` flag which enables more verbose output and prints each test case as it is sent to the client and as results are received from the client.

Finally, while changing this stuff, I noticed that some newer test case names which have a slash, like `bidi-stream/full-duplex/success`, had incorrect-looking names for their gRPC-specific version. Instead of it looking like `<prefix>/(grpc client impl)/bidi-stream/full-duplex/success`, it looked like `<prefix>/bidi-stream/full-duplex/(grpc client impl)/success`. So the logic to insert the gRPC component into the name was always making it next-to-last element instead of always putting it _before_ the test case name. So this PR fixes that, too.

There are some other minor tweaks in here, too, related to the verbose output. In particular, it previously only reported the total number of server configurations computed, instead of the number of configurations that will _actually_ be run (which can be less than the total due to use of `--run` and/or `--skip` flags, to filter the set of test cases).