### PR TITLE
Fix `deflate` algorithm to adhere to RFC 1950

### DIFF
--- a/internal/compression/deflate.go
+++ b/internal/compression/deflate.go
@@ -30,14 +30,24 @@ type deflateDecompressor struct {
 }
 
 func (c *deflateDecompressor) Read(bytes []byte) (int, error) {
+	if c.reader == nil {
+		return 0, io.EOF
+	}
 	return c.reader.Read(bytes)
 }
 func (c *deflateDecompressor) Reset(rdr io.Reader) error {
-	var err error
-	c.reader, err = zlib.NewReader(rdr)
-	return err
+	reader, err := zlib.NewReader(rdr)
+	if err != nil {
+		c.reader = &errorDecompressor{err: err}
+		return err
+	}
+	c.reader = reader
+	return nil
 }
 func (c *deflateDecompressor) Close() error {
+	if c.reader == nil {
+		return nil
+	}
 	return c.reader.Close()
 }
 


### PR DESCRIPTION
We don't default to testing `deflate` right now, as far as I can tell, but this is a pretty potent footgun so I think it is definitely worth getting right.

Though it is not explicitly specified anywhere I can find, [gRPC seems to follow HTTP in treating `deflate` as RFC 1950 (zlib) instead of RFC 1951 (deflate)](https://github.com/grpc/grpc/blob/f99b8b5bc4a89d37f86bf063999ec22e44312663/src/core/lib/compression/message_compress.cc#L131).

The `deflateInit2` function's documentation can be found online [here](https://www.zlib.net/manual.html). But briefly:

- If `windowBits` is [-15, -8], raw deflate (RFC 1951) is used.
- If `windowBits` is [8, 15], deflate with zlib header (RFC 1950) is used.
- If `windowBits` is [24, 31], deflate with gzip header (RFC 1952) is used.

Following this, we can see that gRPC will use either gzip (for the `gzip` encoding) or zlib (for the `deflate` encoding.)