### PR TITLE
Fix missing copyright

### DIFF
--- a/internal/codec_test.go
+++ b/internal/codec_test.go
@@ -1,3 +1,17 @@
+// Copyright 2023-2024 The Connect Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package internal
 
 import (


### PR DESCRIPTION
Weird. The PR that introduced this file (without the copyright) passed all of its CI checks. But the ones failing on main were _skipped_, for reasons I do not understand 🤷:
* https://github.com/connectrpc/conformance/actions/runs/9292978262/job/25575097921
* https://github.com/connectrpc/conformance/actions/runs/9292978262/job/25575098173 

This adds the missing copyright to get CI green.