### PR TITLE
Fix reference server issues related to CORS

### DIFF
--- a/internal/app/connectconformance/testsuites/data/grpc_web_client_compressed_trailers.yaml
+++ b/internal/app/connectconformance/testsuites/data/grpc_web_client_compressed_trailers.yaml
@@ -21,10 +21,6 @@ testCases:
             rawResponse:
               status_code: 200
               headers:
-                - name: "access-control-allow-origin"
-                  value: [ "*" ]
-                - name: "access-control-expose-headers"
-                  value: [ "*" ]
                 - name: content-type
                   value: [ "application/grpc-web" ]
                 - name: grpc-encoding

--- a/internal/app/connectconformance/testsuites/data/grpc_web_client_proto_subformat.yaml
+++ b/internal/app/connectconformance/testsuites/data/grpc_web_client_proto_subformat.yaml
@@ -15,10 +15,6 @@ testCases:
           responseDefinition:
             rawResponse:
               headers:
-                - name: "access-control-allow-origin"
-                  value: [ "*" ]
-                - name: "access-control-expose-headers"
-                  value: [ "*" ]
                 - name: content-type
                   value: [ "application/grpc-web+proto" ]
               stream:
@@ -44,10 +40,6 @@ testCases:
           responseDefinition:
             rawResponse:
               headers:
-                - name: "access-control-allow-origin"
-                  value: [ "*" ]
-                - name: "access-control-expose-headers"
-                  value: [ "*" ]
                 - name: content-type
                   value: [ "application/grpc-web" ]
               stream:

--- a/internal/app/connectconformance/testsuites/data/grpc_web_client_trailers.yaml
+++ b/internal/app/connectconformance/testsuites/data/grpc_web_client_trailers.yaml
@@ -18,10 +18,6 @@ testCases:
             rawResponse:
               status_code: 200
               headers:
-                - name: "access-control-allow-origin"
-                  value: [ "*" ]
-                - name: "access-control-expose-headers"
-                  value: [ "*" ]
                 - name: content-type
                   value: [ "application/grpc-web" ]
                 - name: x-custom-header
@@ -50,10 +46,6 @@ testCases:
             rawResponse:
               status_code: 200
               headers:
-                - name: "access-control-allow-origin"
-                  value: [ "*" ]
-                - name: "access-control-expose-headers"
-                  value: [ "*" ]
                 - name: content-type
                   value: [ "application/grpc-web" ]
                 - name: x-custom-header
@@ -82,10 +74,6 @@ testCases:
             rawResponse:
               status_code: 200
               headers:
-                - name: "access-control-allow-origin"
-                  value: [ "*" ]
-                - name: "access-control-expose-headers"
-                  value: [ "*" ]
                 - name: content-type
                   value: [ "application/grpc-web" ]
                 - name: x-custom-header
@@ -116,10 +104,6 @@ testCases:
             rawResponse:
               status_code: 200
               headers:
-                - name: "access-control-allow-origin"
-                  value: [ "*" ]
-                - name: "access-control-expose-headers"
-                  value: [ "*" ]
                 - name: content-type
                   value: [ "application/grpc-web" ]
                 - name: x-custom-trailer
@@ -144,10 +128,6 @@ testCases:
             rawResponse:
               status_code: 200
               headers:
-                - name: "access-control-allow-origin"
-                  value: [ "*" ]
-                - name: "access-control-expose-headers"
-                  value: [ "*" ]
                 - name: content-type
                   value: [ "application/grpc-web" ]
                 - name: x-custom-trailer

--- a/internal/app/connectconformance/testsuites/data/grpc_web_client_unexpected.yaml
+++ b/internal/app/connectconformance/testsuites/data/grpc_web_client_unexpected.yaml
@@ -16,10 +16,6 @@ testCases:
             rawResponse:
               statusCode: 200
               headers:
-                - name: "access-control-allow-origin"
-                  value: [ "*" ]
-                - name: "access-control-expose-headers"
-                  value: [ "*" ]
                 - name: content-type
                   value: [ "application/grpc-web" ]
               stream:
@@ -44,10 +40,6 @@ testCases:
             rawResponse:
               statusCode: 200
               headers:
-                - name: "access-control-allow-origin"
-                  value: [ "*" ]
-                - name: "access-control-expose-headers"
-                  value: [ "*" ]
                 - name: content-type
                   value: [ "application/grpc-web" ]
               stream:
