### PR TITLE
Troubleshoot and fix issues in grpc-web JS conformance client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,11 +110,7 @@ runclienttests: $(BIN)/connectconformance $(BIN)/referenceclient $(BIN)/grpcclie
 	$(BIN)/connectconformance -v --conf ./testing/grpc-impls-config.yaml --mode client --trace \
 		--known-failing @./testing/grpcclient-known-failing.txt \
 		-- $(BIN)/grpcclient
-	@# Note that use of --skip is discouraged, but if we don't skip them the client crashes.
-	@# TODO: troubleshoot the skipped test cases and figure out why they crash.
 	$(BIN)/connectconformance -v --conf ./testing/grpc-web-client-impl-config.yaml --mode client --trace \
-		--skip "**/trailers-only/missing-status" \
-		--skip "**/trailers-only/unary-ok-but-no-response" \
 		--known-failing @./testing/grpcwebclient-known-failing.txt \
 		-- ./testing/grpcwebclient/bin/grpcwebclient
 

--- a/internal/app/connectconformance/server_runner.go
+++ b/internal/app/connectconformance/server_runner.go
@@ -206,8 +206,10 @@ func runTestCasesForServer(
 				results.setOutcome(name, true, err)
 			case resp.GetError() != nil:
 				results.failed(name, resp.GetError())
-			default:
+			case resp.GetResponse() != nil:
 				results.assert(name, testCase, resp.GetResponse())
+			default:
+				results.setOutcome(name, false, errors.New("client returned a response with neither an error nor result"))
 			}
 			if isReferenceClient && resp.GetResponse() != nil {
 				for _, msg := range resp.GetResponse().Feedback {

--- a/testing/grpcwebclient-known-failing.txt
+++ b/testing/grpcwebclient-known-failing.txt
@@ -16,11 +16,6 @@ Duplicate Metadata/**/server-stream/**
 gRPC-Web Trailers/**/trailers-in-body/duplicate-metadata
 gRPC-Web Trailers/**/trailers-in-body/mixed-case
 
-# The gRPC-Web client also fails to verify the grpc-status. If it is missing, it assumes the
-# result is okay, even for a unary RPC where there were zero response messages.
-gRPC-Web Unexpected Responses/**/missing-status
-gRPC-Web Unexpected Responses/**/unary-ok-but-no-response
-
 # The gRPC-Web client also does not use the expected error codes for some error situations.
 # It appears to use "unknown" for nearly (which likely means it's just not classifying them
 # at all, which is certainly a bug).

--- a/testing/grpcwebclient/browserscript.ts
+++ b/testing/grpcwebclient/browserscript.ts
@@ -36,13 +36,34 @@ import {
 } from "grpc-web";
 
 // The main entry point into the browser code running in Puppeteer/headless Chrome.
-// This function is invoked by the page.evalulate call in grpcwebclient.
+// This function is invoked by the page.evaluate call in grpcwebclient.
 async function runTestCase(data: number[]): Promise<number[]> {
   const request = ClientCompatRequest.deserializeBinary(new Uint8Array(data));
 
-  const result = await invoke(request);
+  const rpcResult = invoke(request);
+  const timeout = new Promise<ClientResponseResult>((_, reject) => {
+    // Fail if we still don't have a response after 15 seconds
+    // so that user can at least see exactly which test case timed out.
+    setTimeout(() => {
+      reject(new Error("promise never resolved after 15s!"));
+    }, 15*1000);
+  });
+  const result = await Promise.race([rpcResult, timeout]);
 
   return Array.from(result.serializeBinary());
+}
+
+function initTests() {
+  window.addEventListener("error", function (e) {
+    // @ts-ignore
+    window.log("ERROR: uncaught error in browser: " + e.error.filename + ":" + e.error.lineno + ": " + e.message);
+    return false;
+  })
+  window.addEventListener("unhandledrejection", function (e) {
+    // @ts-ignore
+    window.log("ERROR: unhandled promise failure in browser: " + e.reason);
+    return false;
+  })
 }
 
 function invoke(req: ClientCompatRequest) {
@@ -117,10 +138,13 @@ function convertGrpcToProtoError(rpcErr: RpcError): ProtoError {
   err.setCode(convertStatusCodeToCode(rpcErr.code));
   err.setMessage(rpcErr.message);
 
-  const value = rpcErr.metadata["grpc-status-details-bin"];
-  if (value) {
-    const status = Status.deserializeBinary(stringToUint8Array(atob(value)));
-    err.setDetailsList(status.getDetailsList());
+  let md = rpcErr.metadata;
+  if (md !== undefined) {
+    const value = md["grpc-status-details-bin"];
+    if (value) {
+      const status = Status.deserializeBinary(stringToUint8Array(atob(value)));
+      err.setDetailsList(status.getDetailsList());
+    }
   }
 
   return err;
@@ -194,6 +218,15 @@ async function unary(
     (err: RpcError, response: UnaryResponse) => {
       if (err !== null) {
         resp.setError(convertGrpcToProtoError(err));
+        let md = err.metadata;
+        if (md !== undefined) {
+          resp.setResponseTrailersList(convertMetadataToHeader(md));
+        }
+        // Ideally, we'd complete the promise from the "end" event. However,
+        // most RPCs that result in an RPC error (as of 3/15/2024, 50 out of
+        // 57 failed RPCs) do not produce an "end" event after the callback
+        // is invoked with an error.
+        res(resp);
       } else {
         const payload = response.getPayload();
         if (payload !== undefined) {
@@ -212,11 +245,20 @@ async function unary(
 
   // Response trailers (i.e. trailing metadata) are sent in the 'status' event
   result.on("status", (status: GrpcWebStatus) => {
+    // One might expect that the "status" event is always delivered (since
+    // consistency would make it much easier to implement interceptors or
+    // decorators, to instrument all RPCs with cross-cutting concerns, like
+    // metrics, logging, etc). But one would be wrong: as of 3/15/2024, there
+    // are at least two cases where the "status" event is never delivered
+    // (both cases are RPC failures).
     const md = status.metadata;
     if (md !== undefined) {
       resp.setResponseTrailersList(convertMetadataToHeader(md));
-      res(resp);
     }
+  });
+
+  result.on("end", () => {
+    res(resp);
   });
 
   return prom;
@@ -266,18 +308,33 @@ async function serverStream(
   });
   stream.on("error", (err: RpcError) => {
     resp.setError(convertGrpcToProtoError(err));
+    let md = err.metadata;
+    if (md !== undefined) {
+      resp.setResponseTrailersList(convertMetadataToHeader(md));
+    }
+    // Ideally, we'd complete the promise from the "end" event. However, there
+    // are some RPCs that result in an RPC error (as of 3/15/2024, 3 out of 44
+    // failed RPCs) that produce neither a "status" nor an "end" event after
+    // the "error" event.
     res(resp);
   });
 
   // Response trailers (i.e. trailing metadata) are sent in the 'status' event
   stream.on("status", (status: GrpcWebStatus) => {
+    // One might expect that the "status" event is always delivered (since
+    // consistency would make it much easier to implement interceptors or
+    // decorators, to instrument all RPCs with cross-cutting concerns, like
+    // metrics, logging, etc). But one would be wrong: as of 3/15/2024, there
+    // are four cases where the "status" event is never delivered for a
+    // streaming call (3 of these cases are RPC failures; more surprisingly,
+    // 1 case is a successful RPC!).
     const md = status.metadata;
     if (md !== undefined) {
       resp.setResponseTrailersList(convertMetadataToHeader(md));
     }
   });
 
-  stream.on("end", function () {
+  stream.on("end", () => {
     res(resp);
   });
 
@@ -337,3 +394,5 @@ async function unimplemented(
 
 // @ts-ignore
 window.runTestCase = runTestCase;
+// @ts-ignore
+window.initTests = initTests;

--- a/testing/grpcwebclient/browserscript.ts
+++ b/testing/grpcwebclient/browserscript.ts
@@ -53,7 +53,7 @@ async function runTestCase(data: number[]): Promise<number[]> {
   return Array.from(result.serializeBinary());
 }
 
-function initTests() {
+function addErrorListeners() {
   window.addEventListener("error", function (e) {
     // @ts-ignore
     window.log("ERROR: uncaught error in browser: " + e.error.filename + ":" + e.error.lineno + ": " + e.message);
@@ -249,8 +249,8 @@ async function unary(
     // consistency would make it much easier to implement interceptors or
     // decorators, to instrument all RPCs with cross-cutting concerns, like
     // metrics, logging, etc). But one would be wrong: as of 3/15/2024, there
-    // are at least two cases where the "status" event is never delivered
-    // (both cases are RPC failures).
+    // are 2 cases where the "status" event is never delivered (both cases
+    // are RPC failures).
     const md = status.metadata;
     if (md !== undefined) {
       resp.setResponseTrailersList(convertMetadataToHeader(md));
@@ -314,8 +314,7 @@ async function serverStream(
     }
     // Ideally, we'd complete the promise from the "end" event. However, there
     // are some RPCs that result in an RPC error (as of 3/15/2024, 3 out of 44
-    // failed RPCs) that produce neither a "status" nor an "end" event after
-    // the "error" event.
+    // failed RPCs) that do not produce an "end" event after the "error" event.
     res(resp);
   });
 
@@ -325,9 +324,8 @@ async function serverStream(
     // consistency would make it much easier to implement interceptors or
     // decorators, to instrument all RPCs with cross-cutting concerns, like
     // metrics, logging, etc). But one would be wrong: as of 3/15/2024, there
-    // are four cases where the "status" event is never delivered for a
-    // streaming call (3 of these cases are RPC failures; more surprisingly,
-    // 1 case is a successful RPC!).
+    // is one case (out of 62 total RPCs) where the "status" event is never
+    // delivered for a streaming call.
     const md = status.metadata;
     if (md !== undefined) {
       resp.setResponseTrailersList(convertMetadataToHeader(md));
@@ -395,4 +393,4 @@ async function unimplemented(
 // @ts-ignore
 window.runTestCase = runTestCase;
 // @ts-ignore
-window.initTests = initTests;
+window.addErrorListeners = addErrorListeners;

--- a/testing/grpcwebclient/grpcwebclient.ts
+++ b/testing/grpcwebclient/grpcwebclient.ts
@@ -42,8 +42,10 @@ export async function run() {
   });
 
   await page.evaluate(() => {
+    // This allows us log uncaught errors in the browser to this script's
+    // stderr, so they can be seen in the console output when running tests.
     // @ts-ignore
-    return window.initTests();
+    return window.addErrorListeners();
   });
 
   for await (const next of readReqBuffers(process.stdin)) {

--- a/testing/grpcwebclient/grpcwebclient.ts
+++ b/testing/grpcwebclient/grpcwebclient.ts
@@ -23,13 +23,27 @@ import {
 } from "./gen/proto/connectrpc/conformance/v1/client_compat_pb.js";
 
 export async function run() {
-  // Launch a browser. For a non-headless browser, pass false
+  // Launch a browser. For a non-headless browser, pass {headless: false}.
+  // Note that the test runner kills the process at the end if it takes too
+  // long to shut down, and puppeteer can't/won't leave browser open after
+  // this script terminates, so the value of non-headless browser is quite
+  // limited. It may be more effective for troubleshooting to instead add
+  // calls to window.log in browserscript.ts (these messages will show up
+  // in the test runner output).
   const browser = await puppeteer.launch({ headless: "new" });
   const page = await browser.newPage();
 
+  await page.exposeFunction("log", (message: string) => {
+    process.stderr.write(message + "\n");
+  })
   await page.addScriptTag({
     type: "application/javascript",
     content: await buildBrowserScript(),
+  });
+
+  await page.evaluate(() => {
+    // @ts-ignore
+    return window.initTests();
   });
 
   for await (const next of readReqBuffers(process.stdin)) {


### PR DESCRIPTION
There were a couple of bugs in the conformance client that:
1) Were causing the tests to outright hang. That is why I had to add "--skip" flags in the `Makefile`, so we could at
   least run all of the test cases that _didn't_ hang. It turns out this was due to two issues:
   * Sometimes (rarely, just in two cases) the "status" event is _never_ invoked for a unary RPC (only happens with certain kinds of failing RPCs). This was the event where the code was resolving the promise.
   * In at least one case, the `metadata` field of an error object was _undefined_. This tickled a bug that produced an uncaught error, that in turn prevented the result promise from ever being resolved.
2) Were causing a few of the unary RPC test cases to report "no error", even though an error was in fact reported. This is because, in apparently very rare circumstances, a "stream" event is observed _before_ the callback is invoked. So we resolved the promise prematurely with a result that had no error, even though knowledge of the error was coming afterwards.

Previously, the unary case always resolved the promise from the "status" event, and the server-stream case would resolve the promise from the "error" or "end" event (whichever occurred first). I've changed them to now be consistent: we resolve the RPC from the "error" or "end" event (in the case of a unary RPC, it treats the result callback as the "error" event if it supplies an error instead of a message). Also, since we're always resolving from an "error" event, which almost always happens before a "status" event, we now pull the trailers from the error object.

This also adds some other logging and safeguards so that we can hopefully more easily detect problems in the future. So if there is ever an uncaught error, we'll log it. And we also forcibly resolve promises after 15s (with an appropriate error message), so that a failure to resolve the promise from the RPC callbacks won't cause the whole thing to hang.

I added lots of temporary instrumentation and logging in the client to learn the ins-and-outs of what was going on. Here's a summary from that instrumentation:

Out of 71 unary RPCs (of which 57 failed):
* 0 successful RPCs did not report a 'status' event
* 0 successful RPCs did not report an 'end' event
* 2 failed RPCs did not report a 'status' event
* 50 failed RPCs did not report an 'end' event
* 3 failed RPCs observed `status` before `error`

Out of 62 server-stream RPCs (of which 44 failed):
* 1 successful RPC did not report a 'status' event
* 0 successful RPCs did not report an 'end' event
* 0 failed RPCs did not report a 'status' event
* 3 failed RPCs did not report an 'end' event
* 0 failed RPCs observed `status` before `error`

I went ahead a pushed a couple of branches with some exploratory code related to my investigation. The instrumentation that produced the above stats is [here](https://github.com/connectrpc/conformance/compare/jh/grpcwebclient-issues-more-logging). And I also experimented with the use of a non-headless browser, so I code poke at the JavaScript console and see what was happening; that code is [here](https://github.com/connectrpc/conformance/compare/jh/grpcwebclient-html-log).