### PR TITLE
Expand test cases for gRPC-Web Trailers to servers-streaming RPCs

### DIFF
--- a/internal/app/connectconformance/testsuites/data/grpc_web_client_trailers.yaml
+++ b/internal/app/connectconformance/testsuites/data/grpc_web_client_trailers.yaml
@@ -10,9 +10,9 @@ relevantCodecs:
 # cover unary and servers-streaming RPCs - the two types that are supported in
 # web browsers.
 testCases:
-  # Trailers and status are in body (no other response messages)
+  # Unary: Trailers and status are in body (no other response messages)
   - request:
-      testName: trailers-in-body/expected
+      testName: unary/trailers-in-body/expected
       streamType: STREAM_TYPE_UNARY
       requestMessages:
         - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
@@ -40,7 +40,7 @@ testCases:
         - name: x-custom-trailer
           value: [ "bing" ]
   - request:
-      testName: trailers-in-body/mixed-case
+      testName: unary/trailers-in-body/mixed-case
       streamType: STREAM_TYPE_UNARY
       requestMessages:
         - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
@@ -68,7 +68,7 @@ testCases:
         - name: x-custom-trailer
           value: [ "bing" ]
   - request:
-      testName: trailers-in-body/duplicate-metadata
+      testName: unary/trailers-in-body/duplicate-metadata
       streamType: STREAM_TYPE_UNARY
       requestMessages:
         - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
@@ -96,9 +96,9 @@ testCases:
         - name: x-custom-trailer
           value: [ "bing", "quuz" ]
 
-  # Trailers-only responses, where status and trailers are in HTTP headers
+  # Unary: Trailers-only responses, where status and trailers are in HTTP headers
   - request:
-      testName: trailers-only/expected
+      testName: unary/trailers-only/expected
       streamType: STREAM_TYPE_UNARY
       requestMessages:
         - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
@@ -122,7 +122,7 @@ testCases:
         - name: x-custom-trailer
           value: [ "bing" ]
   - request:
-      testName: trailers-only/duplicate-metadata
+      testName: unary/trailers-only/duplicate-metadata
       streamType: STREAM_TYPE_UNARY
       requestMessages:
         - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest

--- a/internal/app/connectconformance/testsuites/data/grpc_web_client_trailers.yaml
+++ b/internal/app/connectconformance/testsuites/data/grpc_web_client_trailers.yaml
@@ -6,7 +6,9 @@ relevantCodecs:
   - CODEC_PROTO
 # These tests verify that a gRPC-Web client can handle trailers in the body with
 # no response, trailers-only responses (trailers in headers), and trailers with
-# different cases (in addition to the "standard" all lower-case).
+# different cases (in addition to the "standard" all lower-case). The tests
+# cover unary and servers-streaming RPCs - the two types that are supported in
+# web browsers.
 testCases:
   # Trailers and status are in body (no other response messages)
   - request:
@@ -124,6 +126,142 @@ testCases:
       streamType: STREAM_TYPE_UNARY
       requestMessages:
         - "@type": type.googleapis.com/connectrpc.conformance.v1.UnaryRequest
