### PR TITLE
Revise some of the docs, add information about upgrading

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ This will build the necessary binaries and run tests of the following implementa
     confirm interoperability with official gRPC implementations.
 
 Both of the above clients are tested against both the Connect reference server and the gRPC server.
-The servers are tested against the Connect reference client and the gRPC client. And since the gRPC
+Both servers are tested against the Connect reference client and the gRPC client. And since the gRPC
 client does not support gRPC-Web, the servers are also tested against the official gRPC-Web JS client.
 
 ## Status: Stable
@@ -149,7 +149,21 @@ formats, or the Protobuf messages used by clients and servers under test in the
 Note, however, that we reserve the right to rename, remove, or re-organize
 individual test cases, which may impact the "known failing" and "known flaky"
 configurations for an implementation under test. We will document these changes
-in the [release notes](https://github.com/connectrpc/conformance/releases).
+in the [release notes].
+
+We also intend to occasionally add new test cases, and occasionally these
+additions may also necessitate updates to the Protobuf schemas (such as new
+request or response fields). The Protobuf changes will remain compatible, so
+your programs will continue to compile, but actually passing new/updated test
+cases may require updates to your program, to incorporate the new fields into
+the behavior of the client or server under test. These kinds of changes will
+also be documented in the releases notes.
+
+New test cases in a release could also reveal previously undetected conformance
+issues which may require fixes to the implementations you are testing. So while
+we aim for backwards-compatibility and making it easy to upgrade to new releases
+of the conformance suite, it is expected that some releases may incur some effort
+to adopt. (See [the docs][upgrading] for more details.)
 
 ## Ecosystem
 
@@ -197,3 +211,5 @@ Offered under the [Apache 2 license][license].
 [docs]: https://connectrpc.com
 [license]: https://github.com/connectrpc/conformance/blob/main/LICENSE
 [protobuf-es]: https://github.com/bufbuild/protobuf-es
+[release notes]: https://github.com/connectrpc/conformance/releases
+[upgrading]: ./docs/configuring_and_running_tests.md#upgrading

--- a/docs/testing_clients.md
+++ b/docs/testing_clients.md
@@ -199,9 +199,9 @@ ignored (and the headers and/or trailers treated as empty).
 ### Cancellation
 
 The `ClientCompatRequest` can contain instructions for the client program to cancel the
-RPC before it has completed. When the RPC is canceled based on these instructions, the
-rest of the invocation logic should proceed as if it had _not_ been canceled. This way,
-the client program exercises the client implementation's cancellation handling, and how
+RPC before it has completed. Ideally, when the RPC is canceled based on these instructions,
+the rest of the invocation logic should proceed as if it had _not_ been canceled. This way,
+the client program can exercises the client implementation's cancellation handling, and how
 it impacts subsequent operations for the call. This allows the conformance suite to verify
 that asynchronous cancellations are handled correctly by the implementation and result in
 proper notification of the cancellation to the code that is consuming the RPC results.
@@ -241,6 +241,7 @@ invoke the method using the given request headers,
    delay the indicated number of milliseconds   
    cancel the RPC (but do not return)
 }
+receive the response
 
 if the operation fails {
    abort, returning a result that describes the error and any
@@ -252,9 +253,9 @@ construct a result using the payload and any available headers
 ```
 
 _*_ Note: some client APIs will provide a blocking operation for unary RPCs,
-    which doesn't return until the RPC is complete. For these cases, you must
-    arrange for the RPC to be canceled asynchronously after the indicated
-    number of milliseconds, and then invoke the unary operation.
+    which doesn't return until the RPC response is recevied. For these cases,
+    you must arrange for the RPC to be canceled asynchronously after the indicated
+    number of milliseconds, and then invoke the blocking operation.
 
 #### Client stream
 

--- a/docs/testing_clients.md
+++ b/docs/testing_clients.md
@@ -201,7 +201,7 @@ ignored (and the headers and/or trailers treated as empty).
 The `ClientCompatRequest` can contain instructions for the client program to cancel the
 RPC before it has completed. Ideally, when the RPC is canceled based on these instructions,
 the rest of the invocation logic should proceed as if it had _not_ been canceled. This way,
-the client program can exercises the client implementation's cancellation handling, and how
+the client program can exercise the client implementation's cancellation handling, and how
 it impacts subsequent operations for the call. This allows the conformance suite to verify
 that asynchronous cancellations are handled correctly by the implementation and result in
 proper notification of the cancellation to the code that is consuming the RPC results.
@@ -253,7 +253,7 @@ construct a result using the payload and any available headers
 ```
 
 _*_ Note: some client APIs will provide a blocking operation for unary RPCs,
-    which doesn't return until the RPC response is recevied. For these cases,
+    which doesn't return until the RPC response is received. For these cases,
     you must arrange for the RPC to be canceled asynchronously after the indicated
     number of milliseconds, and then invoke the blocking operation.
 


### PR DESCRIPTION
I was reviewing some of the docs and noticed a few things that could be improved.

The changes to the **Status: Stable** section of the README stem from thinking about other kinds of changes that we must reasonably make from time to time that could prevent a user from easily being able to upgrade to a newer version of the suite. I figured being very explicit about this in this document is best for clarity and transparency.

This also adds a section to the README that describes the machinery of the thing and also includes a sequence diagram to show what's going on inside the test runner.
