### PR TITLE
Use strict codecs in reference client and server

### DIFF
--- a/internal/app/referenceclient/client.go
+++ b/internal/app/referenceclient/client.go
@@ -261,7 +261,7 @@ func invoke(ctx context.Context, req *conformancev1.ClientCompatRequest, referen
 	case conformancev1.Codec_CODEC_PROTO:
 		// this is the default, no option needed
 	case conformancev1.Codec_CODEC_JSON:
-		clientOptions = append(clientOptions, connect.WithProtoJSON())
+		clientOptions = append(clientOptions, connect.WithCodec(internal.StrictJSONCodec{}))
 	case conformancev1.Codec_CODEC_TEXT: //nolint:staticcheck // staticcheck complains because this const is deprecated
 		return nil, fmt.Errorf("%s is deprecated and should not be used", req.Codec)
 	default:

--- a/internal/app/referenceserver/server.go
+++ b/internal/app/referenceserver/server.go
@@ -178,6 +178,7 @@ func createServer(req *conformancev1.ServerCompatRequest, listenAddr, tlsCertFil
 		connect.WithCompression(compression.Deflate, compression.NewDeflateDecompressor, compression.NewDeflateCompressor),
 		connect.WithCompression(compression.Snappy, compression.NewSnappyDecompressor, compression.NewSnappyCompressor),
 		connect.WithCompression(compression.Zstd, compression.NewZstdDecompressor, compression.NewZstdCompressor),
+		connect.WithCodec(internal.StrictJSONCodec{}),
 		connect.WithInterceptors(interceptors...),
 	}
 	if req.MessageReceiveLimit > 0 {

--- a/internal/codec.go
+++ b/internal/codec.go
@@ -252,16 +252,16 @@ func (s StrictProtoCodec) Unmarshal(data []byte, msg any) error {
 	if len(unrecognized) == 0 {
 		return nil
 	}
-	num, typ, length := protowire.ConsumeTag(unrecognized)
-	if length <= 0 {
+	num, typ, tagLength := protowire.ConsumeTag(unrecognized)
+	if tagLength <= 0 {
 		// Should not be possible since above call to proto.Unmarshal succeeded.
-		l := len(unrecognized)
+		unrecognizedLen := len(unrecognized)
 		var suffix string
-		if l > 50 {
+		if unrecognizedLen > 50 {
 			unrecognized = unrecognized[:50]
 			suffix = "..."
 		}
-		return fmt.Errorf("message data included %d unprocessable bytes: %x%s", l, unrecognized, suffix)
+		return fmt.Errorf("message data included %d unprocessable bytes: %x%s", unrecognizedLen, unrecognized, suffix)
 	}
 	var wireType string
 	switch typ {

--- a/internal/codec.go
+++ b/internal/codec.go
@@ -24,6 +24,7 @@ import (
 
 	"connectrpc.com/connect"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -219,4 +220,87 @@ func (s StrictJSONCodec) MarshalStable(msg any) ([]byte, error) {
 
 func (s StrictJSONCodec) IsBinary() bool {
 	return false
+}
+
+// StrictProtoCodec is a codec for connect (and implements the optional methods
+// for stable output and for appending to existing bytes for better performance).
+// It is like Connect's builtin Proto codec, except that it does NOT allow
+// unrecognized fields. If the peer sends a message where not all elements are
+// recognized, it will return an error.
+type StrictProtoCodec struct{}
+
+var _ connect.Codec = StrictProtoCodec{}
+
+func (s StrictProtoCodec) Name() string {
+	return "proto"
+}
+
+func (s StrictProtoCodec) Marshal(msg any) ([]byte, error) {
+	return s.MarshalAppend(nil, msg)
+}
+
+func (s StrictProtoCodec) Unmarshal(data []byte, msg any) error {
+	protoMsg, ok := msg.(proto.Message)
+	if !ok {
+		return fmt.Errorf("message type %T is not a proto.Message", msg)
+	}
+	if err := proto.Unmarshal(data, protoMsg); err != nil {
+		return err
+	}
+	// We are being strict and thus disallow any unrecognized fields.
+	unrecognized := protoMsg.ProtoReflect().GetUnknown()
+	if len(unrecognized) == 0 {
+		return nil
+	}
+	num, typ, length := protowire.ConsumeTag(unrecognized)
+	if length <= 0 {
+		// Should not be possible since above call to proto.Unmarshal succeeded.
+		l := len(unrecognized)
+		var suffix string
+		if l > 50 {
+			unrecognized = unrecognized[:50]
+			suffix = "..."
+		}
+		return fmt.Errorf("message data included %d unprocessable bytes: %x%s", l, unrecognized, suffix)
+	}
+	var wireType string
+	switch typ {
+	case protowire.VarintType:
+		wireType = "varint"
+	case protowire.Fixed32Type:
+		wireType = "fixed32"
+	case protowire.Fixed64Type:
+		wireType = "fixed64"
+	case protowire.BytesType:
+		wireType = "bytes"
+	case protowire.StartGroupType:
+		wireType = "start-group"
+	case protowire.EndGroupType:
+		// This and the default case below should not really be possible
+		// since above call to proto.Unmarshal succeeded.
+		return fmt.Errorf("message data included field %d that incorrectly starts with end-group wire type", num)
+	default:
+		return fmt.Errorf("message data included field %d that uses unknown wire type %d", num, typ)
+	}
+	return fmt.Errorf("message data includes unrecognized field %d with %s wire type", num, wireType)
+}
+
+func (s StrictProtoCodec) MarshalAppend(b []byte, msg any) ([]byte, error) {
+	protoMsg, ok := msg.(proto.Message)
+	if !ok {
+		return nil, fmt.Errorf("message type %T is not a proto.Message", msg)
+	}
+	return protojson.MarshalOptions{}.MarshalAppend(b, protoMsg)
+}
+
+func (s StrictProtoCodec) MarshalStable(msg any) ([]byte, error) {
+	protoMsg, ok := msg.(proto.Message)
+	if !ok {
+		return nil, fmt.Errorf("message type %T is not a proto.Message", msg)
+	}
+	return proto.MarshalOptions{Deterministic: true}.Marshal(protoMsg)
+}
+
+func (s StrictProtoCodec) IsBinary() bool {
+	return true
 }

--- a/internal/codec_test.go
+++ b/internal/codec_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestStrictJSONCodec(t *testing.T) {
+	t.Parallel()
 	codec := StrictJSONCodec{}
 	err := codec.Unmarshal([]byte(`{
 		"somefield": 123
@@ -16,6 +17,7 @@ func TestStrictJSONCodec(t *testing.T) {
 }
 
 func TestStrictProtoCodec(t *testing.T) {
+	t.Parallel()
 	codec := StrictProtoCodec{}
 	err := codec.Unmarshal([]byte{8, 0}, &emptypb.Empty{})
 	require.ErrorContains(t, err, `message data includes unrecognized field 1 with varint wire type`)

--- a/internal/codec_test.go
+++ b/internal/codec_test.go
@@ -1,0 +1,22 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+func TestStrictJSONCodec(t *testing.T) {
+	codec := StrictJSONCodec{}
+	err := codec.Unmarshal([]byte(`{
+		"somefield": 123
+	}`), &emptypb.Empty{})
+	require.ErrorContains(t, err, `unknown field "somefield"`)
+}
+
+func TestStrictProtoCodec(t *testing.T) {
+	codec := StrictProtoCodec{}
+	err := codec.Unmarshal([]byte{8, 0}, &emptypb.Empty{})
+	require.ErrorContains(t, err, `message data includes unrecognized field 1 with varint wire type`)
+}


### PR DESCRIPTION
This should make it easier to troubleshoot issues caused by accidentally using a non-conformant JSON format. For example, it turns out that Dart's [default JSON format](https://github.com/google/protobuf.dart/issues/220) is _not_ the format defined by the [proto3 mapping spec](https://protobuf.dev/programming-guides/proto3/#json) but some bespoke format that uses tag numbers instead of names.

Previously, a server or client would accept such messages and just ignore unrecognized fields (which could be all of them). This could result in hard-to-troubleshoot errors, since the server would behave like it got a partial or empty request message.

This will cause the codec to complain about the unrecognized field name, which should produce more intuitive errors.

We do similar for the Protobuf binary format, too, disallowing unrecognized fields in the data.