+          responseDefinition:
+            rawResponse:
+              status_code: 200
+              headers:
+                - name: content-type
+                  value: [ "application/grpc-web" ]
+                - name: x-custom-trailer
+                  value: [ "bing", "quuz" ]
+                - name: grpc-status
+                  value: [ "9" ]
+                - name: grpc-message
+                  value: [ "error" ]
+    expectedResponse:
+      error:
+        code: 9
+        message: error
+      responseTrailers:
+        - name: x-custom-trailer
+          value: [ "bing", "quuz" ]
+
+  # Server-streaming: Trailers and status are in body (no other response messages)
+  - request:
+      testName: server-stream/trailers-in-body/expected
+      streamType: STREAM_TYPE_SERVER_STREAM
+      requestMessages:
+        - "@type": type.googleapis.com/connectrpc.conformance.v1.ServerStreamRequest
+          responseDefinition:
+            rawResponse:
+              status_code: 200
+              headers:
+                - name: content-type
+                  value: [ "application/grpc-web" ]
+                - name: x-custom-header
+                  value: [ "foo" ]
+              stream:
+                items:
+                  - flags: 128
+                    payload:
+                      text: "grpc-status: 9\r\ngrpc-message: error\r\nx-custom-trailer: bing\r\n"
+    expectedResponse:
+      responseHeaders:
+        - name: x-custom-header
+          value: [ "foo" ]
+      error:
+        code: 9
+        message: error
+      responseTrailers:
+        - name: x-custom-trailer
+          value: [ "bing" ]
+  - request:
+      testName: server-stream/trailers-in-body/mixed-case
+      streamType: STREAM_TYPE_SERVER_STREAM
+      requestMessages:
+        - "@type": type.googleapis.com/connectrpc.conformance.v1.ServerStreamRequest
+          responseDefinition:
+            rawResponse:
+              status_code: 200
+              headers:
+                - name: content-type
+                  value: [ "application/grpc-web" ]
+                - name: x-custom-header
+                  value: [ "foo" ]
+              stream:
+                items:
+                  - flags: 128
+                    payload:
+                      text: "Grpc-Status: 9\r\ngRPC-Message: error\r\nx-Custom-Trailer: bing\r\n"
+    expectedResponse:
+      responseHeaders:
+        - name: x-custom-header
+          value: [ "foo" ]
+      error:
+        code: 9
+        message: error
+      responseTrailers:
+        - name: x-custom-trailer
+          value: [ "bing" ]
+  - request:
+      testName: server-stream/trailers-in-body/duplicate-metadata
+      streamType: STREAM_TYPE_SERVER_STREAM
+      requestMessages:
+        - "@type": type.googleapis.com/connectrpc.conformance.v1.ServerStreamRequest
+          responseDefinition:
+            rawResponse:
+              status_code: 200
+              headers:
+                - name: content-type
+                  value: [ "application/grpc-web" ]
+                - name: x-custom-header
+                  value: [ "foo", "bar", "baz" ]
+              stream:
+                items:
+                  - flags: 128
+                    payload:
+                      text: "grpc-status: 9\r\ngrpc-message: error\r\nx-custom-trailer: bing\r\nx-custom-trailer: quuz\r\n"
+    expectedResponse:
+      responseHeaders:
+        - name: x-custom-header
+          value: [ "foo", "bar", "baz" ]
+      error:
+        code: 9
+        message: error
+      responseTrailers:
+        - name: x-custom-trailer
+          value: [ "bing", "quuz" ]
+
+  # Server-streaming: Trailers-only responses, where status and trailers are in HTTP headers
+  - request:
+      testName: server-stream/trailers-only/expected
+      streamType: STREAM_TYPE_SERVER_STREAM
+      requestMessages:
+        - "@type": type.googleapis.com/connectrpc.conformance.v1.ServerStreamRequest
+          responseDefinition:
+            rawResponse:
+              status_code: 200
+              headers:
+                - name: content-type
+                  value: [ "application/grpc-web" ]
+                - name: x-custom-trailer
+                  value: [ "bing" ]
+                - name: grpc-status
+                  value: [ "9" ]
+                - name: grpc-message
+                  value: [ "error" ]
+    expectedResponse:
+      error:
+        code: 9
+        message: error
+      responseTrailers:
+        - name: x-custom-trailer
+          value: [ "bing" ]
+  - request:
+      testName: server-stream/trailers-only/duplicate-metadata
+      streamType: STREAM_TYPE_SERVER_STREAM
+      requestMessages:
+        - "@type": type.googleapis.com/connectrpc.conformance.v1.ServerStreamRequest
           responseDefinition:
             rawResponse:
               status_code: 200


### PR DESCRIPTION
We noticed a bug in the gRPC-Web transport from `@connectrpc/connect-web`, where a trailers-only response for a _server-streaming_ RPC failed to raise an error as expected.

I think it makes sense to expand the test cases to cover server-streaming in addition to unary.