### PR TITLE
Fix "te: trailers" headers in test cases

### DIFF
--- a/internal/app/connectconformance/testsuites/data/grpc_server_unexpected.yaml
+++ b/internal/app/connectconformance/testsuites/data/grpc_server_unexpected.yaml
@@ -43,6 +43,8 @@ testCases:
         headers:
           - name: content-type
             value: [ "application/grpc+proto" ]
+          - name: te
+            value: [ "trailers" ]
     expectedResponse:
       error:
         code: CODE_UNIMPLEMENTED
@@ -57,6 +59,8 @@ testCases:
         headers:
           - name: content-type
             value: [ "application/grpc+proto" ]
+          - name: te
+            value: [ "trailers" ]
         stream:
           items:
             - flags: 0
@@ -82,6 +86,8 @@ testCases:
         headers:
           - name: content-type
             value: [ "application/grpc+proto" ]
+          - name: te
+            value: [ "trailers" ]
     expectedResponse:
       error:
         code: CODE_UNIMPLEMENTED
@@ -96,6 +102,8 @@ testCases:
         headers:
           - name: content-type
             value: [ "application/grpc+proto" ]
+          - name: te
+            value: [ "trailers" ]
         stream:
           items:
             - flags: 0


### PR DESCRIPTION
This also adds an extra check to the `referenceserver` so we don't forget these headers in gRPC test cases in the future.

cc @jchadwick-buf 