### PR TITLE
Add tracing support to gRPC impls by sniffing HTTP/2 frames on underlying TCP socket

### DIFF
--- a/docs/configuring_and_running_tests.md
+++ b/docs/configuring_and_running_tests.md
@@ -405,10 +405,6 @@ protocol, it gets run against both reference implementations, as a way of furthe
 interoperability with the ecosystem. (Note that the standard reference implementations _also_ support
 the gRPC protocol; so the gRPC test cases are repeated with a different server.)
 
-Note that an HTTP trace, for failing tests when the `--test` flag is used, will only available with the
-primary reference implementations. Test cases that fail against the gRPC implementations will not have
-a trace (only the primary reference implementations are instrumented to capture such traces).
-
 ### Selecting Test Cases
 
 The `connectconformance` test runner supports four different options for selecting which test cases to

--- a/internal/app/connectconformance/connectconformance.go
+++ b/internal/app/connectconformance/connectconformance.go
@@ -269,7 +269,9 @@ func run( //nolint:gocyclo
 				start: runInProcess([]string{
 					"grpc-reference-client",
 					"-p", strconv.Itoa(int(flags.Parallelism)),
-				}, grpcclient.Run),
+				}, func(ctx context.Context, args []string, inReader io.ReadCloser, outWriter, errWriter io.WriteCloser) error {
+					return grpcclient.RunWithTrace(ctx, args, inReader, outWriter, errWriter, trace)
+				}),
 				isGrpcImpl: true,
 			},
 		}
@@ -312,7 +314,9 @@ func run( //nolint:gocyclo
 						"grpc-reference-server",
 						"-port", strconv.FormatUint(uint64(flags.ServerPort), 10),
 						"-bind", flags.ServerBind,
-					}, grpcserver.Run),
+					}, func(ctx context.Context, args []string, inReader io.ReadCloser, outWriter, errWriter io.WriteCloser) error {
+						return grpcserver.RunWithTrace(ctx, args, inReader, outWriter, errWriter, trace)
+					}),
 					isGrpcImpl: true,
 				},
 			}

--- a/internal/app/connectconformance/results.go
+++ b/internal/app/connectconformance/results.go
@@ -24,7 +24,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"connectrpc.com/conformance/internal"
 	conformancev1 "connectrpc.com/conformance/internal/gen/proto/go/connectrpc/conformance/v1"
@@ -93,18 +92,10 @@ func (r *testResults) fetchTrace(testCase string) {
 	if r.tracer == nil {
 		return
 	}
-	if strings.Contains(testCase, grpcImplMarker) ||
-		strings.Contains(testCase, grpcClientImplMarker) ||
-		strings.Contains(testCase, grpcServerImplMarker) {
-		// No trace coming from the grpc-go impls.
-		r.tracer.Clear(testCase)
-		return
-	}
-
 	r.traceWaitGroup.Add(1)
 	go func() {
 		defer r.traceWaitGroup.Done()
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), tracer.TraceTimeout)
 		defer cancel()
 		trace, err := r.tracer.Await(ctx, testCase)
 		r.tracer.Clear(testCase)

--- a/internal/app/grpcserver/server.go
+++ b/internal/app/grpcserver/server.go
@@ -124,7 +124,7 @@ func runGRPCServer(ctx context.Context, server *grpc.Server, listener net.Listen
 	var serveError error
 	serveDone := make(chan struct{})
 	if trace != nil {
-		listener = &tracingListener{Listener: listener, trace: trace}
+		listener = tracer.TracingHTTP2Listener(listener, trace)
 	}
 	go func() {
 		defer close(serveDone)
@@ -175,17 +175,4 @@ func runGRPCWebServer(ctx context.Context, server *grpc.Server, listener net.Lis
 		}
 		return nil
 	}
-}
-
-type tracingListener struct {
-	net.Listener
-	trace *tracer.Tracer
-}
-
-func (t *tracingListener) Accept() (net.Conn, error) {
-	conn, err := t.Listener.Accept()
-	if err != nil {
-		return nil, err
-	}
-	return tracer.TracingHTTP2Conn(conn, true, t.trace), nil
 }