@@ -95,10 +87,6 @@ testCases:
             rawResponse:
               statusCode: 200
               headers:
-                - name: "access-control-allow-origin"
-                  value: [ "*" ]
-                - name: "access-control-expose-headers"
-                  value: [ "*" ]
                 - name: content-type
                   value: [ "application/grpc-web" ]
               stream:
@@ -146,10 +134,6 @@ testCases:
             rawResponse:
               statusCode: 200
               headers:
-                - name: "access-control-allow-origin"
-                  value: [ "*" ]
-                - name: "access-control-expose-headers"
-                  value: [ "*" ]
                 - name: content-type
                   value: [ "application/grpc-web" ]
                 - name: grpc-message
@@ -171,10 +155,6 @@ testCases:
             rawResponse:
               statusCode: 200
               headers:
-                - name: "access-control-allow-origin"
-                  value: [ "*" ]
-                - name: "access-control-expose-headers"
-                  value: [ "*" ]
                 - name: content-type
                   value: [ "application/grpc-web" ]
                 - name: grpc-status
@@ -191,10 +171,6 @@ testCases:
             rawResponse:
               statusCode: 200
               headers:
-                - name: "access-control-allow-origin"
-                  value: [ "*" ]
-                - name: "access-control-expose-headers"
-                  value: [ "*" ]
                 - name: content-type
                   value: [ "application/grpc-web" ]
                 - name: grpc-status
@@ -212,10 +188,6 @@ testCases:
             rawResponse:
               statusCode: 200
               headers:
-                - name: "access-control-allow-origin"
-                  value: [ "*" ]
-                - name: "access-control-expose-headers"
-                  value: [ "*" ]
                 - name: content-type
                   value: [ "application/grpc-web" ]
                 - name: "grpc-status"

--- a/internal/app/referenceserver/server.go
+++ b/internal/app/referenceserver/server.go
@@ -231,6 +231,13 @@ func createServer(req *conformancev1.ServerCompatRequest, listenAddr, tlsCertFil
 	// The server needs a lenient cors setup so that it can handle testing
 	// browser clients.
 	handler = cors.New(cors.Options{
+		// In case TLS client certs are used.
+		AllowCredentials: true,
+		// If credentials are used, default "allow all origins" doesn't work since
+		// it echos back "*" in the "Access-Control-Allow-Origin" header. But asterisk
+		// isn't accepted by clients when credentials are used. So we have to allow
+		// all this way:
+		AllowOriginFunc: func(string) bool { return true },
 		AllowedMethods: []string{
 			http.MethodHead,
 			http.MethodGet,

--- a/testing/grpcwebclient-known-failing.txt
+++ b/testing/grpcwebclient-known-failing.txt
@@ -30,9 +30,11 @@ gRPC-Web Unexpected Responses/**/ok-but-no-response
 # grpc-status header/trailer key.
 HTTP to RPC Code Mapping/**/bad-gateway
 HTTP to RPC Code Mapping/**/bad-request
-HTTP to RPC Code Mapping/**/forbidden
 HTTP to RPC Code Mapping/**/gateway-timeout
 HTTP to RPC Code Mapping/**/not-found
-HTTP to RPC Code Mapping/**/service-unavailable
 HTTP to RPC Code Mapping/**/too-many-requests
-HTTP to RPC Code Mapping/**/unauthorized
+
+# The above table maps 409 and 412 to "unknown" RPC code. But this client
+# instead maps them to "aborted" and "failed_precondition" respectively.
+HTTP to RPC Code Mapping/**/conflict
+HTTP to RPC Code Mapping/**/precondition-failed


### PR DESCRIPTION
The reference server was already configured to use CORS and to be permissive. But there were some quirks to its config that could be improved (especially if anyone were to test using TLS client certs, which means we have to allow credentials in the cross-origin requests).

Also, the "raw response" capability of the reference server was interfering with the CORS middleware. So this fixes that, which in turn activates some alternate behavior in the gRPC Web JS client: apparently, some of the behavior observed was actually the result of failed preflight requests and not the intended behavior of the library 🤦.

On a positive note: it is no longer necessary/useful to add access control headers to raw responses. The CORS middleware now handles that correctly.