### PR TITLE
Require that client implementations properly enforce timeouts

### DIFF
--- a/internal/app/referenceserver/impl.go
+++ b/internal/app/referenceserver/impl.go
@@ -541,8 +541,8 @@ func createRequestInfo(
 	}
 
 	var timeoutMs *int64
-	if deadline, ok := ctx.Deadline(); ok {
-		timeoutMs = proto.Int64(time.Until(deadline).Milliseconds())
+	if timeout, ok := timeoutFromContext(ctx); ok {
+		timeoutMs = proto.Int64(timeout.Milliseconds())
 	}
 
 	// Set all observed request headers and requests in the response payload


### PR DESCRIPTION
Because the connect-go server framework will try to curtail work beyond the deadline, the timeout test cases weren't working quite as expected. They worked for unary, but for the streaming endpoints, the deadline would elapse and cause the server handler's stream interactions to return a `deadline_exceeded` error, which it would then return to the client. So the client was correctly reporting a `deadline_exceeded` error for the streaming tests, even when it didn't actually enforce a deadline.

So this change causes the reference server to _remove_ the timeout headers, so that the connect-go framework it is built on will not bother trying to enforce any client-provided deadline. In order to actually validate the client deadline in these cases, the timeout is parsed (by the same code that removes it from the headers) and is stored off separately (in a context value), for retrieval from the server handler.

cc @rebello95