### PR TITLE
Improve test runner behavior when client times out, crashes, or exits prematurely

### DIFF
--- a/internal/app/connectconformance/client_runner.go
+++ b/internal/app/connectconformance/client_runner.go
@@ -195,7 +195,7 @@ func (c *clientProcessRunner) consumeOutput() {
 			if err == nil || errors.Is(err, io.EOF) {
 				err = errNoOutcome
 			}
-			action(key, nil, &errFailedToGetResult{err})
+			action(key, nil, &failedToGetResultError{err})
 			delete(c.pendingOps, key)
 		}
 	}()
@@ -229,14 +229,14 @@ func (c *clientProcessRunner) consumeOutput() {
 	}
 }
 
-type errFailedToGetResult struct {
+type failedToGetResultError struct {
 	err error
 }
 
-func (e *errFailedToGetResult) Error() string {
+func (e *failedToGetResultError) Error() string {
 	return fmt.Sprintf("failed to get result from client: %v", e.err)
 }
 
-func (e *errFailedToGetResult) Unwrap() error {
+func (e *failedToGetResultError) Unwrap() error {
 	return e.err
 }

--- a/internal/app/connectconformance/client_runner.go
+++ b/internal/app/connectconformance/client_runner.go
@@ -32,8 +32,11 @@ const (
 	maxClientResponseSize = 16 * 1024 * 1024 // 16 MB
 )
 
-var errClosed = errors.New("send-to-client is closed")
-var errDuplicate = errors.New("duplicate test case")
+var (
+	errClosed    = errors.New("could not send request: client stdin is closed")
+	errDuplicate = errors.New("duplicate test case")
+	errNoOutcome = errors.New("no outcome ever received")
+)
 
 type clientRunner interface {
 	sendRequest(req *conformancev1.ClientCompatRequest, whenDone func(string, *conformancev1.ClientCompatResponse, error)) error
@@ -124,7 +127,7 @@ func (c *clientProcessRunner) sendRequest(req *conformancev1.ClientCompatRequest
 		}
 
 		if errors.Is(err, io.ErrClosedPipe) {
-			err = errors.New("could not write request: client closed stdin")
+			err = errClosed
 		}
 		c.err.CompareAndSwap(nil, &err)
 		return err
@@ -190,9 +193,9 @@ func (c *clientProcessRunner) consumeOutput() {
 		for key, action := range c.pendingOps {
 			err := reasonForReturn
 			if err == nil || errors.Is(err, io.EOF) {
-				err = fmt.Errorf("client never provided response for test case %q", key)
+				err = errNoOutcome
 			}
-			action(key, nil, err)
+			action(key, nil, &errFailedToGetResult{err})
 			delete(c.pendingOps, key)
 		}
 	}()
@@ -224,4 +227,16 @@ func (c *clientProcessRunner) consumeOutput() {
 		testCaseNames[resp.TestName] = struct{}{}
 		action(resp.TestName, resp, nil)
 	}
+}
+
+type errFailedToGetResult struct {
+	err error
+}
+
+func (e *errFailedToGetResult) Error() string {
+	return fmt.Sprintf("failed to get result from client: %v", e.err)
+}
+
+func (e *errFailedToGetResult) Unwrap() error {
+	return e.err
 }

--- a/internal/app/connectconformance/client_runner_test.go
+++ b/internal/app/connectconformance/client_runner_test.go
@@ -67,7 +67,7 @@ func TestRunClient(t *testing.T) {
 			name:       "client fails",
 			clientFunc: (&testClientProcess{failAfter: 2}).run,
 			failToSend: 2,
-			expectErr:  "could not send request: client stdin is closedx",
+			expectErr:  "could not send request: client stdin is closed",
 			expectedResults: map[string]bool{
 				"TestSuite1/testcase1": true,
 				"TestSuite1/testcase2": true,

--- a/internal/app/connectconformance/client_runner_test.go
+++ b/internal/app/connectconformance/client_runner_test.go
@@ -67,7 +67,7 @@ func TestRunClient(t *testing.T) {
 			name:       "client fails",
 			clientFunc: (&testClientProcess{failAfter: 2}).run,
 			failToSend: 2,
-			expectErr:  "could not write request: client closed stdin",
+			expectErr:  "could not send request: client stdin is closedx",
 			expectedResults: map[string]bool{
 				"TestSuite1/testcase1": true,
 				"TestSuite1/testcase2": true,

--- a/internal/app/connectconformance/connectconformance.go
+++ b/internal/app/connectconformance/connectconformance.go
@@ -115,10 +115,13 @@ func Run(flags *Flags, logPrinter internal.Printer, errPrinter internal.Printer)
 	}
 
 	results, err := run(configCases, knownFailing, knownFlaky, runPatterns, skipPatterns, allSuites, logPrinter, errPrinter, flags)
-	if err != nil {
+	if results == nil {
 		return false, err
 	}
-	return results.report(logPrinter), nil
+	if err != nil {
+		errPrinter.Printf("%v", err)
+	}
+	return results.report(logPrinter) && err == nil, nil
 }
 
 func run( //nolint:gocyclo
@@ -204,27 +207,39 @@ func run( //nolint:gocyclo
 	}
 
 	filter := newFilter(run, skip)
+	var filteredTestCount int
+	type serverConfig struct {
+		serverInstance
+		isGrpcClient, isGrpcServer bool
+	}
+	allServerConfigs, filteredServerConfigs := map[serverConfig]struct{}{}, map[serverConfig]struct{}{}
+	for _, testCase := range allPermutations {
+		svrConfig := serverConfig{
+			serverInstance: serverInstance{
+				protocol:          testCase.Request.Protocol,
+				httpVersion:       testCase.Request.HttpVersion,
+				useTLS:            len(testCase.Request.ServerTlsCert) > 0,
+				useTLSClientCerts: testCase.Request.ClientTlsCreds != nil,
+			},
+			isGrpcClient: strings.Contains(testCase.Request.TestName, grpcImplMarker) ||
+				strings.Contains(testCase.Request.TestName, grpcClientImplMarker),
+			isGrpcServer: strings.Contains(testCase.Request.TestName, grpcImplMarker) ||
+				strings.Contains(testCase.Request.TestName, grpcServerImplMarker),
+		}
+		allServerConfigs[svrConfig] = struct{}{}
+		if filter.accept(testCase) {
+			filteredTestCount++
+			filteredServerConfigs[svrConfig] = struct{}{}
+		}
+	}
+
 	if flags.Verbose { //nolint:nestif
 		logPrinter.Printf("Computed %d test case permutation(s) across %d server configuration(s).",
-			len(allPermutations), len(testCaseLib.casesByServer))
-		if filter != nil {
-			var count int
-			filteredServerInstances := map[serverInstance]struct{}{}
-			for _, testCase := range allPermutations {
-				if filter.accept(testCase) {
-					count++
-					filteredServerInstances[serverInstance{
-						protocol:          testCase.Request.Protocol,
-						httpVersion:       testCase.Request.HttpVersion,
-						useTLS:            len(testCase.Request.ServerTlsCert) > 0,
-						useTLSClientCerts: testCase.Request.ClientTlsCreds != nil,
-					}] = struct{}{}
-				}
-			}
-			if count != len(allPermutations) {
-				logPrinter.Printf("Filtered tests to %d test case permutation(s) across %d server configuration(s).",
-					count, len(filteredServerInstances))
-			}
+			len(allPermutations), len(allServerConfigs))
+
+		if filteredTestCount != len(allPermutations) {
+			logPrinter.Printf("Filtered tests to %d test case permutation(s) across %d server configuration(s).",
+				filteredTestCount, len(filteredServerConfigs))
 		}
 	}
 
@@ -293,7 +308,7 @@ func run( //nolint:gocyclo
 		}
 	}
 
-	results := newResults(knownFailing, knownFlaky, trace)
+	results := newResults(filteredTestCount, knownFailing, knownFlaky, trace)
 
 	for _, clientInfo := range clients {
 		clientProcess, err := runClient(ctx, clientInfo.start)
@@ -356,6 +371,15 @@ func run( //nolint:gocyclo
 						return err
 					}
 
+					// Double-check that client is still running before spawning a server process.
+					if !clientProcess.isRunning() {
+						err := clientProcess.waitForResponses()
+						if err == nil {
+							err = errors.New("client process unexpectedly stopped")
+						}
+						return err
+					}
+
 					if flags.Verbose {
 						var with string
 						switch {
@@ -367,17 +391,6 @@ func run( //nolint:gocyclo
 							with = serverInfo.name
 						}
 						logTestCaseInfo(with, svrInstance, len(testCases), logPrinter)
-					}
-
-					// Double-check that client is still running before spawning a server process.
-					if !clientProcess.isRunning() {
-						err := clientProcess.waitForResponses()
-						if err == nil {
-							err = errors.New("client process unexpectedly stopped")
-						} else {
-							err = fmt.Errorf("client process unexpectedly stopped: %w", err)
-						}
-						return err
 					}
 
 					wg.Add(1)
@@ -407,12 +420,12 @@ func run( //nolint:gocyclo
 		}()
 
 		if err != nil {
-			return nil, err
+			return results, err
 		}
 
 		clientProcess.closeSend()
 		if err := clientProcess.waitForResponses(); err != nil {
-			return nil, err
+			return results, err
 		}
 	}
 

--- a/internal/app/connectconformance/connectconformance.go
+++ b/internal/app/connectconformance/connectconformance.go
@@ -233,7 +233,7 @@ func run( //nolint:gocyclo
 		}
 	}
 
-	if flags.Verbose { //nolint:nestif
+	if flags.Verbose {
 		logPrinter.Printf("Computed %d test case permutation(s) across %d server configuration(s).",
 			len(allPermutations), len(allServerConfigs))
 

--- a/internal/app/connectconformance/results.go
+++ b/internal/app/connectconformance/results.go
@@ -255,7 +255,7 @@ func (r *testResults) report(printer internal.Printer) bool {
 			expectError = outcome.knownFailing ||
 				(outcome.knownFlaky && outcome.actualFailure != nil)
 		}
-		var noRun *errCouldNotRun
+		var noRun *couldNotRunError
 		switch {
 		case errors.As(outcome.actualFailure, &noRun):
 			couldNotRun++

--- a/internal/app/connectconformance/results.go
+++ b/internal/app/connectconformance/results.go
@@ -45,9 +45,10 @@ const timeoutCheckGracePeriodMillis = 250
 // log writer. It can also incorporate data provided out-of-band by a reference
 // server, when testing a client implementation.
 type testResults struct {
-	knownFailing *testTrie
-	knownFlaky   *testTrie
-	tracer       *tracer.Tracer
+	totalTestCount int
+	knownFailing   *testTrie
+	knownFlaky     *testTrie
+	tracer         *tracer.Tracer
 
 	traceWaitGroup sync.WaitGroup
 
@@ -57,8 +58,9 @@ type testResults struct {
 	serverSideband map[string]string
 }
 
-func newResults(knownFailing, knownFlaky *testTrie, tracer *tracer.Tracer) *testResults {
+func newResults(totalTestCount int, knownFailing, knownFlaky *testTrie, tracer *tracer.Tracer) *testResults {
 	return &testResults{
+		totalTestCount: totalTestCount,
 		knownFailing:   knownFailing,
 		knownFlaky:     knownFlaky,
 		tracer:         tracer,
@@ -241,6 +243,10 @@ func (r *testResults) report(printer internal.Printer) bool {
 		testCaseNames = append(testCaseNames, testCaseName)
 	}
 	var succeeded, failed, expectedFailures int
+	couldNotRun := r.totalTestCount - len(testCaseNames)
+	if couldNotRun < 0 {
+		couldNotRun = 0 // Possible in tests that don't bother configuring actual test count.
+	}
 	sort.Strings(testCaseNames)
 	for _, name := range testCaseNames {
 		outcome := r.outcomes[name]
@@ -249,7 +255,10 @@ func (r *testResults) report(printer internal.Printer) bool {
 			expectError = outcome.knownFailing ||
 				(outcome.knownFlaky && outcome.actualFailure != nil)
 		}
+		var noRun *errCouldNotRun
 		switch {
+		case errors.As(outcome.actualFailure, &noRun):
+			couldNotRun++
 		case !expectError && outcome.actualFailure != nil:
 			printer.Printf("FAILED: %s:\n%s", name, indent(outcome.actualFailure.Error()))
 			trace := r.traces[name]
@@ -273,7 +282,11 @@ func (r *testResults) report(printer internal.Printer) bool {
 		// Add a blank line to separate summary from messages above
 		printer.Printf("\n")
 	}
+
 	printer.Printf("Total cases: %d\n%d passed, %d failed", len(r.outcomes), succeeded, failed)
+	if couldNotRun > 0 {
+		printer.Printf("Another %d could not be run due to client timing out or exiting prematurely.", couldNotRun)
+	}
 	if expectedFailures > 0 {
 		printer.Printf("(Another %d failed as expected due to being known failures/flakes.)", expectedFailures)
 	}

--- a/internal/app/connectconformance/results_test.go
+++ b/internal/app/connectconformance/results_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestResults_SetOutcome(t *testing.T) {
 	t.Parallel()
-	results := newResults(makeKnownFailing(), makeKnownFlaky(), nil)
+	results := newResults(0, makeKnownFailing(), makeKnownFlaky(), nil)
 	results.setOutcome("foo/bar/1", false, nil)
 	results.setOutcome("foo/bar/2", true, errors.New("fail"))
 	results.setOutcome("foo/bar/3", false, errors.New("fail"))
@@ -58,7 +58,7 @@ func TestResults_SetOutcome(t *testing.T) {
 
 func TestResults_FailedToStart(t *testing.T) {
 	t.Parallel()
-	results := newResults(makeKnownFailing(), makeKnownFlaky(), nil)
+	results := newResults(0, makeKnownFailing(), makeKnownFlaky(), nil)
 	results.failedToStart([]*conformancev1.TestCase{
 		{Request: &conformancev1.ClientCompatRequest{TestName: "foo/bar/1"}},
 		{Request: &conformancev1.ClientCompatRequest{TestName: "known-to-fail/1"}},
@@ -76,7 +76,7 @@ func TestResults_FailedToStart(t *testing.T) {
 
 func TestResults_FailRemaining(t *testing.T) {
 	t.Parallel()
-	results := newResults(makeKnownFailing(), makeKnownFlaky(), nil)
+	results := newResults(0, makeKnownFailing(), makeKnownFlaky(), nil)
 	results.setOutcome("foo/bar/1", false, nil)
 	results.setOutcome("known-to-fail/1", false, errors.New("fail"))
 	results.failRemaining([]*conformancev1.TestCase{
@@ -101,7 +101,7 @@ func TestResults_FailRemaining(t *testing.T) {
 
 func TestResults_Failed(t *testing.T) {
 	t.Parallel()
-	results := newResults(makeKnownFailing(), makeKnownFlaky(), nil)
+	results := newResults(0, makeKnownFailing(), makeKnownFlaky(), nil)
 	results.failed("foo/bar/1", &conformancev1.ClientErrorResult{Message: "fail"})
 	results.failed("known-to-fail/1", &conformancev1.ClientErrorResult{Message: "fail"})
 
@@ -116,7 +116,7 @@ func TestResults_Failed(t *testing.T) {
 
 func TestResults_Assert(t *testing.T) {
 	t.Parallel()
-	results := newResults(makeKnownFailing(), makeKnownFlaky(), nil)
+	results := newResults(0, makeKnownFailing(), makeKnownFlaky(), nil)
 	payload1 := &conformancev1.ClientResponseResult{
 		Payloads: []*conformancev1.ConformancePayload{
 			{Data: []byte{0, 1, 2, 3, 4}},
@@ -678,7 +678,7 @@ func TestResults_Assert_ReportsAllErrors(t *testing.T) {
 		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
-			results := newResults(&testTrie{}, &testTrie{}, nil)
+			results := newResults(0, &testTrie{}, &testTrie{}, nil)
 
 			expected := &conformancev1.TestCase{
 				Request:          &conformancev1.ClientCompatRequest{StreamType: conformancev1.StreamType_STREAM_TYPE_UNARY},
@@ -715,7 +715,7 @@ func TestResults_Assert_ReportsAllErrors(t *testing.T) {
 
 func TestResults_ServerSideband(t *testing.T) {
 	t.Parallel()
-	results := newResults(makeKnownFailing(), makeKnownFlaky(), nil)
+	results := newResults(0, makeKnownFailing(), makeKnownFlaky(), nil)
 	results.setOutcome("foo/bar/1", false, nil)
 	results.setOutcome("foo/bar/2", false, errors.New("fail"))
 	results.setOutcome("foo/bar/3", false, nil)
@@ -738,7 +738,7 @@ func TestResults_ServerSideband(t *testing.T) {
 
 func TestResults_Report(t *testing.T) {
 	t.Parallel()
-	results := newResults(makeKnownFailing(), makeKnownFlaky(), nil)
+	results := newResults(0, makeKnownFailing(), makeKnownFlaky(), nil)
 	logger := &internal.SimplePrinter{}
 
 	// No test cases? Report success.
@@ -746,42 +746,42 @@ func TestResults_Report(t *testing.T) {
 	require.True(t, success)
 
 	// Only successful outcomes? Report success.
-	results = newResults(makeKnownFailing(), makeKnownFlaky(), nil)
+	results = newResults(0, makeKnownFailing(), makeKnownFlaky(), nil)
 	results.setOutcome("foo/bar/1", false, nil)
 	success = results.report(logger)
 	require.True(t, success)
 
 	// Unexpected failure? Report failure.
-	results = newResults(makeKnownFailing(), makeKnownFlaky(), nil)
+	results = newResults(0, makeKnownFailing(), makeKnownFlaky(), nil)
 	results.setOutcome("foo/bar/1", false, errors.New("ruh roh"))
 	success = results.report(logger)
 	require.False(t, success)
 
 	// Unexpected failure during setup? Report failure.
-	results = newResults(makeKnownFailing(), makeKnownFlaky(), nil)
+	results = newResults(0, makeKnownFailing(), makeKnownFlaky(), nil)
 	results.setOutcome("foo/bar/1", true, errors.New("ruh roh"))
 	success = results.report(logger)
 	require.False(t, success)
 
 	// Expected failure? Report success.
-	results = newResults(makeKnownFailing(), makeKnownFlaky(), nil)
+	results = newResults(0, makeKnownFailing(), makeKnownFlaky(), nil)
 	results.setOutcome("known-to-fail/1", false, errors.New("ruh roh"))
 	success = results.report(logger)
 	require.True(t, success)
 
 	// Setup error from expected failure? Report failure (setup errors never acceptable).
-	results = newResults(makeKnownFailing(), makeKnownFlaky(), nil)
+	results = newResults(0, makeKnownFailing(), makeKnownFlaky(), nil)
 	results.setOutcome("known-to-fail/1", true, errors.New("ruh roh"))
 	success = results.report(logger)
 	require.False(t, success)
 
 	// Flaky? Report success whether it passes or fails
-	results = newResults(makeKnownFailing(), makeKnownFlaky(), nil)
+	results = newResults(0, makeKnownFailing(), makeKnownFlaky(), nil)
 	results.setOutcome("known-to-flake/1", false, nil) // succeeds
 	success = results.report(logger)
 	require.True(t, success)
 
-	results = newResults(makeKnownFailing(), makeKnownFlaky(), nil)
+	results = newResults(0, makeKnownFailing(), makeKnownFlaky(), nil)
 	results.setOutcome("known-to-flake/1", false, errors.New("ruh roh"))
 	success = results.report(logger)
 	require.True(t, success)

--- a/internal/app/connectconformance/server_runner.go
+++ b/internal/app/connectconformance/server_runner.go
@@ -213,7 +213,7 @@ func runTestCasesForServer(
 		}
 		err := client.sendRequest(req, func(name string, resp *conformancev1.ClientCompatResponse, err error) {
 			defer wg.Done()
-			var errNoResult *errFailedToGetResult
+			var errNoResult *failedToGetResultError
 			if logEach && !errors.As(err, &errNoResult) {
 				logPrinter.Printf("Received response for %q...", req.TestName)
 			}
@@ -237,7 +237,7 @@ func runTestCasesForServer(
 			wg.Done() // call it explicitly since callback above won't be invoked
 			// client pipe broken: mark remaining tests, including this one, as failed
 			for j := i; j < len(testCases); j++ {
-				results.setOutcome(testCases[j].Request.TestName, true, &errCouldNotRun{err})
+				results.setOutcome(testCases[j].Request.TestName, true, &couldNotRunError{err})
 			}
 			break
 		}
@@ -253,17 +253,17 @@ func runTestCasesForServer(
 	}
 
 	// If there are any tests without outcomes, mark them now.
-	results.failRemaining(testCases, &errFailedToGetResult{errNoOutcome})
+	results.failRemaining(testCases, &failedToGetResultError{errNoOutcome})
 }
 
-type errCouldNotRun struct {
+type couldNotRunError struct {
 	err error
 }
 
-func (e *errCouldNotRun) Error() string {
+func (e *couldNotRunError) Error() string {
 	return e.err.Error()
 }
 
-func (e *errCouldNotRun) Unwrap() error {
+func (e *couldNotRunError) Unwrap() error {
 	return e.err
 }

--- a/internal/app/connectconformance/server_runner.go
+++ b/internal/app/connectconformance/server_runner.go
@@ -213,7 +213,8 @@ func runTestCasesForServer(
 		}
 		err := client.sendRequest(req, func(name string, resp *conformancev1.ClientCompatResponse, err error) {
 			defer wg.Done()
-			if logEach {
+			var errNoResult *errFailedToGetResult
+			if logEach && !errors.As(err, &errNoResult) {
 				logPrinter.Printf("Received response for %q...", req.TestName)
 			}
 			switch {
@@ -236,8 +237,9 @@ func runTestCasesForServer(
 			wg.Done() // call it explicitly since callback above won't be invoked
 			// client pipe broken: mark remaining tests, including this one, as failed
 			for j := i; j < len(testCases); j++ {
-				results.setOutcome(testCases[j].Request.TestName, true, err)
+				results.setOutcome(testCases[j].Request.TestName, true, &errCouldNotRun{err})
 			}
+			break
 		}
 	}
 
@@ -251,5 +253,17 @@ func runTestCasesForServer(
 	}
 
 	// If there are any tests without outcomes, mark them now.
-	results.failRemaining(testCases, errors.New("no outcome received from the client"))
+	results.failRemaining(testCases, &errFailedToGetResult{errNoOutcome})
+}
+
+type errCouldNotRun struct {
+	err error
+}
+
+func (e *errCouldNotRun) Error() string {
+	return e.err.Error()
+}
+
+func (e *errCouldNotRun) Unwrap() error {
+	return e.err
 }

--- a/internal/app/connectconformance/server_runner_test.go
+++ b/internal/app/connectconformance/server_runner_test.go
@@ -196,7 +196,7 @@ func TestRunTestCasesForServer(t *testing.T) {
 		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
-			results := newResults(&testTrie{}, &testTrie{}, nil)
+			results := newResults(len(requests), &testTrie{}, &testTrie{}, nil)
 
 			var procAddr atomic.Pointer[process] // populated when server process created
 			var actualSvrRequest bytes.Buffer


### PR DESCRIPTION
While troubleshooting some other test cases, and trying to figure out which test cases were causing a client impl to hang, I noticed a issues with the output of the test runner when this sort of thing happens:

1. If `-v` or `--vv` is used, it can be seen that the runner will print that it's trying to run more test cases and send one or more tests to the client, even though it has failed (timed out usually, but can also happen if it crashes). So I've fixed it up so that once the client fails or times out, we don't try to do anything else and don't print anything else about trying to run other test cases.
2. If `--vv` is used, the pending test cases (at least one of which would be the culprit for the client hanging or crashing) all get printed in "Received response for ..." messages, even though no response was actually received from the client.
3. When the client timed out or crashed, the process would abort and not bother showing any other results. This can be kind of a pain -- it is often useful to see the results that _were_ computed for all of the tests that completed prior to the client hanging or crashing.
4. Finally, unrelated to clients hanging/crashing: the `-v` output that printed the number of server configurations was misleading. For example, when running `make runconformance` in this repo, it prints 19 configurations for the reference client and server. _But_ it then proceeds in printing "Running X tests with ..." 20 or 22 times. This is because it actually starts different processes when testing with the gRPC implementations. So there may be 19 distinct configurations like `{HTTP_VERSION_2, PROTOCOL_GRPC, TLS:false}`, there actually 20 or 22 servers started, some being used with the gRPC reference implementation.

All of these issues are resolved in this PR.