### PR TITLE
Prepare for v1.0.2

### DIFF
--- a/internal/version.go
+++ b/internal/version.go
@@ -17,7 +17,7 @@ package internal
 //nolint:gochecknoglobals
 var (
 	// NB: These are vars instead of consts so they can be changed via -X ldflags.
-	buildVersion       = "v1.1.0-dev"
+	buildVersion       = "v1.0.2"
 	buildVersionSuffix = ""
 
 	// Version is the version to report from all binaries.


### PR DESCRIPTION
Draft release notes:

----

# v1.0.2

This release includes fixes for testing Connect clients that run in browser environments.

## What's Changed

# Bugfixes

* Fix reference server issues related to CORS by @jhump in #855 and @srikrsna-buf in #857
* When reference server is in HTTP 1.1 mode, don't allow client to negotiate HTTP/2 via TLS by @jhump in #856

## New Contributors
* @srikrsna-buf made their first contribution in #857

**Full Changelog**: https://github.com/connectrpc/conformance/compare/v1.0.1...v1.0.2