### PR TITLE
Must percent-encode gRPC message

### DIFF
--- a/internal/app/connectconformance/results.go
+++ b/internal/app/connectconformance/results.go
@@ -174,14 +174,18 @@ func (r *testResults) assert(
 		// "error metadata". The conformance client should record those as trailers when
 		// sending back a ClientResponseResult message.
 
-		// So first we see if normal attribute succeeds
+		// So first we see if normal attribution succeeds.
 		metadataErrs := checkHeaders("response headers", expected.ResponseHeaders, actual.ResponseHeaders)
 		metadataErrs = append(metadataErrs, checkHeaders("response trailers", expected.ResponseTrailers, actual.ResponseTrailers)...)
 		if len(metadataErrs) > 0 {
-			// That did not work. So we test to see if client attributed them all as trailers.
+			// That did not work. So we test to see if client attributed them all as headers
+			// or all as trailers.
 			merged := mergeHeaders(expected.ResponseHeaders, expected.ResponseTrailers)
-			if allTrailersErrs := checkHeaders("response metadata", merged, actual.ResponseTrailers); len(allTrailersErrs) != 0 {
-				// That check failed also. So the received headers/trailers are incorrect.
+			allHeadersErrs := checkHeaders("response metadata", merged, actual.ResponseHeaders)
+			allTrailersErrs := checkHeaders("response metadata", merged, actual.ResponseTrailers)
+			// That check failed also. So see if client attributed them all as headers.
+			if len(allHeadersErrs) != 0 && len(allTrailersErrs) != 0 {
+				// These checks failed also. So the received headers/trailers are incorrect.
 				// Report the original errors computed above.
 				errs = append(errs, metadataErrs...)
 			}

--- a/internal/app/connectconformance/testsuites/data/grpc_web_client_trailers.yaml
+++ b/internal/app/connectconformance/testsuites/data/grpc_web_client_trailers.yaml
@@ -122,8 +122,6 @@ testCases:
                   value: [ "*" ]
                 - name: content-type
                   value: [ "application/grpc-web" ]
-                - name: x-custom-header
-                  value: [ "foo" ]
                 - name: x-custom-trailer
                   value: [ "bing" ]
                 - name: grpc-status
@@ -131,9 +129,6 @@ testCases:
                 - name: grpc-message
                   value: [ "error" ]
     expectedResponse:
-      responseHeaders:
-        - name: x-custom-header
-          value: [ "foo" ]
       error:
         code: 9
         message: error
@@ -155,8 +150,6 @@ testCases:
                   value: [ "*" ]
                 - name: content-type
                   value: [ "application/grpc-web" ]
-                - name: x-custom-header
-                  value: [ "foo", "bar", "baz" ]
                 - name: x-custom-trailer
                   value: [ "bing", "quuz" ]
                 - name: grpc-status
@@ -164,9 +157,6 @@ testCases:
                 - name: grpc-message
                   value: [ "error" ]
     expectedResponse:
-      responseHeaders:
-        - name: x-custom-header
-          value: [ "foo", "bar", "baz" ]
       error:
         code: 9
         message: error

--- a/internal/tracer/builder.go
+++ b/internal/tracer/builder.go
@@ -130,6 +130,8 @@ func (b *builder) add(event Event) {
 			// for client-side traces, the HTTP version of the request
 			// isn't known until we get back the response
 			b.trace.Request.Proto = event.Response.Proto
+			b.trace.Request.ProtoMajor = event.Response.ProtoMajor
+			b.trace.Request.ProtoMinor = event.Response.ProtoMinor
 		}
 	case *ResponseError:
 		b.trace.Err = event.Err

--- a/internal/tracer/builder.go
+++ b/internal/tracer/builder.go
@@ -116,7 +116,7 @@ func (b *builder) add(event Event) {
 		event.MessageIndex = b.reqCount
 		b.reqCount++
 	case *RequestBodyEnd:
-		if b.trace.Err != nil {
+		if b.trace.Err == nil {
 			b.trace.Err = event.Err
 		}
 		if event.Err != nil {
@@ -149,11 +149,14 @@ func (b *builder) add(event Event) {
 		event.MessageIndex = b.respCount
 		b.respCount++
 	case *ResponseBodyEnd:
-		if b.trace.Err != nil {
+		if b.trace.Err == nil {
 			b.trace.Err = event.Err
 		}
 		finish = true
 	case *RequestCanceled:
+		if b.trace.Err == nil {
+			b.trace.Err = context.Canceled
+		}
 		finish = true
 	}
 	event.setEventOffset(time.Since(b.start))

--- a/internal/tracer/middleware.go
+++ b/internal/tracer/middleware.go
@@ -42,6 +42,10 @@ func TracingRoundTripper(transport http.RoundTripper, collector Collector) http.
 			cancel()
 			return nil, err
 		}
+		// copy over info about the HTTP version to the request
+		builder.trace.Request.Proto = resp.Proto
+		builder.trace.Request.ProtoMajor = resp.ProtoMajor
+		builder.trace.Request.ProtoMinor = resp.ProtoMinor
 		builder.add(&ResponseStart{Response: resp})
 		resp.Body = newReader(resp.Header, resp.Body, false, builder, cancel)
 		return resp, nil

--- a/internal/tracer/middleware.go
+++ b/internal/tracer/middleware.go
@@ -42,10 +42,6 @@ func TracingRoundTripper(transport http.RoundTripper, collector Collector) http.
 			cancel()
 			return nil, err
 		}
-		// copy over info about the HTTP version to the request
-		builder.trace.Request.Proto = resp.Proto
-		builder.trace.Request.ProtoMajor = resp.ProtoMajor
-		builder.trace.Request.ProtoMinor = resp.ProtoMinor
 		builder.add(&ResponseStart{Response: resp})
 		resp.Body = newReader(resp.Header, resp.Body, false, builder, cancel)
 		return resp, nil


### PR DESCRIPTION
I thought I had tested this change against a bunch of other implementations, but I clearly missed this. But in #840, the code was not correctly percent-encoding the "grpc-message" trailer. It turns out that most implementations (including grpc-java, grpc-go, and connect-go) were all lenient in the face of this issue, which is _how_ I missed this. Looks like we'll need a 1.0.1 😒 

I think what might have been happening is that `net/http` was _dropping_ the invalid header (since one of the tests has a newline in the message, which is not allowed in headers) but it was still being picked up from the `grpc-status-details-bin` header. But it caused an error in connect-kotlin. (I could have _sworn_ I tested that commit against kotlin last week, but I guess I didn't actually do that correctly.)

So... this fixes the issue: when the reference server synthesizes a raw response, to reply with independent header and trailer metadata, it now correctly encodes the "grpc-message" key.

The _bulk_ of this PR is actually adding new checks in the reference client that could have caught this issue: it examines the "grpc-status", "grpc-message", and "grpc-status-details-bin" to make numerous checks to verify that the server implementation adheres to the specs. It also applies similar checks to other binary metadata.

There are a handful of small other changes in here too that I addresses while troubleshooting and fix this.