### PR TITLE
Update the Connect GET test suite configuration so it's only run when a client/server supports GET

### DIFF
--- a/internal/app/connectconformance/connectconformance_test.go
+++ b/internal/app/connectconformance/connectconformance_test.go
@@ -45,6 +45,18 @@ func TestRun(t *testing.T) {
 			ConnectVersionMode:     conformancev1.TestSuite_CONNECT_VERSION_MODE_UNSPECIFIED,
 		},
 		{
+			Version:                conformancev1.HTTPVersion_HTTP_VERSION_1,
+			Protocol:               conformancev1.Protocol_PROTOCOL_CONNECT,
+			Codec:                  conformancev1.Codec_CODEC_JSON,
+			Compression:            conformancev1.Compression_COMPRESSION_IDENTITY,
+			StreamType:             conformancev1.StreamType_STREAM_TYPE_UNARY,
+			UseTLS:                 false,
+			UseTLSClientCerts:      false,
+			UseConnectGET:          true,
+			UseMessageReceiveLimit: false,
+			ConnectVersionMode:     conformancev1.TestSuite_CONNECT_VERSION_MODE_UNSPECIFIED,
+		},
+		{
 			Version:                conformancev1.HTTPVersion_HTTP_VERSION_2,
 			Protocol:               conformancev1.Protocol_PROTOCOL_GRPC,
 			Codec:                  conformancev1.Codec_CODEC_PROTO,

--- a/internal/app/connectconformance/testsuites/data/connect_with_get.yaml
+++ b/internal/app/connectconformance/testsuites/data/connect_with_get.yaml
@@ -2,14 +2,15 @@ name: Connect with GET
 relevantProtocols:
   - PROTOCOL_CONNECT
 relevantCompressions:
-  # TODO - Clients only use compression for GET requests if the request is
-  # larger than a particular size. So since we aren't sending a request here
-  # that exceeds that, our requests won't use compression even if we specify
-  # it. So, we're limiting this test to identity
+  # TODO: The reference client only uses compression for GET requests if the
+  # request is larger than a particular size. So since we aren't sending a
+  # request here that exceeds that, our requests won't use compression even
+  # if we specify it. So, we're limiting this test to identity.
   - COMPRESSION_IDENTITY
 relevantCodecs:
   - CODEC_JSON
   - CODEC_PROTO
+relies_on_connect_get: true
 testCases:
 - request:
     testName: success


### PR DESCRIPTION
The test suite was missing a configuration attribute that would cause it to be omitted if the client or server under test was configured as not supporting Connect GET.

Resolves #882.