### PR TITLE
Reconcile test cases w/ latest spec changes and fixes from latest connect-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module connectrpc.com/conformance
 go 1.20
 
 require (
-	connectrpc.com/connect v1.15.0
+	connectrpc.com/connect v1.15.1-0.20240312013426-946e37a1e2d0
 	github.com/andybalholm/brotli v1.1.0
 	github.com/bufbuild/protoyaml-go v0.1.8
 	github.com/golang/snappy v0.0.4

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module connectrpc.com/conformance
 go 1.20
 
 require (
-	connectrpc.com/connect v1.15.1-0.20240318165016-0f46eaa59eb4
+	connectrpc.com/connect v1.16.0
 	github.com/andybalholm/brotli v1.1.0
 	github.com/bufbuild/protoyaml-go v0.1.8
 	github.com/golang/snappy v0.0.4

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module connectrpc.com/conformance
 go 1.20
 
 require (
-	connectrpc.com/connect v1.15.1-0.20240312013426-946e37a1e2d0
+	connectrpc.com/connect v1.15.1-0.20240318165016-0f46eaa59eb4
 	github.com/andybalholm/brotli v1.1.0
 	github.com/bufbuild/protoyaml-go v0.1.8
 	github.com/golang/snappy v0.0.4
@@ -20,7 +20,7 @@ require (
 	golang.org/x/sync v0.6.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240123012728-ef4313101c80
 	google.golang.org/grpc v1.62.0
-	google.golang.org/protobuf v1.32.0
+	google.golang.org/protobuf v1.33.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.31.0-2023110619213
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.31.0-20231106192134-1baebb0a1518.2/go.mod h1:xafc+XIsTxTy76GJQ1TKgvJWsSugFBqMaN27WhUblew=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
-connectrpc.com/connect v1.15.1-0.20240318165016-0f46eaa59eb4 h1:SIIcGoeWugMDCh+vln8Ri/HkrEMnOIF/Rj18Yi2W+Os=
-connectrpc.com/connect v1.15.1-0.20240318165016-0f46eaa59eb4/go.mod h1:XpZAduBQUySsb4/KO5JffORVkDI4B6/EYPi7N8xpNZw=
+connectrpc.com/connect v1.16.0 h1:rdtfQjZ0OyFkWPTegBNcH7cwquGAN1WzyJy80oFNibg=
+connectrpc.com/connect v1.16.0/go.mod h1:XpZAduBQUySsb4/KO5JffORVkDI4B6/EYPi7N8xpNZw=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.31.0-2023110619213
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.31.0-20231106192134-1baebb0a1518.2/go.mod h1:xafc+XIsTxTy76GJQ1TKgvJWsSugFBqMaN27WhUblew=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
-connectrpc.com/connect v1.15.0 h1:lFdeCbZrVVDydAqwr4xGV2y+ULn+0Z73s5JBj2LikWo=
-connectrpc.com/connect v1.15.0/go.mod h1:bQmjpDY8xItMnttnurVgOkHUBMRT9cpsNi2O4AjKhmA=
+connectrpc.com/connect v1.15.1-0.20240312013426-946e37a1e2d0 h1:O+k+ZPPgXw0iYTVo1BoKAPLLz9/ADWcFlv+SlqF2Ago=
+connectrpc.com/connect v1.15.1-0.20240312013426-946e37a1e2d0/go.mod h1:bQmjpDY8xItMnttnurVgOkHUBMRT9cpsNi2O4AjKhmA=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.31.0-2023110619213
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.31.0-20231106192134-1baebb0a1518.2/go.mod h1:xafc+XIsTxTy76GJQ1TKgvJWsSugFBqMaN27WhUblew=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
-connectrpc.com/connect v1.15.1-0.20240312013426-946e37a1e2d0 h1:O+k+ZPPgXw0iYTVo1BoKAPLLz9/ADWcFlv+SlqF2Ago=
-connectrpc.com/connect v1.15.1-0.20240312013426-946e37a1e2d0/go.mod h1:bQmjpDY8xItMnttnurVgOkHUBMRT9cpsNi2O4AjKhmA=
+connectrpc.com/connect v1.15.1-0.20240318165016-0f46eaa59eb4 h1:SIIcGoeWugMDCh+vln8Ri/HkrEMnOIF/Rj18Yi2W+Os=
+connectrpc.com/connect v1.15.1-0.20240318165016-0f46eaa59eb4/go.mod h1:XpZAduBQUySsb4/KO5JffORVkDI4B6/EYPi7N8xpNZw=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
@@ -543,8 +543,8 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
-google.golang.org/protobuf v1.32.0 h1:pPC6BG5ex8PDFnkbrGU3EixyhKcQ2aDuBS36lqK/C7I=
-google.golang.org/protobuf v1.32.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
+google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
+google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/app/connectconformance/testsuites/data/client_http_to_connect_code.yaml
+++ b/internal/app/connectconformance/testsuites/data/client_http_to_connect_code.yaml
@@ -1,16 +1,10 @@
 name: HTTP to Connect Code Mapping
 # If a server returns a non-200 HTTP code for unary requests without an
-# explicit Connect error code, the client must synthesize an RPC code
+# explicit RPC error code, the client must synthesize an RPC code
 # from the HTTP code. These tests cases verify that mapping by forcing
 # the server to return a specified HTTP code and then test whether the
 # client correctly returns the required RPC code.
-#
-# TODO: Remove relevant protocols once the Connect code mapping table
-#       is updated to align with gRPC.
-## https://github.com/connectrpc/connectrpc.com/pull/130
 mode: TEST_MODE_CLIENT
-relevantProtocols:
-  - PROTOCOL_CONNECT
 testCases:
 - request:
     testName: bad-request
@@ -18,12 +12,11 @@ testCases:
     requestMessages:
     - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
       responseDefinition:
-        responseData: "dGVzdCByZXNwb25zZQ=="
         rawResponse:
           statusCode: 400
   expectedResponse:
     error:
-      code: CODE_INVALID_ARGUMENT
+      code: CODE_INTERNAL
 - request:
     testName: unauthorized
     streamType: STREAM_TYPE_UNARY
@@ -58,17 +51,6 @@ testCases:
     error:
       code: CODE_UNIMPLEMENTED
 - request:
-    testName: request-timeout
-    streamType: STREAM_TYPE_UNARY
-    requestMessages:
-    - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
-      responseDefinition:
-        rawResponse:
-          statusCode: 408
-  expectedResponse:
-    error:
-      code: CODE_DEADLINE_EXCEEDED
-- request:
      testName: conflict
      streamType: STREAM_TYPE_UNARY
      requestMessages:
@@ -78,7 +60,7 @@ testCases:
            statusCode: 409
   expectedResponse:
     error:
-      code: CODE_ABORTED
+      code: CODE_UNKNOWN
 - request:
     testName: precondition-failed
     streamType: STREAM_TYPE_UNARY
@@ -89,7 +71,7 @@ testCases:
           statusCode: 412
   expectedResponse:
     error:
-      code: CODE_FAILED_PRECONDITION
+      code: CODE_UNKNOWN
 - request:
     testName: payload-too-large
     streamType: STREAM_TYPE_UNARY
@@ -100,20 +82,18 @@ testCases:
           statusCode: 413
   expectedResponse:
     error:
-      code: CODE_RESOURCE_EXHAUSTED
-# TODO - uncomment when conformance is updated to the latest release of connect-go
-# that includes this fix
-# - request:
-#     testName: unsupported media type
-#     streamType: STREAM_TYPE_UNARY
-#     requestMessages:
-#     - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
-#       responseDefinition:
-#         rawResponse:
-#           statusCode: 415
-#  expectedResponse:
-#    error:
-#      code: CODE_INTERNAL
+      code: CODE_UNKNOWN
+- request:
+    testName: unsupported media type
+    streamType: STREAM_TYPE_UNARY
+    requestMessages:
+    - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
+      responseDefinition:
+        rawResponse:
+          statusCode: 415
+  expectedResponse:
+    error:
+      code: CODE_UNKNOWN
 - request:
     testName: too-many-requests
     streamType: STREAM_TYPE_UNARY
@@ -135,7 +115,7 @@ testCases:
           statusCode: 431
   expectedResponse:
     error:
-      code: CODE_RESOURCE_EXHAUSTED
+      code: CODE_UNKNOWN
 - request:
     testName: bad-gateway
     streamType: STREAM_TYPE_UNARY
@@ -169,4 +149,14 @@ testCases:
   expectedResponse:
     error:
       code: CODE_UNAVAILABLE
-
+- request:
+    testName: http-version-not-supported
+    streamType: STREAM_TYPE_UNARY
+    requestMessages:
+      - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
+        responseDefinition:
+          rawResponse:
+            statusCode: 505
+  expectedResponse:
+    error:
+      code: CODE_UNKNOWN

--- a/internal/app/connectconformance/testsuites/data/client_http_to_rpc_code.yaml
+++ b/internal/app/connectconformance/testsuites/data/client_http_to_rpc_code.yaml
@@ -1,4 +1,4 @@
-name: HTTP to Connect Code Mapping
+name: HTTP to RPC Code Mapping
 # If a server returns a non-200 HTTP code for unary requests without an
 # explicit RPC error code, the client must synthesize an RPC code
 # from the HTTP code. These tests cases verify that mapping by forcing

--- a/internal/app/connectconformance/testsuites/data/connect_client_code_to_http_code.yaml
+++ b/internal/app/connectconformance/testsuites/data/connect_client_code_to_http_code.yaml
@@ -14,7 +14,7 @@ testCases:
         error:
           code: CODE_CANCELED
   expectedResponse:
-    httpStatusCode: 408
+    httpStatusCode: 499
     error:
       code: CODE_CANCELED
       details: 
@@ -71,7 +71,7 @@ testCases:
         error:
           code: CODE_DEADLINE_EXCEEDED
   expectedResponse:
-    httpStatusCode: 408
+    httpStatusCode: 504
     error:
       code: CODE_DEADLINE_EXCEEDED
       details: 
@@ -166,7 +166,7 @@ testCases:
         error:
           code: CODE_FAILED_PRECONDITION
   expectedResponse:
-    httpStatusCode: 412
+    httpStatusCode: 400
     error:
       code: CODE_FAILED_PRECONDITION
       details: 
@@ -223,7 +223,7 @@ testCases:
         error:
           code: CODE_UNIMPLEMENTED
   expectedResponse:
-    httpStatusCode: 404
+    httpStatusCode: 501
     error:
       code: CODE_UNIMPLEMENTED
       details: 

--- a/internal/app/connectconformance/testsuites/data/connect_client_error_endstream.yaml
+++ b/internal/app/connectconformance/testsuites/data/connect_client_error_endstream.yaml
@@ -248,33 +248,31 @@ testCases:
       error:
         code: CODE_UNKNOWN
         message: oops
-#  # TODO: uncomment this once connect-go can de-serialize the
-#  #        rest of the JSON in the face of an invalid code
-#  - request:
-#      testName: end-stream/unrecognized-code
-#      service: connectrpc.conformance.v1.ConformanceService
-#      method: ServerStream
-#      streamType: STREAM_TYPE_SERVER_STREAM
-#      requestMessages:
-#        - "@type": type.googleapis.com/connectrpc.conformance.v1.ServerStreamRequest
-#          responseDefinition:
-#            rawResponse:
-#              statusCode: 200
-#              headers:
-#                - name: content-type
-#                  value: [ "application/connect+proto" ]
-#              stream:
-#                items:
-#                  - flags: 2
-#                    payload:
-#                      text: |
-#                        {
-#                          "error": { "code": "foobar", "message": "oops" }
-#                        }
-#    expectedResponse:
-#      error:
-#        code: CODE_UNKNOWN
-#        message: oops
+  - request:
+      testName: end-stream/unrecognized-code
+      service: connectrpc.conformance.v1.ConformanceService
+      method: ServerStream
+      streamType: STREAM_TYPE_SERVER_STREAM
+      requestMessages:
+        - "@type": type.googleapis.com/connectrpc.conformance.v1.ServerStreamRequest
+          responseDefinition:
+            rawResponse:
+              statusCode: 200
+              headers:
+                - name: content-type
+                  value: [ "application/connect+proto" ]
+              stream:
+                items:
+                  - flags: 2
+                    payload:
+                      text: |
+                        {
+                          "error": { "code": "foobar", "message": "oops" }
+                        }
+    expectedResponse:
+      error:
+        code: CODE_UNKNOWN
+        message: oops
   - request:
       testName: end-stream/allow-unrecognized-fields
       service: connectrpc.conformance.v1.ConformanceService

--- a/internal/app/connectconformance/testsuites/data/connect_client_error_endstream.yaml
+++ b/internal/app/connectconformance/testsuites/data/connect_client_error_endstream.yaml
@@ -22,7 +22,7 @@ testCases:
                 text: "null"
     expectedResponse:
       error:
-        code: CODE_UNKNOWN
+        code: CODE_UNAUTHENTICATED
   - request:
       testName: error/null-code
       service: connectrpc.conformance.v1.ConformanceService
@@ -41,7 +41,7 @@ testCases:
                   { "code": null, "message": "oops" }
     expectedResponse:
       error:
-        code: CODE_UNKNOWN
+        code: CODE_UNAUTHENTICATED
         message: oops
   - request:
       testName: error/missing-code
@@ -61,31 +61,28 @@ testCases:
                   { "message": "oops" }
     expectedResponse:
       error:
-        code: CODE_UNKNOWN
+        code: CODE_UNAUTHENTICATED
         message: oops
-
-#  # TODO: uncomment this once connect-go can de-serialize the
-#  #        rest of the JSON in the face of an invalid code
-#  - request:
-#      testName: error/unrecognized-code
-#      service: connectrpc.conformance.v1.ConformanceService
-#      method: Unary
-#      streamType: STREAM_TYPE_UNARY
-#      requestMessages:
-#        - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
-#          responseDefinition:
-#            rawResponse:
-#              statusCode: 422
-#              headers:
-#                - name: content-type
-#                  value: [ "application/json" ]
-#              unary:
-#                text: |
-#                  { "code": "foobar", "message": "oops" }
-#    expectedResponse:
-#      error:
-#        code: CODE_UNKNOWN
-#        message: oops
+  - request:
+      testName: error/unrecognized-code
+      service: connectrpc.conformance.v1.ConformanceService
+      method: Unary
+      streamType: STREAM_TYPE_UNARY
+      requestMessages:
+        - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
+          responseDefinition:
+            rawResponse:
+              statusCode: 429
+              headers:
+                - name: content-type
+                  value: [ "application/json" ]
+              unary:
+                text: |
+                  { "code": "foobar", "message": "oops" }
+    expectedResponse:
+      error:
+        code: CODE_UNAVAILABLE
+        message: oops
   - request:
       testName: error/allow-unrecognized-fields
       service: connectrpc.conformance.v1.ConformanceService

--- a/internal/app/connectconformance/testsuites/data/connect_client_unexpected.yaml
+++ b/internal/app/connectconformance/testsuites/data/connect_client_unexpected.yaml
@@ -14,7 +14,7 @@ testCases:
         - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
           responseDefinition:
             rawResponse:
-              statusCode: 412
+              statusCode: 403
               headers:
                 - name: content-type
                   value: [ "application/proto" ]
@@ -22,8 +22,8 @@ testCases:
                 binary_message: { "@type": "type.googleapis.com/connectrpc.conformance.v1.UnaryResponse"}
     expectedResponse:
       error:
-        # mapped from 412 status code (invalid body ignored)
-        code: CODE_FAILED_PRECONDITION
+        # mapped from 403 status code (invalid body ignored)
+        code: CODE_PERMISSION_DENIED
 
   - request:
       testName: client-stream/ok-but-no-response

--- a/internal/app/connectconformance/testsuites/data/connect_client_unexpected.yaml
+++ b/internal/app/connectconformance/testsuites/data/connect_client_unexpected.yaml
@@ -43,7 +43,7 @@ testCases:
                       text: |
                         {
                           "code": "out_of_range",
-                          "message": "oops",
+                          "message": "oops"
                         }
     expectedResponse:
       error:
@@ -74,7 +74,7 @@ testCases:
                       text: |
                         {
                           "code": "out_of_range",
-                          "message": "oops",
+                          "message": "oops"
                         }
     expectedResponse:
       error:

--- a/internal/app/connectconformance/testsuites/data/connect_server_unexpected.yaml
+++ b/internal/app/connectconformance/testsuites/data/connect_server_unexpected.yaml
@@ -8,6 +8,24 @@ relevantCodecs:
   - CODEC_PROTO
 testCases:
   - request:
+      testName: unexpected-content-type
+      streamType: STREAM_TYPE_UNARY
+      requestMessages:
+        - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
+      rawRequest:
+        verb: POST
+        uri: /connectrpc.conformance.v1.ConformanceService/Unary
+        headers:
+          - name: content-type
+            value: [ "image/jpeg" ]
+        unary:
+          binary: "12345678"
+    expectedResponse:
+      httpStatusCode: 415
+      error:
+        code: CODE_UNKNOWN
+
+  - request:
       testName: server-stream/no-request
       streamType: STREAM_TYPE_SERVER_STREAM
       requestMessages:

--- a/internal/app/connectconformance/testsuites/data/grpc_client_unexpected.yaml
+++ b/internal/app/connectconformance/testsuites/data/grpc_client_unexpected.yaml
@@ -183,14 +183,9 @@ testCases:
               headers:
                 - name: Content-Type
                   value: [ "image/jpeg" ]
-    otherAllowedErrorCodes:
-      # Not actually specified what error code to use, but only
-      # internal and unknown really make any sense. There may be
-      # an argument for unimplemented, too.
-      - CODE_INTERNAL
-      - CODE_UNIMPLEMENTED
     expectedResponse:
       error:
+        # derived from 200 response code
         code: CODE_UNKNOWN
   - request:
       testName: unexpected-codec

--- a/internal/app/connectconformance/testsuites/data/grpc_server_unexpected.yaml
+++ b/internal/app/connectconformance/testsuites/data/grpc_server_unexpected.yaml
@@ -128,32 +128,33 @@ testCases:
     expectedResponse:
       error:
         code: CODE_UNIMPLEMENTED
-## TODO: uncomment this test case once connect-go distinguishes between unknown
-##       (content-type that is clearly not an RPC client, can send back 415 status)
-##       and internal (looks like an RPC client, but unsupported codec, so send
-##       back RPC error response).
-## https://github.com/connectrpc/connect-go/issues/689
-#  - request:
-#      testName: unexpected codec
-#      streamType: STREAM_TYPE_UNARY
-#      requestMessages:
-#        - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
-#      rawRequest:
-#        verb: POST
-#        uri: /connectrpc.conformance.v1.ConformanceService/Unary
-#        headers:
-#          - name: content-type
-#            value: [ "application/grpc+foo" ]
-#          - name: te
-#            value: [ "trailers" ]
-#        stream:
-#          items:
-#            - flags: 0
-#              payload:
-#                binary_message: { "@type": "type.googleapis.com/connectrpc.conformance.v1.UnaryRequest"}
-#    expectedResponse:
-#      error:
-#        code: CODE_INTERNAL
+  - request:
+      testName: unexpected codec
+      streamType: STREAM_TYPE_UNARY
+      requestMessages:
+        - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
+      rawRequest:
+        verb: POST
+        uri: /connectrpc.conformance.v1.ConformanceService/Unary
+        headers:
+          - name: content-type
+            value: [ "application/grpc+foo" ]
+          - name: te
+            value: [ "trailers" ]
+        stream:
+          items:
+            - flags: 0
+              payload:
+                binary_message: { "@type": "type.googleapis.com/connectrpc.conformance.v1.UnaryRequest"}
+    otherAllowedErrorCodes:
+      # Not actually specified what error code to use, but only
+      # internal and unknown really make any sense. There may be
+      # an argument for unimplemented, too.
+      - CODE_INTERNAL
+      - CODE_UNIMPLEMENTED
+    expectedResponse:
+      error:
+        code: CODE_UNKNOWN
   - request:
       testName: unexpected-compression
       streamType: STREAM_TYPE_UNARY

--- a/internal/app/connectconformance/testsuites/data/grpc_server_unexpected.yaml
+++ b/internal/app/connectconformance/testsuites/data/grpc_server_unexpected.yaml
@@ -8,6 +8,31 @@ relevantCodecs:
   - CODEC_PROTO
 testCases:
   - request:
+      testName: unexpected-content-type
+      streamType: STREAM_TYPE_UNARY
+      requestMessages:
+        - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
+      rawRequest:
+        verb: POST
+        uri: /connectrpc.conformance.v1.ConformanceService/Unary
+        headers:
+          - name: content-type
+            value: [ "image/jpeg" ]
+        unary:
+          binary: "12345678"
+    otherAllowedErrorCodes:
+      # Not actually specified what error code to use, but only
+      # internal and unknown really make any sense. There may be
+      # an argument for unimplemented, too.
+      - CODE_INTERNAL
+      - CODE_UNIMPLEMENTED
+    expectedResponse:
+      # Ideally, the server would return a 415. But it's not actually specified :/
+      # httpStatusCode: 415
+      error:
+        code: CODE_UNKNOWN
+
+  - request:
       testName: unary/no-request
       streamType: STREAM_TYPE_UNARY
       requestMessages:

--- a/internal/app/connectconformance/testsuites/data/grpc_server_unexpected.yaml
+++ b/internal/app/connectconformance/testsuites/data/grpc_server_unexpected.yaml
@@ -103,10 +103,18 @@ testCases:
             - flags: 0
               payload:
                 binary_message: { "@type": "type.googleapis.com/connectrpc.conformance.v1.UnaryRequest"}
+    otherAllowedErrorCodes:
+      # Not actually specified what error code to use, but only
+      # internal and unknown really make any sense. There may be
+      # an argument for unimplemented, too.
+      - CODE_INTERNAL
+      - CODE_UNIMPLEMENTED
     expectedResponse:
-      httpStatusCode: 405
+      # Ideally, the server would return a 405. But it's not actually specified :/
+      # httpStatusCode: 405
       error:
         code: CODE_UNKNOWN
+
   - request:
       testName: unexpected-uri
       streamType: STREAM_TYPE_UNARY

--- a/internal/app/connectconformance/testsuites/data/grpc_web_client_unexpected.yaml
+++ b/internal/app/connectconformance/testsuites/data/grpc_web_client_unexpected.yaml
@@ -242,14 +242,9 @@ testCases:
               headers:
                 - name: Content-Type
                   value: [ "image/jpeg" ]
-    otherAllowedErrorCodes:
-      # Not actually specified what error code to use, but only
-      # internal and unknown really make any sense. There may be
-      # an argument for unimplemented, too.
-      - CODE_INTERNAL
-      - CODE_UNIMPLEMENTED
     expectedResponse:
       error:
+        # derived from 200 response code
         code: CODE_UNKNOWN
   - request:
       testName: unexpected-codec

--- a/internal/app/connectconformance/testsuites/data/grpc_web_server_unexpected.yaml
+++ b/internal/app/connectconformance/testsuites/data/grpc_web_server_unexpected.yaml
@@ -124,30 +124,31 @@ testCases:
     expectedResponse:
       error:
         code: CODE_UNIMPLEMENTED
-  ## TODO: uncomment this test case once connect-go distinguishes between unknown
-  ##       (content-type that is clearly not an RPC client, can send back 415 status)
-  ##       and internal (looks like an RPC client, but unsupported codec, so send
-  ##       back RPC error response).
-  ## https://github.com/connectrpc/connect-go/issues/689
-  #  - request:
-  #      testName: unexpected-codec
-  #      streamType: STREAM_TYPE_UNARY
-  #      requestMessages:
-  #        - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
-  #      rawRequest:
-  #        verb: POST
-  #        uri: /connectrpc.conformance.v1.ConformanceService/Unary
-  #        headers:
-  #          - name: content-type
-  #            value: [ "application/grpc-web+foo" ]
-  #        stream:
-  #          items:
-  #            - flags: 0
-  #              payload:
-  #                binary_message: { "@type": "type.googleapis.com/connectrpc.conformance.v1.UnaryRequest"}
-  #    expectedResponse:
-  #      error:
-  #        code: CODE_INTERNAL
+  - request:
+      testName: unexpected-codec
+      streamType: STREAM_TYPE_UNARY
+      requestMessages:
+        - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
+      rawRequest:
+        verb: POST
+        uri: /connectrpc.conformance.v1.ConformanceService/Unary
+        headers:
+          - name: content-type
+            value: [ "application/grpc-web+foo" ]
+        stream:
+          items:
+            - flags: 0
+              payload:
+                binary_message: { "@type": "type.googleapis.com/connectrpc.conformance.v1.UnaryRequest"}
+    otherAllowedErrorCodes:
+      # Not actually specified what error code to use, but only
+      # internal and unknown really make any sense. There may be
+      # an argument for unimplemented, too.
+      - CODE_INTERNAL
+      - CODE_UNIMPLEMENTED
+    expectedResponse:
+      error:
+        code: CODE_UNKNOWN
   - request:
       testName: unexpected-compression
       streamType: STREAM_TYPE_UNARY

--- a/internal/app/connectconformance/testsuites/data/grpc_web_server_unexpected.yaml
+++ b/internal/app/connectconformance/testsuites/data/grpc_web_server_unexpected.yaml
@@ -101,10 +101,18 @@ testCases:
             - flags: 0
               payload:
                 binary_message: { "@type": "type.googleapis.com/connectrpc.conformance.v1.UnaryRequest"}
+    otherAllowedErrorCodes:
+      # Not actually specified what error code to use, but only
+      # internal and unknown really make any sense. There may be
+      # an argument for unimplemented, too.
+      - CODE_INTERNAL
+      - CODE_UNIMPLEMENTED
     expectedResponse:
-      httpStatusCode: 405
+      # Ideally, the server would return a 405. But it's not actually specified :/
+      # httpStatusCode: 405
       error:
         code: CODE_UNKNOWN
+
   - request:
       testName: unexpected-uri
       streamType: STREAM_TYPE_UNARY

--- a/internal/app/connectconformance/testsuites/data/grpc_web_server_unexpected.yaml
+++ b/internal/app/connectconformance/testsuites/data/grpc_web_server_unexpected.yaml
@@ -8,6 +8,31 @@ relevantCodecs:
   - CODEC_PROTO
 testCases:
   - request:
+      testName: unexpected-content-type
+      streamType: STREAM_TYPE_UNARY
+      requestMessages:
+        - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
+      rawRequest:
+        verb: POST
+        uri: /connectrpc.conformance.v1.ConformanceService/Unary
+        headers:
+          - name: content-type
+            value: [ "image/jpeg" ]
+        unary:
+          binary: "12345678"
+    otherAllowedErrorCodes:
+      # Not actually specified what error code to use, but only
+      # internal and unknown really make any sense. There may be
+      # an argument for unimplemented, too.
+      - CODE_INTERNAL
+      - CODE_UNIMPLEMENTED
+    expectedResponse:
+      # Ideally, the server would return a 415. But it's not actually specified :/
+      # httpStatusCode: 415
+      error:
+        code: CODE_UNKNOWN
+
+  - request:
       testName: unary/no-request
       streamType: STREAM_TYPE_UNARY
       requestMessages:

--- a/internal/app/connectconformance/testsuites/data/server_unexpected.yaml
+++ b/internal/app/connectconformance/testsuites/data/server_unexpected.yaml
@@ -1,8 +1,0 @@
-name: Server Unexpected Requests
-mode: TEST_MODE_SERVER
-relevantCompressions:
-  - COMPRESSION_IDENTITY
-relevantCodecs:
-  - CODEC_PROTO
-testCases:
-

--- a/internal/app/connectconformance/testsuites/data/server_unexpected.yaml
+++ b/internal/app/connectconformance/testsuites/data/server_unexpected.yaml
@@ -1,6 +1,3 @@
-# TODO: remove the ".disabled" extension from this file once Connect's HTTP -> Code
-#       mapping has been reconciled with gRPC. Until then, this test case fails.
-# https://github.com/connectrpc/connectrpc.com/pull/130
 name: Server Unexpected Requests
 mode: TEST_MODE_SERVER
 relevantCompressions:

--- a/internal/app/connectconformance/testsuites/data/server_unexpected.yaml
+++ b/internal/app/connectconformance/testsuites/data/server_unexpected.yaml
@@ -5,27 +5,4 @@ relevantCompressions:
 relevantCodecs:
   - CODEC_PROTO
 testCases:
-  - request:
-      testName: unexpected-content-type
-      streamType: STREAM_TYPE_UNARY
-      requestMessages:
-        - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
-      rawRequest:
-        verb: POST
-        uri: /connectrpc.conformance.v1.ConformanceService/Unary
-        headers:
-          - name: content-type
-            value: [ "image/jpeg" ]
-        unary:
-          binary: "12345678"
-    otherAllowedErrorCodes:
-      # Not actually specified what error code to use, but only
-      # internal and unknown really make any sense. There may be
-      # an argument for unimplemented, too.
-      - CODE_INTERNAL
-      - CODE_UNIMPLEMENTED
-    expectedResponse:
-      # Ideally, the server would return a 415. But it's not actually specified :/
-      # httpStatusCode: 415
-      error:
-        code: CODE_UNKNOWN
+

--- a/internal/app/connectconformance/testsuites/data/server_unexpected.yaml
+++ b/internal/app/connectconformance/testsuites/data/server_unexpected.yaml
@@ -6,7 +6,7 @@ relevantCodecs:
   - CODEC_PROTO
 testCases:
   - request:
-      testName: unexpected content type
+      testName: unexpected-content-type
       streamType: STREAM_TYPE_UNARY
       requestMessages:
         - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
@@ -18,7 +18,14 @@ testCases:
             value: [ "image/jpeg" ]
         unary:
           binary: "12345678"
+    otherAllowedErrorCodes:
+      # Not actually specified what error code to use, but only
+      # internal and unknown really make any sense. There may be
+      # an argument for unimplemented, too.
+      - CODE_INTERNAL
+      - CODE_UNIMPLEMENTED
     expectedResponse:
-      httpStatusCode: 415
+      # Ideally, the server would return a 415. But it's not actually specified :/
+      # httpStatusCode: 415
       error:
         code: CODE_UNKNOWN

--- a/testing/grpcserver-web-known-failing.txt
+++ b/testing/grpcserver-web-known-failing.txt
@@ -1,16 +1,8 @@
-# These return 400 instead of 405 and 415. This is an inconsistency in grpc-go
-# between using its builtin HTTP/2 implementation vs. using net/http. So the
-#  normal grpc protocol works (using the former); it's just grpc-web that does not.
-# These will be fixed in the next release of grpc-go:
-#    https://github.com/grpc/grpc-go/pull/6989
-gRPC-Web Unexpected Requests/**/unexpected-verb
-Server Unexpected Requests/HTTPVersion:1/**/unexpected content type
-
- # The entries for "cardinality violation" in the following doc indicate that
- # these cases should fail with "unimplemented":
- #   https://grpc.github.io/grpc/core/md_doc_statuscodes.html
- # But the grpc-go client instead fails with "unknown".
- **/unary/multiple-requests
- **/unary/no-request
- **/server-stream/multiple-requests
- **/server-stream/no-request
+# The entries for "cardinality violation" in the following doc indicate that
+# these cases should fail with "unimplemented":
+#   https://grpc.github.io/grpc/core/md_doc_statuscodes.html
+# But the grpc-go client instead fails with "unknown".
+**/unary/multiple-requests
+**/unary/no-request
+**/server-stream/multiple-requests
+**/server-stream/no-request

--- a/testing/grpcserver-web-known-failing.txt
+++ b/testing/grpcserver-web-known-failing.txt
@@ -1,6 +1,10 @@
- # This returns 400 instead of 405. This is an inconsistency in grpc-go.
- # https://github.com/grpc/grpc-go/pull/6989
- gRPC-Web Unexpected Requests/**/unexpected-verb
+# These return 400 instead of 405 and 415. This is an inconsistency in grpc-go
+# between using its builtin HTTP/2 implementation vs. using net/http. So the
+#  normal grpc protocol works (using the former); it's just grpc-web that does not.
+# These will be fixed in the next release of grpc-go:
+#    https://github.com/grpc/grpc-go/pull/6989
+gRPC-Web Unexpected Requests/**/unexpected-verb
+Server Unexpected Requests/HTTPVersion:1/**/unexpected content type
 
  # The entries for "cardinality violation" in the following doc indicate that
  # these cases should fail with "unimplemented":

--- a/testing/grpcwebclient-known-failing.txt
+++ b/testing/grpcwebclient-known-failing.txt
@@ -27,11 +27,11 @@ gRPC-Web Unexpected Responses/**/ok-but-no-response
 #   https://github.com/grpc/grpc/blob/master/doc/http-grpc-status-mapping.md
 # Instead, it always returns an "unknown" code if the response does not include a
 # grpc-status header/trailer key.
-HTTP to Connect Code Mapping/**/bad-gateway
-HTTP to Connect Code Mapping/**/bad-request
-HTTP to Connect Code Mapping/**/forbidden
-HTTP to Connect Code Mapping/**/gateway-timeout
-HTTP to Connect Code Mapping/**/not-found
-HTTP to Connect Code Mapping/**/service-unavailable
-HTTP to Connect Code Mapping/**/too-many-requests
-HTTP to Connect Code Mapping/**/unauthorized
+HTTP to RPC Code Mapping/**/bad-gateway
+HTTP to RPC Code Mapping/**/bad-request
+HTTP to RPC Code Mapping/**/forbidden
+HTTP to RPC Code Mapping/**/gateway-timeout
+HTTP to RPC Code Mapping/**/not-found
+HTTP to RPC Code Mapping/**/service-unavailable
+HTTP to RPC Code Mapping/**/too-many-requests
+HTTP to RPC Code Mapping/**/unauthorized

--- a/testing/grpcwebclient-known-failing.txt
+++ b/testing/grpcwebclient-known-failing.txt
@@ -21,3 +21,17 @@ gRPC-Web Unexpected Responses/**/unexpected-compressed-message
 gRPC-Web Unexpected Responses/**/unexpected-compression
 gRPC-Web Unexpected Responses/**/multiple-responses
 gRPC-Web Unexpected Responses/**/ok-but-no-response
+
+# The gRPC-Web client does not appear to actually implement the HTTP to gRPC status code
+# mapping described in this part of the spec:
+#   https://github.com/grpc/grpc/blob/master/doc/http-grpc-status-mapping.md
+# Instead, it always returns an "unknown" code if the response does not include a
+# grpc-status header/trailer key.
+HTTP to Connect Code Mapping/**/bad-gateway
+HTTP to Connect Code Mapping/**/bad-request
+HTTP to Connect Code Mapping/**/forbidden
+HTTP to Connect Code Mapping/**/gateway-timeout
+HTTP to Connect Code Mapping/**/not-found
+HTTP to Connect Code Mapping/**/service-unavailable
+HTTP to Connect Code Mapping/**/too-many-requests
+HTTP to Connect Code Mapping/**/unauthorized

--- a/testing/referenceclient-known-failing.txt
+++ b/testing/referenceclient-known-failing.txt
@@ -1,11 +1,1 @@
-# Currently, connect-go returns an "internal" error when either of these occurs.
-# However, the gRPC specs state that a problem with message cardinality (where
-# a single message is expected but stream actually has a different number), in
-# both clients and servers, should be an "unimplemented" error.
-#
-# Search for "cardinality violation" in this doc:
-#   https://grpc.github.io/grpc/core/md_doc_statuscodes.html
-**/unary/multiple-responses
-**/unary/ok-but-no-response
-**/client-stream/multiple-responses
-**/client-stream/ok-but-no-response
+# W00T! There are no known failures in the reference client.

--- a/testing/referenceclient-known-failing.txt
+++ b/testing/referenceclient-known-failing.txt
@@ -1,1 +1,1 @@
-# W00T! There are no known failures in the reference client.
+# There are no known failures in the reference client.

--- a/testing/referenceserver-known-failing.txt
+++ b/testing/referenceserver-known-failing.txt
@@ -1,1 +1,1 @@
-# W00T! There are no known failures in the reference server.
+# There are no known failures in the reference server.

--- a/testing/referenceserver-known-failing.txt
+++ b/testing/referenceserver-known-failing.txt
@@ -1,8 +1,1 @@
-# The entries for "cardinality violation" in the following doc indicate that
-# these cases should fail with "unimplemented":
-#   https://grpc.github.io/grpc/core/md_doc_statuscodes.html
-# But the grpc-go client instead fails with "unknown".
-**/unary/multiple-requests
-**/unary/no-request
-**/server-stream/multiple-requests
-**/server-stream/no-request
+# W00T! There are no known failures in the reference server.


### PR DESCRIPTION
This updates to the latest connect-go release and reconciles the test cases with the latest spec changes (from https://github.com/connectrpc/connectrpc.com/pull/130). It also enables some other tests that were waiting on connect-go fixes and cleans up the "known failing" lists based on these fixes and the new test cases. Finally, there are some tweaks to gRPC test cases, related to relaxing error code assertions.

This should be the last thing we need before releasing v1.0.0-rc4.

Resolves #810.

This also brings in [a fix in connect-go](https://github.com/connectrpc/connect-go/pull/709) that resolves #813.