### PR TITLE
When reference server is in HTTP 1.1 mode, don't allow negotiating HTTP/2 via TLS

### DIFF
--- a/internal/app/referenceserver/server.go
+++ b/internal/app/referenceserver/server.go
@@ -314,6 +314,8 @@ func newH1Server(handler http.Handler, listenAddr string, tlsConf *tls.Config) (
 		TLSConfig:         tlsConf,
 		ReadHeaderTimeout: 5 * time.Second,
 		ErrorLog:          nopLogger(),
+		// We disable automatic HTTP/2 support by setting this to non-nil
+		TLSNextProto: map[string]func(*http.Server, *tls.Conn, http.Handler){},
 	}
 	lis, err := net.Listen("tcp", listenAddr)
 	if err != nil {
@@ -333,6 +335,9 @@ func newH2Server(handler http.Handler, listenAddr string, tlsConf *tls.Config) (
 		TLSConfig:         tlsConf,
 		ReadHeaderTimeout: 5 * time.Second,
 		ErrorLog:          nopLogger(),
+		// There's no way to disable HTTP 1.1 support and *require* HTTP/2. So
+		// if the client says it supports HTTP/2, we rely on it negotiating
+		// that during ALPN of TLS handshake instead of HTTP 1.1. ¯\_(ツ)_/¯
 	}
 	lis, err := net.Listen("tcp", listenAddr)
 	if err != nil {


### PR DESCRIPTION
Some clients may not have the direct ability to _disable_ negotiating HTTP/2 if the server advertises its support during ALPN step of TLS handshake. So to prevent such clients from using HTTP/2, if HTTP 1.1. is the intent, we disable HTTP/2 in the reference server. (Sadly, we can't also disable HTTP 1.1 when HTTP/2 is the intent since Go's `net/http` doesn't provide a way to do that 🤷.)

This should resolve #854