### PR TITLE
Prevent errant 'content-length: 0' request header from being printed

### DIFF
--- a/internal/app/connectconformance/server_runner.go
+++ b/internal/app/connectconformance/server_runner.go
@@ -41,6 +41,8 @@ import (
 //
 // If isReferenceServer is true, then the server's stderr will be examined as well, to
 // record out-of-band feedback about the client requests.
+//
+//nolint:gocyclo
 func runTestCasesForServer(
 	ctx context.Context,
 	isReferenceClient bool,

--- a/internal/app/connectconformance/server_runner.go
+++ b/internal/app/connectconformance/server_runner.go
@@ -151,7 +151,7 @@ func runTestCasesForServer(
 		req := proto.Clone(testCase.Request).(*conformancev1.ClientCompatRequest) //nolint:errcheck,forcetypeassert
 		req.Host = resp.Host
 		if req.Host == "" {
-			req.Host = "127.0.0.1"
+			req.Host = internal.DefaultHost
 		}
 		req.Port = resp.Port
 		req.ServerTlsCert = resp.PemCert

--- a/internal/app/connectconformance/server_runner.go
+++ b/internal/app/connectconformance/server_runner.go
@@ -148,6 +148,9 @@ func runTestCasesForServer(
 		}
 		req := proto.Clone(testCase.Request).(*conformancev1.ClientCompatRequest) //nolint:errcheck,forcetypeassert
 		req.Host = resp.Host
+		if req.Host == "" {
+			req.Host = "127.0.0.1"
+		}
 		req.Port = resp.Port
 		req.ServerTlsCert = resp.PemCert
 		req.ClientTlsCreds = clientCreds

--- a/internal/app/connectconformance/testsuites/data/grpc_server_proto_subformat.yaml
+++ b/internal/app/connectconformance/testsuites/data/grpc_server_proto_subformat.yaml
@@ -20,6 +20,8 @@ testCases:
         headers:
           - name: content-type
             value: [ "application/grpc+proto" ]
+          - name: te
+            value: [ "trailers" ]
         stream:
           items:
             - flags: 0
@@ -41,6 +43,8 @@ testCases:
         headers:
           - name: content-type
             value: [ "application/grpc" ]
+          - name: te
+            value: [ "trailers" ]
         stream:
           items:
             - flags: 0

--- a/internal/app/connectconformance/testsuites/data/grpc_server_unexpected.yaml
+++ b/internal/app/connectconformance/testsuites/data/grpc_server_unexpected.yaml
@@ -18,6 +18,8 @@ testCases:
         headers:
           - name: content-type
             value: [ "application/grpc" ]
+          - name: te
+            value: [ "trailers" ]
         stream:
           items:
             - flags: 0
@@ -38,6 +40,8 @@ testCases:
         headers:
           - name: content-type
             value: [ "application/grpc" ]
+          - name: te
+            value: [ "trailers" ]
         stream:
           items:
             - flags: 0
@@ -62,6 +66,8 @@ testCases:
 #        headers:
 #          - name: content-type
 #            value: [ "application/grpc+foo" ]
+#          - name: te
+#            value: [ "trailers" ]
 #        stream:
 #          items:
 #            - flags: 0
@@ -83,6 +89,8 @@ testCases:
             value: [ "application/grpc" ]
           - name: grpc-encoding
             value: ["foo"]
+          - name: te
+            value: [ "trailers" ]
         stream:
           items:
             - flags: 0
@@ -105,6 +113,8 @@ testCases:
             value: [ "application/grpc+proto" ]
           - name: grpc-encoding
             value: ["identity"]
+          - name: te
+            value: [ "trailers" ]
         stream:
           items:
             - flags: 1

--- a/internal/app/referenceclient/wire_details.go
+++ b/internal/app/referenceclient/wire_details.go
@@ -47,6 +47,11 @@ type wireCaptureTransport struct {
 // given one. The returned transport instruments the given one for tracing and
 // the ability to capture wire-level details from that trace. Also see
 // withWireCapture and examineWireDetails.
+//
+// The contextcheck lint issue is a false positive here. And ignoring it with
+// nolint then causes a false positive for the nolintlint :(
+//
+//nolint:contextcheck,nolintlint
 func newWireCaptureTransport(transport http.RoundTripper, trace *tracer.Tracer) http.RoundTripper {
 	return &wireCaptureTransport{
 		Transport: tracer.TracingRoundTripper(transport, &wireTracer{

--- a/internal/app/referenceserver/checks.go
+++ b/internal/app/referenceserver/checks.go
@@ -150,6 +150,8 @@ func checkProtocol(expected conformancev1.Protocol, req *http.Request, feedback 
 	}
 	if expected != actual {
 		feedback.Printf("expected protocol %v; instead got %v", expected, actual)
+	} else if expected == conformancev1.Protocol_PROTOCOL_GRPC && req.Header.Get("TE") != "trailers" {
+		feedback.Printf("gRPC protocol client should use 'te: trailers' header to indicate to proxies that it expects trailer")
 	}
 }
 

--- a/internal/app/referenceserver/server.go
+++ b/internal/app/referenceserver/server.go
@@ -103,7 +103,7 @@ func run(ctx context.Context, referenceMode bool, args []string, inReader io.Rea
 		return err
 	}
 	if actualHost == "" || actualHost == "0.0.0.0" {
-		actualHost = "127.0.0.1"
+		actualHost = internal.DefaultHost
 	}
 
 	// Start the server

--- a/internal/app/referenceserver/server.go
+++ b/internal/app/referenceserver/server.go
@@ -102,6 +102,9 @@ func run(ctx context.Context, referenceMode bool, args []string, inReader io.Rea
 	if err != nil {
 		return err
 	}
+	if actualHost == "" || actualHost == "0.0.0.0" {
+		actualHost = "127.0.0.1"
+	}
 
 	// Start the server
 	var serveError error

--- a/internal/tracer/middleware.go
+++ b/internal/tracer/middleware.go
@@ -60,7 +60,7 @@ func TracingHandler(handler http.Handler, collector Collector) http.Handler {
 			<-ctx.Done()
 			builder.add(&RequestCanceled{})
 		}()
-
+		//nolint:contextcheck
 		req = req.Clone(ctx)
 		req.Body = newRequestReader(req.Header, req.Body, true, builder)
 		traceWriter := &tracingResponseWriter{

--- a/internal/tracer/tracer.go
+++ b/internal/tracer/tracer.go
@@ -169,7 +169,8 @@ type Envelope struct {
 // is recorded when the client sends the request or when the server
 // receives it. This is always the first event for an HTTP operation.
 type RequestStart struct {
-	Request *http.Request
+	Request    *http.Request
+	getHeaders func() http.Header
 
 	eventOffset
 }
@@ -185,10 +186,7 @@ func (r *RequestStart) print(printer internal.Printer) {
 		urlClone.Scheme = "http"
 	}
 	printer.Printf("%s %9.3fms %s %s %s", requestPrefix, r.offsetMillis(), r.Request.Method, urlClone.String(), r.Request.Proto)
-	printHeaders(requestPrefix, r.Request.Header, printer)
-	if r.Request.ContentLength != -1 && len(r.Request.Header.Values("Content-Length")) == 0 {
-		printer.Printf("%s %11s Content-Length: %d", requestPrefix, "", r.Request.ContentLength)
-	}
+	printHeaders(requestPrefix, r.getHeaders(), printer)
 	printer.Printf(requestPrefix)
 }
 


### PR DESCRIPTION
I happened to notice in a trace output a "Content-Length: 0" that was _not_ possible. It turns out, the logic here was incorrectly deciding to add it to the trace output.

The `http.Request.ContentLength` field is actually interpreted differently between client and server requests (those created by a client, to send via a `http.RoundTripper`, and those created by a server to provide to an `http.Handler`). It turns out that the client's rules for when the header is added are complicated, and it can also transparently add other headers. So in order to _accurately_ show the real headers sent to the server, we need to use the `httptrace` package.

There are a handful of other small changes in here, because I saw this errant content-length issue when examining the output of tests run against a grpc-java server. The conformance server implementation was incorrectly leaving `Host` empty in the `ServerCompatResponse`, and yet everything worked (except that the trace printed the URL without a host name). I've changed it to explicitly use "127.0.0.1" as a default if the server does not provide a host. And I also added some "TE: Trailers" request headers to the gRPC raw requests in test cases, because grpc-java servers complain in the logs if the requests do not include this. (All proper gRPC clients _do_ include it.)