### PR TITLE
Remove connect-go reference implementation workaround for HTTP/1.x streams

### DIFF
--- a/internal/app/referenceclient/raw_request_test.go
+++ b/internal/app/referenceclient/raw_request_test.go
@@ -433,3 +433,9 @@ func TestRawRequestSender(t *testing.T) {
 		})
 	}
 }
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}

--- a/internal/app/referenceserver/server.go
+++ b/internal/app/referenceserver/server.go
@@ -189,16 +189,7 @@ func createServer(req *conformancev1.ServerCompatRequest, listenAddr, tlsCertFil
 		&conformanceServer{referenceMode: referenceMode},
 		opts...,
 	))
-	handler := http.Handler(http.HandlerFunc(func(respWriter http.ResponseWriter, req *http.Request) {
-		if strings.HasSuffix(req.URL.Path, conformancev1connect.ConformanceServiceBidiStreamProcedure) &&
-			req.ProtoMajor == 1 {
-			// To force support for bidirectional RPC over HTTP 1.1 (for half-duplex testing),
-			// we "trick" the handler into thinking this is HTTP/2. We have to do this because
-			// otherwise, connect-go refuses to handle bidi streams over HTTP 1.1.
-			req.ProtoMajor, req.ProtoMinor = 2, 0
-		}
-		mux.ServeHTTP(respWriter, req)
-	}))
+	handler := (http.Handler)(mux)
 	if referenceMode {
 		handler = referenceServerChecks(handler, errPrinter)
 		handler = rawResponder(handler)


### PR DESCRIPTION
This PR removes the workarounds to support bidi streams over HTTP/1.x transports. Support is now added upstream in the connect-go library in https://github.com/connectrpc/connect-go/pull/796 .

Test will fail until https://github.com/connectrpc/connect-go/pull/796 is merged. Will update when pulled in.