--- a/internal/tracer/builder.go
+++ b/internal/tracer/builder.go
@@ -115,6 +115,7 @@ func (b *builder) add(event Event) {
 	case *RequestBodyEnd:
 		if b.trace.Err != nil {
 			b.trace.Err = event.Err
+			finish = true
 		}
 	case *ResponseStart:
 		b.trace.Response = event.Response

--- a/internal/tracer/http2.go
+++ b/internal/tracer/http2.go
@@ -1,0 +1,541 @@
+// Copyright 2023-2024 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tracer
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"math"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/hpack"
+)
+
+const (
+	frameHeaderLen = 9
+	clientPreface  = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
+
+	// When the server sends a "refused" RST_STREAM frame, we will wait this long to
+	// see if client auto-retries. This should be lenient enough that a client that
+	// retries refused streams will can perform the retry before this period lapses.
+	// But it also must be less than TraceTimeout, so if the client is *not* retrying
+	// then we can still provide a trace within the timeout window.
+	retryWait = 3 * time.Second
+)
+
+// TracingHTTP2Conn applies tracing to the given net.Conn, which uses the
+// HTTP/2 protocol. If TLS is used, it should already be applied, so the
+// given conn should be used for reading/writing clear-text (i.e.
+// pre-encryption, post-decryption).
+//
+// If isServer is true, this is a server connection, so requests are read
+// and responses are written. Otherwise, this is a client connection, and
+// requests are written and responses are read.
+func TracingHTTP2Conn(conn net.Conn, isServer bool, collector Collector) net.Conn {
+	tracer := &tracingHTTP2Conn{
+		Conn:        conn,
+		isServer:    isServer,
+		collector:   &http2RetryCollector{collector: collector},
+		readTracer:  http2FrameTracer{isRequest: isServer},
+		writeTracer: http2FrameTracer{isRequest: !isServer},
+	}
+	tracer.readTracer.c = tracer
+	tracer.readTracer.decoder = hpack.NewDecoder(math.MaxUint32, nil)
+	tracer.writeTracer.c = tracer
+	tracer.writeTracer.decoder = hpack.NewDecoder(math.MaxUint32, nil)
+	prefaceBytes := make([]byte, 0, len(clientPreface))
+	if isServer {
+		tracer.readTracer.prefaceBytes = prefaceBytes
+	} else {
+		tracer.writeTracer.prefaceBytes = prefaceBytes
+	}
+	return tracer
+}
+
+type tracingHTTP2Conn struct {
+	net.Conn
+	isServer  bool
+	collector *http2RetryCollector
+
+	mu          sync.Mutex
+	streams     map[uint32]*http2Stream
+	maxStreamID uint32
+	readTracer  http2FrameTracer
+	writeTracer http2FrameTracer
+}
+
+func (c *tracingHTTP2Conn) Read(b []byte) (n int, err error) {
+	n, err = c.Conn.Read(b)
+	c.readTracer.trace(b[:n])
+	if err != nil {
+		c.cancelAll(err)
+	}
+	return n, err
+}
+
+func (c *tracingHTTP2Conn) Write(b []byte) (n int, err error) {
+	n, err = c.Conn.Write(b)
+	c.writeTracer.trace(b[:n])
+	if err != nil {
+		c.cancelAll(err)
+	}
+	return n, err
+}
+
+func (c *tracingHTTP2Conn) handleFrame(frame http2.Frame, isRequest bool) {
+	switch frame := frame.(type) {
+	case *http2.MetaHeadersFrame:
+		stream, isNew := c.getStream(frame, isRequest)
+		if stream == nil {
+			return
+		}
+		switch {
+		case isNew:
+		// request headers, which resulted in a new stream; nothing else to do
+		case !isRequest && !stream.gotResponse:
+			// response headers
+			c.receiveResponse(stream, frame)
+		case isRequest:
+			// request trailers
+			stream.builder.trace.Request.Trailer = makeHeaders(frame)
+		default:
+			// response trailers
+			stream.builder.trace.Response.Trailer = makeHeaders(frame)
+		}
+		if frame.StreamEnded() {
+			c.closeStream(frame.StreamID, stream, isRequest, nil)
+		}
+	case *http2.DataFrame:
+		stream := c.getExistingStream(frame.StreamID)
+		if stream == nil {
+			return
+		}
+		if isRequest {
+			stream.requestTracer.trace(frame.Data())
+		} else {
+			stream.responseTracer.trace(frame.Data())
+		}
+		if frame.StreamEnded() {
+			c.closeStream(frame.StreamID, stream, isRequest, nil)
+		}
+	case *http2.RSTStreamFrame:
+		stream := c.getExistingStream(frame.StreamID)
+		if stream == nil {
+			return
+		}
+		c.closeStream(frame.StreamID, stream, isRequest, http2.StreamError{
+			StreamID: frame.StreamID,
+			Code:     frame.ErrCode,
+		})
+
+	case *http2.GoAwayFrame:
+		c.setMaxStreamID(frame.LastStreamID, http2.ConnectionError(frame.ErrCode))
+	}
+}
+
+func (c *tracingHTTP2Conn) receiveResponse(stream *http2Stream, frame *http2.MetaHeadersFrame) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	stream.gotResponse = true
+	resp := makeResponse(frame) //nolint:bodyclose // there is no body to close on this response
+	stream.builder.add(&ResponseStart{Response: resp})
+	stream.responseTracer.isStreamProtocol, stream.responseTracer.decompressor = propertiesFromHeaders(resp.Header)
+	stream.responseTracer.builder = stream.builder
+}
+
+func (c *tracingHTTP2Conn) getStream(frame *http2.MetaHeadersFrame, createIfNotFound bool) (*http2Stream, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	stream := c.streams[frame.StreamID]
+	if stream != nil {
+		return stream, false
+	}
+	if !createIfNotFound {
+		return nil, false
+	}
+	if c.maxStreamID != 0 && frame.StreamID > c.maxStreamID {
+		return nil, false // stream ID too high; ignore
+	}
+	stream = c.newStreamLocked(frame)
+	return stream, true
+}
+
+func (c *tracingHTTP2Conn) newStreamLocked(frame *http2.MetaHeadersFrame) *http2Stream {
+	req := makeRequest(frame)
+	builder, _ := newBuilder(req, !c.isServer, c.collector)
+	isStream, decompressor := propertiesFromHeaders(req.Header)
+	stream := &http2Stream{
+		builder:       builder,
+		requestTracer: dataTracer{isRequest: true, isStreamProtocol: isStream, decompressor: decompressor, builder: builder},
+	}
+	c.collector.newAttempt(builder.trace.TestName)
+	if c.streams == nil {
+		c.streams = map[uint32]*http2Stream{}
+	}
+	c.streams[frame.StreamID] = stream
+	return stream
+}
+
+func (c *tracingHTTP2Conn) getExistingStream(streamID uint32) *http2Stream {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.streams[streamID]
+}
+
+func (c *tracingHTTP2Conn) closeStream(streamID uint32, stream *http2Stream, isRequest bool, err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !isRequest || err != nil {
+		// This is either end of response or an error, which means the
+		// whole operation done.
+		delete(c.streams, streamID)
+	}
+	if isRequest {
+		stream.requestTracer.emitUnfinished()
+		stream.builder.add(&RequestBodyEnd{Err: err})
+	} else if stream.responseTracer.builder != nil {
+		stream.responseTracer.emitUnfinished()
+		stream.builder.add(&ResponseBodyEnd{Err: err})
+	}
+}
+
+func (c *tracingHTTP2Conn) setMaxStreamID(maxStreamID uint32, err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.maxStreamID = maxStreamID
+	for streamID, stream := range c.streams {
+		if streamID > maxStreamID {
+			delete(c.streams, streamID)
+			stream.builder.add(&ResponseBodyEnd{Err: err})
+		}
+	}
+}
+
+func (c *tracingHTTP2Conn) cancelAll(err error) {
+	func() {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		for streamID, stream := range c.streams {
+			delete(c.streams, streamID)
+			if c.isServer {
+				stream.builder.add(&ResponseBodyEnd{Err: err})
+			} else {
+				stream.builder.add(&RequestBodyEnd{Err: err})
+			}
+		}
+	}()
+	c.collector.cancel()
+}
+
+type http2Stream struct {
+	builder        *builder
+	requestTracer  dataTracer
+	gotResponse    bool
+	responseTracer dataTracer
+}
+
+type http2FrameTracer struct {
+	c         *tracingHTTP2Conn
+	isRequest bool
+	decoder   *hpack.Decoder
+
+	prefaceBytes []byte
+	broken       bool
+	prefix       []byte
+	header       http2.FrameHeader
+	frame        bytes.Buffer
+	expecting    uint32
+	actual       uint64
+}
+
+func (h *http2FrameTracer) trace(data []byte) {
+	if h.broken {
+		return
+	}
+	for {
+		if len(data) == 0 {
+			return
+		}
+		if h.isRequest && len(h.prefaceBytes) < len(clientPreface) {
+			need := len(clientPreface) - len(h.prefaceBytes)
+			if len(data) < need {
+				h.prefaceBytes = append(h.prefaceBytes, data...)
+				return
+			}
+			h.prefaceBytes = append(h.prefaceBytes, data[:need]...)
+			data = data[need:]
+			if !prefaceIsValid(h.prefaceBytes) {
+				h.broken = true
+				return
+			}
+			if len(data) == 0 {
+				return
+			}
+		}
+
+		if h.expecting == 0 {
+			// still reading envelope prefix
+			n, done := h.traceHeaderLocked(data)
+			if !done {
+				// need to read more data to finish prefix
+				return
+			}
+			data = data[n:]
+			continue
+		}
+
+		n, done := h.traceFrameLocked(data)
+		if !done {
+			// need to read more data to finish message
+			return
+		}
+		data = data[n:]
+	}
+}
+
+func (h *http2FrameTracer) traceHeaderLocked(data []byte) (int, bool) {
+	need := frameHeaderLen - len(h.prefix)
+	if len(data) < need {
+		// envelope still not complete...
+		h.prefix = append(h.prefix, data...)
+		return need, false
+	}
+
+	h.prefix = append(h.prefix, data[:need]...)
+	var err error
+	h.header, err = http2.ReadFrameHeader(bytes.NewReader(h.prefix))
+	if err != nil {
+		h.broken = true
+		return need, false
+	}
+	h.expecting = h.header.Length
+	h.frame.Write(h.prefix)
+	h.prefix = h.prefix[:0]
+	if h.expecting == 0 {
+		return need, h.emitFrame()
+	}
+	return need, true
+}
+
+func (h *http2FrameTracer) traceFrameLocked(data []byte) (int, bool) {
+	need := int(h.expecting - uint32(h.actual))
+	if len(data) < need {
+		// message still not complete...
+		h.actual += uint64(len(data))
+		h.frame.Write(data)
+		return need, false
+	}
+
+	h.frame.Write(data[:need])
+	h.expecting = 0
+	h.actual = 0
+	return need, h.emitFrame()
+}
+
+func (h *http2FrameTracer) emitFrame() bool {
+	defer func() {
+		h.frame.Reset()
+	}()
+	framer := http2.NewFramer(io.Discard, &h.frame)
+	framer.ReadMetaHeaders = h.decoder
+	frame, err := framer.ReadFrame()
+	if err != nil {
+		h.broken = true
+		return false
+	}
+	h.c.handleFrame(frame, h.isRequest)
+	return true
+}
+
+type http2RetryCollector struct {
+	collector Collector
+	mu        sync.Mutex
+	waiting   map[string]*http2RetryWaitState
+}
+
+type http2RetryWaitState struct {
+	trace Trace
+	stop  func()
+}
+
+func (h *http2RetryCollector) Complete(trace Trace) {
+	if isRetryable(trace.Err) {
+		// When the server refuses the stream, the client may auto-retry. So instead of marking
+		// this trace as complete with this error, we will wait for a retry. If no retry occurs
+		// after a timeout (3 seconds), then we will complete the trace. If the retry does occur,
+		// we will ignore this erroneous trace.
+		h.mu.Lock()
+		defer h.mu.Unlock()
+		if h.waiting == nil {
+			h.waiting = map[string]*http2RetryWaitState{}
+		}
+		timer := time.AfterFunc(retryWait, func() {
+			h.timesUp(trace.TestName)
+		})
+		h.waiting[trace.TestName] = &http2RetryWaitState{
+			trace: trace,
+			stop:  func() { timer.Stop() },
+		}
+		return
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	_, alreadyInvoked := h.waiting[trace.TestName]
+	if !alreadyInvoked {
+		h.collector.Complete(trace)
+	}
+}
+
+func (h *http2RetryCollector) newAttempt(testName string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if state, ok := h.waiting[testName]; ok {
+		// This is a retry; cancel the pending wait task.
+		delete(h.waiting, testName)
+		state.stop()
+	}
+}
+
+func (h *http2RetryCollector) timesUp(testName string) {
+	h.mu.Lock()
+	state, ok := h.waiting[testName]
+	if ok {
+		delete(h.waiting, testName)
+	}
+	h.mu.Unlock()
+
+	if state == nil {
+		// This entry has already been replaced by a retry.
+		return
+	}
+	h.collector.Complete(state.trace)
+}
+
+func (h *http2RetryCollector) cancel() {
+	// No more retries coming, so go ahead and finish
+	// all operations that were waiting on a retry.
+	var allWaiting []*http2RetryWaitState
+	func() {
+		h.mu.Lock()
+		defer h.mu.Unlock()
+		allWaiting = make([]*http2RetryWaitState, 0, len(h.waiting))
+		for _, state := range h.waiting {
+			allWaiting = append(allWaiting, state)
+		}
+		h.waiting = nil
+	}()
+
+	for _, state := range allWaiting {
+		state.stop() // release timer resources
+		h.collector.Complete(state.trace)
+	}
+}
+
+func makeRequest(frame *http2.MetaHeadersFrame) *http.Request {
+	req := &http.Request{
+		Proto:      "HTTP/2.0",
+		ProtoMajor: 2,
+		ProtoMinor: 0,
+		URL: &url.URL{
+			Scheme: getPseudoHeader(frame, ":scheme"),
+			Host:   getPseudoHeader(frame, ":authority"),
+			Path:   getPseudoHeader(frame, ":path"),
+		},
+		Method: getPseudoHeader(frame, ":method"),
+		Header: makeHeaders(frame),
+	}
+	return req
+}
+
+func makeResponse(frame *http2.MetaHeadersFrame) *http.Response {
+	status := getPseudoHeader(frame, ":status")
+	var statusInt int
+	if status == "" {
+		statusInt = 500
+	} else {
+		var err error
+		statusInt, err = strconv.Atoi(status)
+		if err != nil {
+			statusInt = 500
+		}
+	}
+	return &http.Response{
+		Proto:      "HTTP/2.0",
+		ProtoMajor: 2,
+		ProtoMinor: 0,
+		StatusCode: statusInt,
+		Status:     http.StatusText(statusInt),
+		Header:     makeHeaders(frame),
+	}
+}
+
+func makeHeaders(frame *http2.MetaHeadersFrame) http.Header {
+	headers := make(http.Header, len(frame.Fields))
+	for _, hdr := range frame.Fields {
+		if strings.HasPrefix(hdr.Name, ":") {
+			continue // http/2 pseudo-header
+		}
+		headers.Add(hdr.Name, hdr.Value)
+	}
+	return headers
+}
+
+func getPseudoHeader(frame *http2.MetaHeadersFrame, headerName string) string {
+	for _, hdr := range frame.Fields {
+		if hdr.Name == headerName {
+			return hdr.Value
+		}
+	}
+	return ""
+}
+
+func prefaceIsValid(actual []byte) bool {
+	// We don't use bytes.Equal since clientPreface is a string, not []byte.
+	// And we don't convert both to string or both to []byte to avoid allocation.
+	if len(actual) != len(clientPreface) {
+		return false
+	}
+	for i := range actual {
+		if actual[i] != clientPreface[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func isRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+	var streamErr http2.StreamError
+	if errors.As(err, &streamErr) {
+		// Retryable if server refused this individual stream
+		return streamErr.Code == http2.ErrCodeRefusedStream
+	}
+	var connErr http2.ConnectionError
+	if errors.As(err, &connErr) {
+		// Retryable if server is performing graceful shutdown.
+		return http2.ErrCode(connErr) == http2.ErrCodeNo
+	}
+	return false
+}

--- a/internal/tracer/http2.go
+++ b/internal/tracer/http2.go
@@ -548,7 +548,7 @@ func makeResponse(frame *http2.MetaHeadersFrame) *http.Response {
 		ProtoMajor: 2,
 		ProtoMinor: 0,
 		StatusCode: statusInt,
-		Status:     http.StatusText(statusInt),
+		Status:     fmt.Sprintf("%d %s", statusInt, http.StatusText(statusInt)),
 		Header:     makeHeaders(frame),
 	}
 }

--- a/internal/tracer/tracer.go
+++ b/internal/tracer/tracer.go
@@ -30,6 +30,10 @@ import (
 )
 
 const (
+	// TraceTimeout is the delay that a consumer should be willing to wait
+	// for a trace, since they are produced asynchronously.
+	TraceTimeout = 5 * time.Second
+
 	requestPrefix  = " request>"
 	responsePrefix = "response<"
 )

--- a/internal/tracer/tracer_test.go
+++ b/internal/tracer/tracer_test.go
@@ -1,0 +1,555 @@
+// Copyright 2023-2024 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tracer
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"connectrpc.com/conformance/internal/compression"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
+)
+
+func TestTracer(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name        string
+		setupClient func(Collector) http.RoundTripper
+		setupServer func(Collector, net.Listener, http.HandlerFunc) (net.Listener, *http.Server)
+	}{
+		{
+			name: "http1-middleware",
+			setupClient: func(collector Collector) http.RoundTripper {
+				return TracingRoundTripper(http.DefaultTransport, collector)
+			},
+			setupServer: func(collector Collector, listener net.Listener, handler http.HandlerFunc) (net.Listener, *http.Server) {
+				return listener, &http.Server{
+					Handler:           TracingHandler(handler, collector),
+					ReadHeaderTimeout: 5 * time.Second,
+				}
+			},
+		},
+		{
+			name: "http2-middleware",
+			// Uses H2C to force HTTP/2 w/out dealing with TLS.
+			setupClient: func(collector Collector) http.RoundTripper {
+				h2cTransport := &http2.Transport{
+					AllowHTTP: true,
+					DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+						return (&net.Dialer{}).DialContext(ctx, network, addr)
+					},
+				}
+				return TracingRoundTripper(h2cTransport, collector)
+			},
+			setupServer: func(collector Collector, listener net.Listener, handler http.HandlerFunc) (net.Listener, *http.Server) {
+				return listener, &http.Server{
+					Handler:           h2c.NewHandler(TracingHandler(handler, collector), &http2.Server{}),
+					ReadHeaderTimeout: 5 * time.Second,
+				}
+			},
+		},
+		{
+			name: "http2-conn",
+			// Wraps net.Conn instances instead of using net/http middleware.
+			// Like above, uses H2C to force HTTP/2 w/out dealing with TLS.
+			setupClient: func(collector Collector) http.RoundTripper {
+				return &http2.Transport{
+					AllowHTTP: true,
+					DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+						conn, err := (&net.Dialer{}).DialContext(ctx, network, addr)
+						if err != nil {
+							return nil, err
+						}
+						return TracingHTTP2Conn(conn, false, collector), nil
+					},
+				}
+			},
+			setupServer: func(collector Collector, listener net.Listener, handler http.HandlerFunc) (net.Listener, *http.Server) {
+				return TracingHTTP2Listener(listener, collector), &http.Server{
+					Handler:           h2c.NewHandler(handler, &http2.Server{}),
+					ReadHeaderTimeout: 5 * time.Second,
+				}
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			var clientTracer, serverTracer Tracer
+			client := testCase.setupClient(&clientTracer)
+			listener, err := net.Listen("tcp", "127.0.0.1:0")
+			require.NoError(t, err)
+
+			responseData := []byte(`{"abc": "def","foo": "bar"}`)
+			var responseLenPrefix [4]byte
+			binary.BigEndian.PutUint32(responseLenPrefix[:], uint32(len(responseData)))
+
+			comp := compression.NewSnappyCompressor()
+			var compressedResponseBuffer bytes.Buffer
+			comp.Reset(&compressedResponseBuffer)
+			_, _ = comp.Write(responseData)
+			_ = comp.Close()
+			compressedResponseData := compressedResponseBuffer.Bytes()
+			var compressedResponseLenPrefix [4]byte
+			binary.BigEndian.PutUint32(compressedResponseLenPrefix[:], uint32(len(compressedResponseData)))
+
+			listener, server := testCase.setupServer(
+				&serverTracer,
+				listener,
+				func(respWriter http.ResponseWriter, req *http.Request) {
+					_, _ = io.Copy(io.Discard, req.Body)
+					_ = req.Body.Close()
+
+					switch req.Header.Get("Content-Type") {
+					case "application/proto":
+						respWriter.Header().Set("Custom-Header", "ABC")
+						respWriter.Header().Set("Content-Type", "application/json")
+						respWriter.WriteHeader(http.StatusConflict)
+						_, _ = respWriter.Write(responseData)
+					case "application/connect+proto":
+						respWriter.Header().Set("Custom-Header", "ABC")
+						respWriter.Header().Set("Content-Type", "application/connect+proto")
+						respWriter.Header().Set("Connect-Content-Encoding", "snappy")
+						respWriter.WriteHeader(http.StatusOK)
+						_, _ = respWriter.Write([]byte{0})
+						_, _ = respWriter.Write(responseLenPrefix[:])
+						_, _ = respWriter.Write(responseData)
+						_, _ = respWriter.Write([]byte{3})
+						_, _ = respWriter.Write(compressedResponseLenPrefix[:])
+						_, _ = respWriter.Write(compressedResponseData)
+					case "application/grpc-web+proto":
+						respWriter.Header().Set("Custom-Header", "ABC")
+						respWriter.Header().Set("Content-Type", "application/grpc-web")
+						_, _ = respWriter.Write([]byte{0})
+						_, _ = respWriter.Write(responseLenPrefix[:])
+						_, _ = respWriter.Write(responseData)
+						_, _ = respWriter.Write([]byte{128})
+						_, _ = respWriter.Write(responseLenPrefix[:])
+						_, _ = respWriter.Write(responseData)
+					case "application/grpc+proto":
+						respWriter.Header().Set("Custom-Header", "ABC")
+						respWriter.Header().Set("Content-Type", "application/grpc")
+						respWriter.Header().Set("Trailer", "Foo, Bar")
+						respWriter.WriteHeader(http.StatusOK)
+						_, _ = respWriter.Write([]byte{0})
+						_, _ = respWriter.Write(responseLenPrefix[:])
+						_, _ = respWriter.Write(responseData)
+						respWriter.Header().Set(http.TrailerPrefix+"Foo", "One")
+						respWriter.Header().Set(http.TrailerPrefix+"Bar", "Two")
+					default:
+						respWriter.Header().Set("Custom-Header", "ABC")
+						respWriter.Header().Set("Content-Type", "application/json")
+						respWriter.WriteHeader(http.StatusAccepted)
+						_, _ = respWriter.Write(responseData)
+					}
+				},
+			)
+			go func() {
+				err := server.Serve(listener)
+				// not using require since we're not on the main goroutine
+				assert.ErrorIs(t, err, http.ErrServerClosed)
+			}()
+			t.Cleanup(func() {
+				_ = server.Close()
+			})
+
+			serverAddr := listener.Addr().String()
+			requestData := []byte(`{"query": "I can haz cheezberder?"}`)
+			var requestLenPrefix [4]byte
+			binary.BigEndian.PutUint32(requestLenPrefix[:], uint32(len(requestData)))
+			testCalls := []struct {
+				name string
+				// This trace's request must be complete as a client-side
+				// request (and usable by an http.RoundTripper).
+				// The trace's response does not need to indicate body
+				// data and basically just reiterates the status code,
+				// headers, and trailers that the handler above emits.
+				// The trace events must be complete in terms of event
+				// types and order, but only body data and end stream
+				// events need their attributes populated.
+				expectTrace *Trace
+			}{
+				{
+					name: "connect-unary-post",
+					expectTrace: &Trace{
+						Request: &http.Request{
+							Method: http.MethodPost,
+							URL: &url.URL{
+								Path: "/com.foo.Service/Bar",
+							},
+							Header: headers(
+								"Content-Type", "application/proto",
+							),
+							Body: io.NopCloser(bytes.NewReader(requestData)),
+						},
+						Response: &http.Response{
+							StatusCode: http.StatusConflict,
+							Header: headers(
+								"Custom-Header", "ABC",
+								"Content-Type", "application/json",
+							),
+						},
+						Events: []Event{
+							&RequestStart{},
+							&RequestBodyData{
+								Len: uint64(len(requestData)),
+							},
+							&RequestBodyEnd{},
+							&ResponseStart{},
+							&ResponseBodyData{
+								Len: uint64(len(responseData)),
+							},
+							&ResponseBodyEnd{},
+						},
+					},
+				},
+				{
+					name: "connect-unary-get",
+					expectTrace: &Trace{
+						Request: &http.Request{
+							Method: http.MethodGet,
+							URL: &url.URL{
+								Path:     "/com.foo.Service/Bar",
+								RawQuery: "encoding=json&msg={}",
+							},
+							Header: headers(),
+							Body:   http.NoBody,
+						},
+						Response: &http.Response{
+							StatusCode: http.StatusAccepted,
+							Header: headers(
+								"Custom-Header", "ABC",
+								"Content-Type", "application/json",
+							),
+						},
+						Events: []Event{
+							&RequestStart{},
+							&RequestBodyEnd{},
+							&ResponseStart{},
+							&ResponseBodyData{
+								Len: uint64(len(responseData)),
+							},
+							&ResponseBodyEnd{},
+						},
+					},
+				},
+				{
+					name: "connect-stream",
+					expectTrace: &Trace{
+						Request: &http.Request{
+							Method: http.MethodPost,
+							URL: &url.URL{
+								Path: "/com.foo.Service/Bar",
+							},
+							Header: headers(
+								"Content-Type", "application/connect+proto",
+							),
+							Body: io.NopCloser(bytes.NewReader(concat(
+								[]byte{0},
+								requestLenPrefix[:],
+								requestData,
+							))),
+						},
+						Response: &http.Response{
+							StatusCode: http.StatusOK,
+							Header: headers(
+								"Custom-Header", "ABC",
+								"Content-Type", "application/connect+proto",
+								"Connect-Content-Encoding", "snappy",
+							),
+						},
+						Events: []Event{
+							&RequestStart{},
+							&RequestBodyData{
+								Envelope: &Envelope{
+									Flags: 0,
+									Len:   uint32(len(requestData)),
+								},
+								Len: uint64(len(requestData)),
+							},
+							&RequestBodyEnd{},
+							&ResponseStart{},
+							&ResponseBodyData{
+								Envelope: &Envelope{
+									Flags: 0,
+									Len:   uint32(len(responseData)),
+								},
+								Len: uint64(len(responseData)),
+							},
+							&ResponseBodyData{
+								Envelope: &Envelope{
+									Flags: 3,
+									Len:   uint32(len(compressedResponseData)),
+								},
+								Len: uint64(len(compressedResponseData)),
+							},
+							&ResponseBodyEndStream{
+								Content: string(responseData),
+							},
+							&ResponseBodyEnd{},
+						},
+					},
+				},
+				{
+					name: "grpc-web",
+					expectTrace: &Trace{
+						Request: &http.Request{
+							Method: http.MethodPost,
+							URL: &url.URL{
+								Path: "/com.foo.Service/Bar",
+							},
+							Header: headers(
+								"Content-Type", "application/grpc-web+proto",
+							),
+							Body: io.NopCloser(bytes.NewReader(concat(
+								[]byte{0},
+								requestLenPrefix[:],
+								requestData,
+							))),
+						},
+						Response: &http.Response{
+							StatusCode: http.StatusOK,
+							Header: headers(
+								"Custom-Header", "ABC",
+								"Content-Type", "application/grpc-web",
+							),
+						},
+						Events: []Event{
+							&RequestStart{},
+							&RequestBodyData{
+								Envelope: &Envelope{
+									Flags: 0,
+									Len:   uint32(len(requestData)),
+								},
+								Len: uint64(len(requestData)),
+							},
+							&RequestBodyEnd{},
+							&ResponseStart{},
+							&ResponseBodyData{
+								Envelope: &Envelope{
+									Flags: 0,
+									Len:   uint32(len(responseData)),
+								},
+								Len: uint64(len(responseData)),
+							},
+							&ResponseBodyData{
+								Envelope: &Envelope{
+									Flags: 128,
+									Len:   uint32(len(responseData)),
+								},
+								Len: uint64(len(responseData)),
+							},
+							&ResponseBodyEndStream{
+								Content: string(responseData),
+							},
+							&ResponseBodyEnd{},
+						},
+					},
+				},
+				{
+					name: "grpc",
+					expectTrace: &Trace{
+						Request: &http.Request{
+							Method: http.MethodPost,
+							URL: &url.URL{
+								Path: "/com.foo.Service/Bar",
+							},
+							Header: headers(
+								"Content-Type", "application/grpc+proto",
+								"TE", "trailers",
+							),
+							Body: io.NopCloser(bytes.NewReader(concat(
+								[]byte{0},
+								requestLenPrefix[:],
+								requestData,
+							))),
+						},
+						Response: &http.Response{
+							StatusCode: http.StatusOK,
+							Header: headers(
+								"Custom-Header", "ABC",
+								"Content-Type", "application/grpc",
+							),
+							Trailer: headers(
+								"Foo", "One",
+								"Bar", "Two",
+							),
+						},
+						Events: []Event{
+							&RequestStart{},
+							&RequestBodyData{
+								Envelope: &Envelope{
+									Flags: 0,
+									Len:   uint32(len(requestData)),
+								},
+								Len: uint64(len(requestData)),
+							},
+							&RequestBodyEnd{},
+							&ResponseStart{},
+							&ResponseBodyData{
+								Envelope: &Envelope{
+									Flags: 0,
+									Len:   uint32(len(responseData)),
+								},
+								Len: uint64(len(responseData)),
+							},
+							&ResponseBodyEnd{},
+						},
+					},
+				},
+			}
+			for _, testCall := range testCalls {
+				testCall := testCall
+				t.Run(testCall.name, func(t *testing.T) {
+					t.Parallel()
+					ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+					defer cancel()
+					req := testCall.expectTrace.Request.Clone(ctx)
+					req.URL.Host = serverAddr
+					req.URL.Scheme = "http"
+					req.Header.Set(testCaseNameHeader, t.Name())
+					clientTracer.Init(t.Name())
+					serverTracer.Init(t.Name())
+					resp, err := client.RoundTrip(req)
+					require.NoError(t, err)
+					_, _ = io.Copy(io.Discard, resp.Body)
+					_ = resp.Body.Close()
+					checkResponse(t, testCall.expectTrace.Response, resp)
+
+					serverTrace, err := serverTracer.Await(ctx, t.Name())
+					require.NoError(t, err)
+					checkTrace(t, testCall.expectTrace, serverTrace)
+
+					clientTrace, err := clientTracer.Await(ctx, t.Name())
+					require.NoError(t, err)
+					checkTrace(t, testCall.expectTrace, clientTrace)
+				})
+			}
+		})
+	}
+}
+
+func checkHeaders(t *testing.T, expected, actual http.Header) {
+	t.Helper()
+	require.GreaterOrEqual(t, len(actual), len(expected))
+	for k, expectedVals := range expected {
+		actualVals, ok := actual[k]
+		require.True(t, ok, "actual metadata missing key %q", k)
+		require.Equal(t, expectedVals, actualVals)
+	}
+}
+
+func checkRequest(t *testing.T, expected, actual *http.Request) {
+	t.Helper()
+	require.NotNil(t, actual)
+	require.Equal(t, expected.Method, actual.Method)
+	require.Equal(t, expected.URL.Path, actual.URL.Path)
+	require.Equal(t, expected.URL.RawQuery, actual.URL.RawQuery)
+	checkHeaders(t, expected.Header, actual.Header)
+	require.Empty(t, actual.Trailer)
+}
+
+func checkResponse(t *testing.T, expected, actual *http.Response) {
+	t.Helper()
+	require.NotNil(t, actual)
+	require.Equal(t, expected.StatusCode, actual.StatusCode)
+	checkHeaders(t, expected.Header, actual.Header)
+	checkHeaders(t, expected.Trailer, actual.Trailer)
+}
+
+func checkMessageEnvelope(t *testing.T, expected, actual *Envelope) {
+	t.Helper()
+	if expected == nil {
+		require.Nil(t, actual)
+		return
+	}
+	require.NotNil(t, actual)
+	require.Equal(t, expected.Flags, actual.Flags)
+	require.Equal(t, expected.Len, actual.Len)
+}
+
+func checkTrace(t *testing.T, expected, actual *Trace) {
+	t.Helper()
+	require.NotNil(t, actual)
+	require.NoError(t, actual.Err)
+	require.Len(t, actual.Events, len(expected.Events),
+		"want [%s]; got [%s]",
+		eventTypes(expected.Events), eventTypes(actual.Events))
+	for i, actualEvent := range actual.Events {
+		expectedEvent := expected.Events[i]
+		require.Equal(t, fmt.Sprintf("%T", expectedEvent), fmt.Sprintf("%T", actualEvent),
+			"event #%d; want [%s]; got [%s]",
+			i, eventTypes(expected.Events), eventTypes(actual.Events))
+		switch actualEvent := actualEvent.(type) {
+		case *RequestStart:
+			require.Same(t, actual.Request, actualEvent.Request)
+		case *RequestBodyData:
+			expectedEvent := expectedEvent.(*RequestBodyData) //nolint:errcheck,forcetypeassert // already checked type above
+			checkMessageEnvelope(t, expectedEvent.Envelope, actualEvent.Envelope)
+			require.Equal(t, expectedEvent.Len, actualEvent.Len)
+		case *ResponseStart:
+			require.Same(t, actual.Response, actualEvent.Response)
+		case *ResponseBodyData:
+			expectedEvent := expectedEvent.(*ResponseBodyData) //nolint:errcheck,forcetypeassert // already checked type above
+			checkMessageEnvelope(t, expectedEvent.Envelope, actualEvent.Envelope)
+			require.Equal(t, expectedEvent.Len, actualEvent.Len)
+		case *ResponseBodyEndStream:
+			expectedEvent := expectedEvent.(*ResponseBodyEndStream) //nolint:errcheck,forcetypeassert // already checked type above
+			require.Equal(t, expectedEvent.Content, actualEvent.Content)
+		default:
+			// we already checked event type above; nothing else to check for other events
+		}
+	}
+	checkRequest(t, expected.Request, actual.Request)
+	checkResponse(t, expected.Response, actual.Response)
+}
+
+func headers(kv ...string) http.Header {
+	result := make(http.Header, len(kv)/2)
+	for i := 0; i < len(kv); i += 2 {
+		result.Add(kv[i], kv[i+1])
+	}
+	return result
+}
+
+func concat(data ...[]byte) []byte {
+	result := data[0]
+	for i := 1; i < len(data); i++ {
+		result = append(result, data[i]...)
+	}
+	return result
+}
+
+func eventTypes(events []Event) string {
+	types := make([]string, len(events))
+	for i := range events {
+		types[i] = fmt.Sprintf("%T", events[i])
+	}
+	return strings.Join(types, ",")
+}


### PR DESCRIPTION
This adds a new tracing capability -- to wrap a `net.Conn` that represents an HTTP/2 connection and examine all of the HTTP/2 traffic to assemble a trace. This is used to instrument a gRPC client and server to support tracing, since they include their own HTTP/2 implementation instead of using `net/http`.

The only testing I've done is to set breakpoints in an IDE to make sure the trace events were flowing. I'll probably add some very basic tests of the tracing (both the new HTTP/2 stuff and the existing `net/http` stuff) and push them to this PR, just so we have more comfort that this stuff doesn't stays functional and doesn't regress since it is admittedly pretty complicated and not otherwise covered by tests.

This will resolve #817.