### PR TITLE
Reference and gRPC servers can send independent header and trailer metadata

### DIFF
--- a/internal/app/grpcserver/impl.go
+++ b/internal/app/grpcserver/impl.go
@@ -55,7 +55,7 @@ func (c *conformanceServiceServer) Unary(
 	responseDefinition := req.ResponseDefinition
 	if responseDefinition != nil {
 		headerMD := grpcutil.ConvertProtoHeaderToMetadata(req.ResponseDefinition.ResponseHeaders)
-		if err := grpc.SetHeader(ctx, headerMD); err != nil {
+		if err := grpc.SendHeader(ctx, headerMD); err != nil {
 			return nil, err
 		}
 		trailerMD := grpcutil.ConvertProtoHeaderToMetadata(req.ResponseDefinition.ResponseTrailers)
@@ -68,7 +68,7 @@ func (c *conformanceServiceServer) Unary(
 	md, _ := metadata.FromIncomingContext(ctx)
 	payload, grpcErr := parseUnaryResponseDefinition(
 		ctx,
-		req.ResponseDefinition,
+		responseDefinition,
 		md,
 		[]*anypb.Any{msgAsAny},
 	)
@@ -116,7 +116,7 @@ func (c *conformanceServiceServer) ClientStream(
 	// Set headers and trailers on stream
 	if responseDefinition != nil {
 		headerMD := grpcutil.ConvertProtoHeaderToMetadata(responseDefinition.ResponseHeaders)
-		if err := stream.SetHeader(headerMD); err != nil {
+		if err := stream.SendHeader(headerMD); err != nil {
 			return err
 		}
 

--- a/internal/app/referenceserver/raw_response_test.go
+++ b/internal/app/referenceserver/raw_response_test.go
@@ -40,7 +40,7 @@ func TestRawResponseRecorder(t *testing.T) {
 		conformancev1connect.UnimplementedConformanceServiceHandler{},
 		connect.WithInterceptors(rawResponseRecorder{}),
 	)
-	svr := httptest.NewUnstartedServer(rawResponder(handler, internal.NewPrinter(&bytes.Buffer{})))
+	svr := httptest.NewUnstartedServer(rawResponder(handler))
 	svr.EnableHTTP2 = true // so we can test bidi stream
 	svr.StartTLS()
 	t.Cleanup(svr.Close)

--- a/internal/app/referenceserver/server.go
+++ b/internal/app/referenceserver/server.go
@@ -186,7 +186,7 @@ func createServer(req *conformancev1.ServerCompatRequest, listenAddr, tlsCertFil
 	}
 
 	mux.Handle(conformancev1connect.NewConformanceServiceHandler(
-		&conformanceServer{},
+		&conformanceServer{referenceMode: referenceMode},
 		opts...,
 	))
 	handler := http.Handler(http.HandlerFunc(func(respWriter http.ResponseWriter, req *http.Request) {
@@ -201,7 +201,7 @@ func createServer(req *conformancev1.ServerCompatRequest, listenAddr, tlsCertFil
 	}))
 	if referenceMode {
 		handler = referenceServerChecks(handler, errPrinter)
-		handler = rawResponder(handler, errPrinter)
+		handler = rawResponder(handler)
 	} else {
 		// When in reference mode, checking requests from a client-under-test, we make sure that the
 		// client sends a "TE: trailers" header.

--- a/internal/errors.go
+++ b/internal/errors.go
@@ -89,7 +89,7 @@ func ConvertProtoToConnectError(err *conformancev1.Error) *connect.Error {
 	if err == nil {
 		return nil
 	}
-	connectErr := connect.NewError(connect.Code(int32(err.Code)), errors.New(err.GetMessage()))
+	connectErr := connect.NewError(connect.Code(err.Code), errors.New(err.GetMessage()))
 	for _, detail := range err.Details {
 		connectDetail, err := connect.NewErrorDetail(detail)
 		if err != nil {

--- a/testing/grpcwebclient-known-failing.txt
+++ b/testing/grpcwebclient-known-failing.txt
@@ -11,8 +11,9 @@ Client Cancellation/**/server-stream/**/cancel-after-zero-responses
 # And since that uses an object keyed to trailer name, it will eliminate dupes. Responses that use a
 # "trailers only" response can succeed, however, because those trailers are actually encoded as HTTP
 # headers, which are not parsed with the above code.
-Duplicate Metadata/**/unary/**/success
-Duplicate Metadata/**/server-stream/**
+#Duplicate Metadata/**/unary/**/success
+#Duplicate Metadata/**/server-stream/**
+Duplicate Metadata/**
 gRPC-Web Trailers/**/trailers-in-body/duplicate-metadata
 gRPC-Web Trailers/**/trailers-in-body/mixed-case
 


### PR DESCRIPTION
The connect-go API doesn't provide a handler a direct way to send independent response headers and trailers from a unary or client-stream RPC. This is because a handler may return either a `*connect.Response` or a `*connect.Error`, but not both. But a `*connect.Error` does not allow setting both headers and trailers: it has only a `Meta()` accessor, which ostensibly could be serialized using either headers or trailers.

The reason this is the case is because frameworks can sometimes decide to send all metadata together, such as in a "trailers-only" response (allowed by the gRPC and gRPC-Web protocols for more compact replies when there is no message data). Because a framework decision could change whether a piece of metadata shows up as a header or a trailer, clients should generally provide a combined view of headers and trailers in the face of an error, to avoid bugs where the client looks for the metadata as a header, but it was actually serialized as a trailer (i.e. in a "trailers-only" response).

Having said all that, it can be surprising for users to see headers and trailers combined in the response from the reference server, in an HTTP trace. So to make the reference server's behavior more intuitive, we send headers and trailers separately -- by going _around_ the direct APIs offered by connect-go.

For client streams, there is an indirect way provided: one can access the underlying `connect.StreamingHandlerConn` and then directly interact with response headers and trailers.

But for unary RPCs, we have to be sneakier. For the Connect unary protocol, all metadata gets serialized as headers. And trailers are differentiated via a "trailer-" prefix. So we can just prefix the metadata that is _intended_ to be trailers with "trailer-". For the gRPC and gRPC-Web protocols, there are no simple hacks to get the connect-go framework to reply as desired. So we leverage the existing "raw response" functionality to go _around_ the framework and directly control what is written to the wire for the response for these cases.