### PR TITLE
Pin to Ubuntu 22.04 to fix Puppeteer

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,8 @@ permissions:
   contents: read
 jobs:
   ci:
+    # TODO(sayers) - Need to run on 22.04 for the time being until 
+    # https://github.com/puppeteer/puppeteer/pull/13196 is released
     runs-on: ubuntu-22.04
     strategy:
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         # When changing this, don't forget to also update

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,7 @@ jobs:
   ci:
     # TODO(sayers) - Need to run on 22.04 for the time being until 
     # https://github.com/puppeteer/puppeteer/pull/13196 is released
+    # See https://github.com/connectrpc/conformance/pull/940 for context
     runs-on: ubuntu-22.04
     strategy:
       matrix:


### PR DESCRIPTION
From Puppeteer docs:

> Ubuntu 23.10+ (or possibly other Linux distros in the future) ship an AppArmor profile that applies to Chrome stable binaries installed at /opt/google/chrome/chrome (the default installation path). This policy is stored at /etc/apparmor.d/chrome. This AppArmor policy prevents Chrome for Testing binaries downloaded by Puppeteer from using user namespaces resulting in the `No usable sandbox!` error when trying to launch the browser

We are currently seeing this error in CI due to our usage of `ubuntu-latest` in our CI Github Action images. It seems that Puppeteer has disabled this check as part of https://github.com/puppeteer/puppeteer/pull/13196, but it doesn't look like this has been released yet. Once it has, we could potentially update to that latest version of Puppeteer and reinstate usage of `ubuntu-latest`. In the meantime, though, this pins our CI image to `ubuntu-22.04` to get CI to pass.