### PR TITLE
Don't exit with a zero code if cmd-line flags can't be parsed

### DIFF
--- a/cmd/connectconformance/main.go
+++ b/cmd/connectconformance/main.go
@@ -127,7 +127,10 @@ line.
 		},
 	}
 	bind(rootCmd, flagset)
-	_ = rootCmd.Execute()
+	err := rootCmd.Execute()
+	if err != nil {
+		os.Exit(2)
+	}
 }
 
 func bind(cmd *cobra.Command, flags *flags) {


### PR DESCRIPTION
Oops. I happened to notice, when updating another place to use these conformance tests, that a typo in the flags doesn't result in a non-zero exit code. So if a mistake were made in a CI invocation, it would just keep going and ignore the error. Doh!