### PR TITLE
Prepare for v1.0.3

### DIFF
--- a/internal/version.go
+++ b/internal/version.go
@@ -17,7 +17,7 @@ package internal
 //nolint:gochecknoglobals
 var (
 	// NB: These are vars instead of consts so they can be changed via -X ldflags.
-	buildVersion       = "v1.1.0-dev"
+	buildVersion       = "v1.0.3"
 	buildVersionSuffix = ""
 
 	// Version is the version to report from all binaries.


### PR DESCRIPTION
The following is a draft of the release notes:

----

## What's Changed
### Bugfixes
* Update test cases for consistency, backfill missing cancel tests by @jhump in #874
* Fix reference server to verify that client implementations properly enforce timeouts by @jhump in #877
* Use strict codecs in reference client and server to produce better error messages in the face of certain codec/format errors by @jhump in #878
* Fix the Connect GET test suite configuration so those tests are only run when a client/server supports GET by @jhump in #883
* Add missing gRPC tests for trailers-only responses by @jhump in https://github.com/connectrpc/conformance/pull/904

### Other changes
* Update to use Go to 1.21 by @jhump in #866
* Deprecate the textpb codec by @jhump in #875

**Full Changelog**: https://github.com/connectrpc/conformance/compare/v1.0.2...v1.0.3