### PR TITLE
Test with go 1.22 and 1.23

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         # When changing this, don't forget to also update
         # the version of Go used in the release.yaml workflow.
-        go-version: [1.21.x, 1.22.x]
+        go-version: [1.22.x, 1.23.x]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -46,10 +46,10 @@ jobs:
         # conflicting guidance, run only on the most recent supported version.
         # For the same reason, only check generated code on the most recent
         # supported version.
-        if: matrix.go-version == '1.22.x'
+        if: matrix.go-version == '1.23.x'
         run: make checkgenerate && make lint
       - name: Check Release
         # We'll only be building releases w/ latest Go, so we only need to
         # test that it can be built w/ latest.
-        if: matrix.go-version == '1.22.x'
+        if: matrix.go-version == '1.23.x'
         run: make checkrelease

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
       - name: Release
         env:
           GITHUB_TOKEN: ${{ github.TOKEN }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,3 @@
-run:
-  skip-dirs-use-default: false
 linters-settings:
   errcheck:
     check-type-assertions: true
@@ -30,35 +28,32 @@ linters:
   disable:
     - cyclop            # covered by gocyclo
     - depguard          # unnecessary for small libraries
-    - deadcode          # abandoned
-    - exhaustivestruct  # replaced by exhaustruct
+    - err113            # don't _always_ need to wrap errors
     - exhaustive        # lots of false positives when using default cases
+    - exportloopref     # deprecated in golangci-lint v1.60.2
     - funlen            # rely on code review to limit function length
     - gocognit          # dubious "cognitive overhead" quantification
     - gofumpt           # prefer standard gofmt
     - goimports         # rely on gci instead
-    - golint            # deprecated by Go team
-    - gomnd             # some unnamed constants are okay
-    - ifshort           # deprecated by author
-    - interfacer        # deprecated by author
+    - inamedparam       # parameter type is often all that is needed for readability
     - ireturn           # "accept interfaces, return structs" isn't ironclad
     - lll               # don't want hard limits for line length
     - maintidx          # covered by gocyclo
-    - maligned          # readability trumps efficient struct packing
+    - mnd               # some unnamed constants are okay
     - nlreturn          # generous whitespace violates house style
     - nonamedreturns    # named returns are fine; it's *bare* returns that are bad
-    - nosnakecase       # deprecated in https://github.com/golangci/golangci-lint/pull/3065
-    - scopelint         # deprecated by author
-    - structcheck       # abandoned
+    - protogetter       # too many false positives
     - testpackage       # internal tests are fine
-    - varcheck          # abandoned
     - wrapcheck         # don't _always_ need to wrap errors
     - wsl               # generous whitespace violates house style
 issues:
+  exclude-dirs-use-default: false
   exclude:
     # Don't ban use of fmt.Errorf to create new errors, but the remaining
     # checks from err113 are useful.
-    - "err113: do not define dynamic errors.*"
+    - "do not define dynamic errors.*"
+    # LOTS of false positives for this gosec check
+    - "integer overflow conversion"
   exclude-rules:
     - path: cmd/.*/main.go
       linters:

--- a/Makefile
+++ b/Makefile
@@ -140,11 +140,11 @@ $(BIN)/buf: Makefile
 
 $(BIN)/license-header: Makefile
 	@mkdir -p $(@D)
-	$(GO) install github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@v1.26.1
+	$(GO) install github.com/bufbuild/buf/private/pkg/licenseheader/cmd/license-header@v1.36.0
 
 $(BIN)/golangci-lint: Makefile
 	@mkdir -p $(@D)
-	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.2
+	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.0
 
 $(BIN)/goreleaser: Makefile
 	@mkdir -p $(@D)

--- a/internal/app/connectconformance/client_runner_test.go
+++ b/internal/app/connectconformance/client_runner_test.go
@@ -97,7 +97,6 @@ func TestRunClient(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			start := runInProcess([]string{"testclient"}, testCase.clientFunc)
@@ -122,9 +121,9 @@ func TestRunClient(t *testing.T) {
 
 			err = runner.waitForResponses()
 			if testCase.expectErr != "" {
-				assert.ErrorContains(t, err, testCase.expectErr)
+				require.ErrorContains(t, err, testCase.expectErr)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 
 			assert.Equal(t, testCase.failToSend, actualFailedToSend)

--- a/internal/app/connectconformance/config_test.go
+++ b/internal/app/connectconformance/config_test.go
@@ -362,7 +362,6 @@ func TestParseConfig_ComputesPermutations(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			cases, err := parseConfig("config.yaml", []byte(testCase.config))
@@ -577,7 +576,6 @@ func TestParseConfig_RejectsInvalidConfigurations(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			_, err := parseConfig("config.yaml", []byte(testCase.config))

--- a/internal/app/connectconformance/connectconformance_test.go
+++ b/internal/app/connectconformance/connectconformance_test.go
@@ -118,7 +118,7 @@ func TestRun(t *testing.T) {
 
 	require.NoError(t, err)
 	require.True(t, results.report(logger))
-	require.Equal(t, expectedNumCases, len(results.outcomes))
+	require.Len(t, results.outcomes, expectedNumCases)
 }
 
 type testPrinter struct {

--- a/internal/app/connectconformance/results.go
+++ b/internal/app/connectconformance/results.go
@@ -518,7 +518,7 @@ func checkError(expected, actual *conformancev1.Error, otherCodes []conformancev
 	}
 	actualReqInfo := &conformancev1.ConformancePayload_RequestInfo{}
 	expectedReqInfo := &conformancev1.ConformancePayload_RequestInfo{}
-	for i := 0; i < length; i++ {
+	for i := range length {
 		// TODO: Should this be more lenient? Are we okay with details getting re-ordered?
 		//       An alternative might be to create a map keyed by type, and for each type
 		//       remove expected messages as they are matched against actual ones.

--- a/internal/app/connectconformance/results_test.go
+++ b/internal/app/connectconformance/results_test.go
@@ -46,14 +46,16 @@ func TestResults_SetOutcome(t *testing.T) {
 	require.False(t, success)
 	lines := errorMessages(logger.Messages)
 	require.Len(t, lines, 7)
-	require.Equal(t, lines[0], "FAILED: foo/bar/2:\n\tfail\n")
-	require.Equal(t, lines[1], "FAILED: foo/bar/3:\n\tfail\n")
-	require.Equal(t, lines[2], "FAILED: known-to-fail/1 was expected to fail but did not\n")
-	require.Equal(t, lines[3], "FAILED: known-to-fail/2:\n\tfail\n")
-	require.Equal(t, lines[4], "INFO: known-to-fail/3 failed (as expected):\n\tfail\n")
-	// since known-to-flake/1 is flaky, it is allowed to pass
-	require.Equal(t, lines[5], "FAILED: known-to-flake/2:\n\tflake\n")
-	require.Equal(t, lines[6], "INFO: known-to-flake/3 failed (as expected):\n\tflake\n")
+	require.Equal(t, []string{
+		"FAILED: foo/bar/2:\n\tfail\n",
+		"FAILED: foo/bar/3:\n\tfail\n",
+		"FAILED: known-to-fail/1 was expected to fail but did not\n",
+		"FAILED: known-to-fail/2:\n\tfail\n",
+		"INFO: known-to-fail/3 failed (as expected):\n\tfail\n",
+		// since known-to-flake/1 is marked flaky, it is allowed to pass
+		"FAILED: known-to-flake/2:\n\tflake\n",
+		"INFO: known-to-flake/3 failed (as expected):\n\tflake\n",
+	}, lines)
 }
 
 func TestResults_FailedToStart(t *testing.T) {
@@ -69,9 +71,11 @@ func TestResults_FailedToStart(t *testing.T) {
 	require.False(t, success)
 	lines := errorMessages(logger.Messages)
 	require.Len(t, lines, 2)
-	require.Equal(t, lines[0], "FAILED: foo/bar/1:\n\tfail\n")
-	// Marked as failure even though expected to fail because it failed to start.
-	require.Equal(t, lines[1], "FAILED: known-to-fail/1:\n\tfail\n")
+	require.Equal(t, []string{
+		"FAILED: foo/bar/1:\n\tfail\n",
+		// Marked as failure even though expected to fail because it failed to start.
+		"FAILED: known-to-fail/1:\n\tfail\n",
+	}, lines)
 }
 
 func TestResults_FailRemaining(t *testing.T) {
@@ -91,12 +95,14 @@ func TestResults_FailRemaining(t *testing.T) {
 	require.False(t, success)
 	lines := errorMessages(logger.Messages)
 	require.Len(t, lines, 3)
-	require.Equal(t, lines[0], "FAILED: foo/bar/2:\n\tsomething went wrong\n")
-	require.Equal(t, lines[1], "INFO: known-to-fail/1 failed (as expected):\n\tfail\n")
-	// Marked as failure even though expected to fail because failRemaining is
-	// used when a process under test dies (so this error is not due to lack of
-	// conformance).
-	require.Equal(t, lines[2], "FAILED: known-to-fail/2:\n\tsomething went wrong\n")
+	require.Equal(t, []string{
+		"FAILED: foo/bar/2:\n\tsomething went wrong\n",
+		"INFO: known-to-fail/1 failed (as expected):\n\tfail\n",
+		// Marked as failure even though expected to fail because failRemaining is
+		// used when a process under test dies (so this error is not due to lack of
+		// conformance).
+		"FAILED: known-to-fail/2:\n\tsomething went wrong\n",
+	}, lines)
 }
 
 func TestResults_Failed(t *testing.T) {
@@ -110,8 +116,10 @@ func TestResults_Failed(t *testing.T) {
 	require.False(t, success)
 	lines := errorMessages(logger.Messages)
 	require.Len(t, lines, 2)
-	require.Equal(t, lines[0], "FAILED: foo/bar/1:\n\tfail\n")
-	require.Equal(t, lines[1], "INFO: known-to-fail/1 failed (as expected):\n\tfail\n")
+	require.Equal(t, []string{
+		"FAILED: foo/bar/1:\n\tfail\n",
+		"INFO: known-to-fail/1 failed (as expected):\n\tfail\n",
+	}, lines)
 }
 
 func TestResults_Assert(t *testing.T) {
@@ -154,8 +162,8 @@ func TestResults_Assert(t *testing.T) {
 	require.Contains(t, lines[1], "FAILED: foo/bar/2:\n\t")
 	require.Contains(t, lines[2], "INFO: known-to-fail/1 failed (as expected):\n\t")
 	require.Contains(t, lines[3], "INFO: known-to-fail/2 failed (as expected):\n\t")
-	require.Equal(t, lines[4], "FAILED: known-to-fail/3 was expected to fail but did not\n")
-	require.Equal(t, lines[5], "FAILED: known-to-fail/4 was expected to fail but did not\n")
+	require.Equal(t, "FAILED: known-to-fail/3 was expected to fail but did not\n", lines[4])
+	require.Equal(t, "FAILED: known-to-fail/4 was expected to fail but did not\n", lines[5])
 }
 
 func TestResults_Assert_ReportsAllErrors(t *testing.T) {
@@ -675,7 +683,6 @@ func TestResults_Assert_ReportsAllErrors(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			results := newResults(0, &testTrie{}, &testTrie{}, nil)
@@ -730,10 +737,12 @@ func TestResults_ServerSideband(t *testing.T) {
 	require.False(t, success)
 	lines := errorMessages(logger.Messages)
 	require.Len(t, lines, 4)
-	require.Equal(t, lines[0], "FAILED: foo/bar/2:\n\tsomething awkward in wire format; fail\n")
-	require.Equal(t, lines[1], "FAILED: foo/bar/3:\n\tsomething awkward in wire format\n")
-	require.Equal(t, lines[2], "INFO: known-to-fail/1 failed (as expected):\n\tsomething awkward in wire format\n")
-	require.Equal(t, lines[3], "INFO: known-to-fail/2 failed (as expected):\n\tfail\n")
+	require.Equal(t, []string{
+		"FAILED: foo/bar/2:\n\tsomething awkward in wire format; fail\n",
+		"FAILED: foo/bar/3:\n\tsomething awkward in wire format\n",
+		"INFO: known-to-fail/1 failed (as expected):\n\tsomething awkward in wire format\n",
+		"INFO: known-to-fail/2 failed (as expected):\n\tfail\n",
+	}, lines)
 }
 
 func TestResults_Report(t *testing.T) {
@@ -834,7 +843,6 @@ func TestCanonicalizeHeaderVals(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			result := canonicalizeHeaderVals(testCase.input)
@@ -873,7 +881,6 @@ func TestExpectedCodeString(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(fmt.Sprintf("%d_other_codes", len(testCase.otherCodes)), func(t *testing.T) {
 			t.Parallel()
 			require.Equal(t, testCase.expectedString, expectedCodeString(testCase.expectedCode, testCase.otherCodes))

--- a/internal/app/connectconformance/server_runner_test.go
+++ b/internal/app/connectconformance/server_runner_test.go
@@ -193,7 +193,6 @@ func TestRunTestCasesForServer(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			results := newResults(len(requests), &testTrie{}, &testTrie{}, nil)
@@ -312,7 +311,7 @@ type fakeProcess struct {
 }
 
 func newFakeProcess(stdin io.Writer, stdout, stderr io.Reader) processStarter {
-	return func(ctx context.Context, pipeStderr bool) (*process, error) {
+	return func(_ context.Context, _ bool) (*process, error) {
 		proc := &fakeProcess{}
 		return &process{
 			processController: proc,
@@ -326,7 +325,7 @@ func newFakeProcess(stdin io.Writer, stdout, stderr io.Reader) processStarter {
 }
 
 func newStillbornProcess(stdin io.Writer, stdout, stderr io.Reader) processStarter {
-	return func(ctx context.Context, pipeStderr bool) (*process, error) {
+	return func(_ context.Context, _ bool) (*process, error) {
 		proc := &fakeProcess{}
 		stdout = &hookReader{
 			r:    stdout,

--- a/internal/app/connectconformance/test_case_library_test.go
+++ b/internal/app/connectconformance/test_case_library_test.go
@@ -389,7 +389,6 @@ func TestNewTestCaseLibrary(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			testCaseLib, err := newTestCaseLibrary(testSuites, testCase.config, testCase.mode)
@@ -437,7 +436,7 @@ func TestParseTestSuites_EmbeddedTestSuites(t *testing.T) {
 			assert.True(t, strings.HasPrefix(testSuiteName, "gRPC") || unicode.IsUpper(rune(testSuiteName[0])),
 				"test suite name %q should start with capital letter", testSuiteName)
 		}
-		assert.True(t, testSuiteName == testSuite.Name,
+		assert.Equal(t, testSuite.Name, testSuiteName,
 			"test suite name %q should not have leading or trailing spaces", testSuiteName)
 		assert.False(t, strings.ContainsFunc(testSuiteName, func(r rune) bool {
 			const allowed = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789- "
@@ -605,7 +604,6 @@ func TestFilter(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			candidates := make([]*conformancev1.TestCase, len(allTestCaseNames))
@@ -837,7 +835,6 @@ func TestExpandRequestData(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			var testCaseProto conformancev1.TestCase
@@ -1888,7 +1885,6 @@ func TestPopulateExpectedResponse(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.testName, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/app/connectconformance/test_trie_test.go
+++ b/internal/app/connectconformance/test_trie_test.go
@@ -95,7 +95,6 @@ func TestParsePatterns(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.testName, func(t *testing.T) {
 			t.Parallel()
 			matched := trie.match(strings.Split(testCase.testName, "/"))

--- a/internal/app/grpcclient/impl.go
+++ b/internal/app/grpcclient/impl.go
@@ -378,7 +378,7 @@ func (i *invoker) unimplemented(
 		func(ctx context.Context, req *conformancev1.UnimplementedRequest, opts ...grpc.CallOption) (*conformancev1.UnimplementedResponse, error) {
 			return i.client.Unimplemented(ctx, req, opts...)
 		},
-		func(resp *conformancev1.UnimplementedResponse) *conformancev1.ConformancePayload {
+		func(_ *conformancev1.UnimplementedResponse) *conformancev1.ConformancePayload {
 			return nil
 		},
 	)

--- a/internal/app/referenceclient/impl.go
+++ b/internal/app/referenceclient/impl.go
@@ -503,7 +503,7 @@ func (i *invoker) unimplemented(
 	req *conformancev1.ClientCompatRequest,
 ) (*conformancev1.ClientResponseResult, error) {
 	return doUnary(ctx, req, i, i.client.Unimplemented,
-		func(resp *conformancev1.UnimplementedResponse) *conformancev1.ConformancePayload {
+		func(_ *conformancev1.UnimplementedResponse) *conformancev1.ConformancePayload {
 			return nil
 		})
 }

--- a/internal/app/referenceclient/raw_request_test.go
+++ b/internal/app/referenceclient/raw_request_test.go
@@ -56,7 +56,7 @@ func TestRawRequestSender(t *testing.T) {
 
 	var requests sync.Map // map[string]chan *http.Request
 	svr := httptest.NewServer(http.HandlerFunc(func(respWriter http.ResponseWriter, req *http.Request) {
-		testCaseName := req.Header.Get("x-test-case-name")
+		testCaseName := req.Header.Get("X-Test-Case-Name")
 		val, ok := requests.Load(testCaseName)
 		reqChan, isChan := val.(chan *http.Request)
 		if !ok || !isChan {
@@ -298,7 +298,6 @@ func TestRawRequestSender(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -308,7 +307,7 @@ func TestRawRequestSender(t *testing.T) {
 
 			sender := &rawRequestSender{
 				transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
-					req.Header.Set("x-test-case-name", testCaseName)
+					req.Header.Set("X-Test-Case-Name", testCaseName)
 					transport := &http.Transport{DisableCompression: true}
 					return transport.RoundTrip(req)
 				}),
@@ -412,8 +411,8 @@ func TestRawRequestSender(t *testing.T) {
 			assert.Equal(t, testCase.req.Verb, req.Method)
 
 			// Then headers
-			req.Header.Del("x-test-case-name") // added by the round tripper above; not in raw request
-			req.Header.Del("user-agent")       // added by http.Transport
+			req.Header.Del("X-Test-Case-Name") // added by the round tripper above; not in raw request
+			req.Header.Del("User-Agent")       // added by http.Transport
 			expectedHeaders := http.Header{}
 			internal.AddHeaders(testCase.req.Headers, expectedHeaders)
 			assert.Equal(t, expectedHeaders, req.Header)

--- a/internal/app/referenceclient/wire_details.go
+++ b/internal/app/referenceclient/wire_details.go
@@ -77,7 +77,7 @@ func (w *wireCaptureTransport) RoundTrip(req *http.Request) (*http.Response, err
 	// If this is a unary error with JSON body, replace the body with a reader
 	// that will save off the body bytes as they are read so that we can access
 	// the body contents in the tracer
-	if isUnaryJSONError(resp.Header.Get("content-type"), resp.StatusCode) {
+	if isUnaryJSONError(resp.Header.Get("Content-Type"), resp.StatusCode) {
 		resp.Body = &wireReader{body: resp.Body, wrapper: wrapper}
 	}
 	return resp, nil
@@ -179,12 +179,12 @@ func examineWireDetails(ctx context.Context, printer internal.Printer) (statusCo
 	}
 
 	// Check end-stream and/or error JSON data in the response.
-	contentType := trace.Response.Header.Get("content-type")
+	contentType := trace.Response.Header.Get("Content-Type")
 	switch {
 	case isUnaryJSONError(contentType, trace.Response.StatusCode):
 		// If this is a unary request that returned an error, then use the entire
 		// response body as the wire error details.
-		decomp := tracer.GetDecompressor(trace.Response.Header.Get("content-encoding"))
+		decomp := tracer.GetDecompressor(trace.Response.Header.Get("Content-Encoding"))
 		if err := decomp.Reset(wrapper.buf); err == nil {
 			if body, err := io.ReadAll(decomp); err == nil {
 				examineConnectError(body, printer)
@@ -571,7 +571,7 @@ func examineGRPCEndStream(endStream string, printer internal.Printer) http.Heade
 func isValidHTTPFieldValue(s string) bool {
 	// Not using "range s" because that uses UTF8 decoding to iterate
 	// through runes. But spec is in terms of bytes.
-	for i := 0; i < len(s); i++ {
+	for i := range len(s) {
 		char := s[i]
 		// Visible range is 32 (SPACE ' ') and up, excluding DEL (127).
 		// Horizontal tab (9, '\t') is allowed but outside the visible range.
@@ -589,7 +589,7 @@ func isValidHTTPFieldValue(s string) bool {
 func isValidHTTPFieldName(s string) bool {
 	// Not using "range s" because that uses UTF8 decoding to iterate
 	// through runes. But spec is in terms of bytes.
-	for i := 0; i < len(s); i++ {
+	for i := range len(s) {
 		char := s[i]
 		switch char {
 		case '!', '#', '$', '%', '&', '\'', '*', '+',
@@ -767,7 +767,7 @@ func checkGRPCStatus(headers http.Header, printer internal.Printer) { //nolint:g
 	if len(msgVals) > 0 { //nolint:nestif
 		msgStr := msgVals[0]
 		var expectHex int
-		for i := 0; i < len(msgStr); i++ {
+		for i := range len(msgStr) {
 			char := msgStr[i]
 			if expectHex > 0 {
 				if (char >= 'a' && char <= 'f') || (char >= 'A' && char <= 'F') || (char >= '0' && char <= '9') {

--- a/internal/app/referenceclient/wire_details_test.go
+++ b/internal/app/referenceclient/wire_details_test.go
@@ -301,10 +301,9 @@ func TestExamineConnectError(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
-			svr := httptest.NewServer(http.HandlerFunc(func(respWriter http.ResponseWriter, req *http.Request) {
+			svr := httptest.NewServer(http.HandlerFunc(func(respWriter http.ResponseWriter, _ *http.Request) {
 				respWriter.Header().Set("Content-Type", "application/json")
 				if testCase.compressed {
 					respWriter.Header().Set("Content-Encoding", "gzip")
@@ -325,7 +324,7 @@ func TestExamineConnectError(t *testing.T) {
 			)
 			ctx := withWireCapture(context.Background())
 			req := connect.NewRequest(&conformancev1.UnaryRequest{})
-			req.Header().Set("x-test-case-name", "foo") // needed to enable tracing
+			req.Header().Set("X-Test-Case-Name", "foo") // needed to enable tracing
 			_, err := client.Unary(ctx, req)
 			require.Error(t, err)
 			printer := &internal.SimplePrinter{}
@@ -461,10 +460,9 @@ func TestExamineConnectEndStream(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
-			svr := httptest.NewServer(http.HandlerFunc(func(respWriter http.ResponseWriter, req *http.Request) {
+			svr := httptest.NewServer(http.HandlerFunc(func(respWriter http.ResponseWriter, _ *http.Request) {
 				respWriter.Header().Set("Content-Type", "application/connect+proto")
 				if testCase.compressed {
 					respWriter.Header().Set("Connect-Content-Encoding", "gzip")
@@ -481,7 +479,7 @@ func TestExamineConnectEndStream(t *testing.T) {
 			)
 			ctx := withWireCapture(context.Background())
 			stream := client.ClientStream(ctx)
-			stream.RequestHeader().Set("x-test-case-name", "foo") // needed to enable tracing
+			stream.RequestHeader().Set("X-Test-Case-Name", "foo") // needed to enable tracing
 			_, err := stream.CloseAndReceive()
 			require.Error(t, err)
 			printer := &internal.SimplePrinter{}
@@ -880,7 +878,6 @@ func TestExamineGRPCEndStream(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			svr := httptest.NewServer(http.HandlerFunc(func(respWriter http.ResponseWriter, req *http.Request) {
@@ -906,7 +903,7 @@ func TestExamineGRPCEndStream(t *testing.T) {
 			)
 			ctx := withWireCapture(context.Background())
 			req := connect.NewRequest(&conformancev1.UnaryRequest{})
-			req.Header().Set("x-test-case-name", "foo") // needed to enable tracing
+			req.Header().Set("X-Test-Case-Name", "foo") // needed to enable tracing
 			if testCase.expectedCode != 0 {
 				req.Header().Set("Expect-Code", testCase.expectedCode.String())
 			}
@@ -1013,7 +1010,6 @@ func TestCheckNoDuplicateKeys(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			_, err := checkNoDuplicateKeys("", json.NewDecoder(strings.NewReader(testCase.input)))

--- a/internal/app/referenceserver/raw_response_test.go
+++ b/internal/app/referenceserver/raw_response_test.go
@@ -259,12 +259,10 @@ func TestRawResponseRecorder(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
 			for _, invoker := range invokers {
-				invoker := invoker
 				t.Run(invoker.name, func(t *testing.T) {
 					t.Parallel()
 
@@ -273,7 +271,7 @@ func TestRawResponseRecorder(t *testing.T) {
 					var body bytes.Buffer
 					testCaseName := t.Name()
 					transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
-						req.Header.Set("x-test-case-name", testCaseName)
+						req.Header.Set("X-Test-Case-Name", testCaseName)
 						resp, err = svr.Client().Transport.RoundTrip(req)
 						if err != nil {
 							return nil, err

--- a/internal/grpcutil/metadata.go
+++ b/internal/grpcutil/metadata.go
@@ -74,12 +74,13 @@ func ConvertProtoHeaderToMetadata(
 // AppendToOutgoingContext appends the given headers to the outgoing context.
 // Used for sending metadata from the client side.
 func AppendToOutgoingContext(ctx context.Context, src []*conformancev1.Header) context.Context {
+	keysVals := make([]string, 0, len(src)*2)
 	for _, hdr := range src {
 		for _, val := range hdr.Value {
-			ctx = metadata.AppendToOutgoingContext(ctx, hdr.Name, val)
+			keysVals = append(keysVals, hdr.Name, val)
 		}
 	}
-	return ctx
+	return metadata.AppendToOutgoingContext(ctx, keysVals...)
 }
 
 // PercentEncodeMessage percent-encodes the given string per the rules in the
@@ -87,7 +88,7 @@ func AppendToOutgoingContext(ctx context.Context, src []*conformancev1.Header) c
 func PercentEncodeMessage(msg string) string {
 	const upperhex = "0123456789ABCDEF"
 	var hexCount int
-	for i := 0; i < len(msg); i++ {
+	for i := range len(msg) {
 		if ShouldEscapeByteInMessage(msg[i]) {
 			hexCount++
 		}
@@ -98,7 +99,7 @@ func PercentEncodeMessage(msg string) string {
 	// We need to escape some characters, so we'll need to allocate a new string.
 	var out strings.Builder
 	out.Grow(len(msg) + 2*hexCount)
-	for i := 0; i < len(msg); i++ {
+	for i := range len(msg) {
 		switch char := msg[i]; {
 		case ShouldEscapeByteInMessage(char):
 			out.WriteByte('%')

--- a/internal/raw_http_body_test.go
+++ b/internal/raw_http_body_test.go
@@ -61,7 +61,6 @@ func TestWriteRawMessageContents(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -151,7 +150,6 @@ func TestWriteRawStreamContents(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/tls.go
+++ b/internal/tls.go
@@ -21,6 +21,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"math/big"
 	"net"
@@ -40,11 +41,11 @@ const (
 // the TLS handshake, for mutually-authenticated TLS.
 func NewClientTLSConfig(caCert, clientCert, clientKey []byte) (*tls.Config, error) {
 	if len(caCert) == 0 {
-		return nil, fmt.Errorf("caCert is empty")
+		return nil, errors.New("caCert is empty")
 	}
 	caCertPool := x509.NewCertPool()
 	if !caCertPool.AppendCertsFromPEM(caCert) {
-		return nil, fmt.Errorf("failed to parse CA cert from given data")
+		return nil, errors.New("failed to parse CA cert from given data")
 	}
 
 	hasClientCert := len(clientCert) != 0
@@ -58,9 +59,9 @@ func NewClientTLSConfig(caCert, clientCert, clientKey []byte) (*tls.Config, erro
 		}
 		certs = []tls.Certificate{certPair}
 	case hasClientCert:
-		return nil, fmt.Errorf("clientCert is not empty but clientKey is")
+		return nil, errors.New("clientCert is not empty but clientKey is")
 	case hasClientKey:
-		return nil, fmt.Errorf("clientKey is not empty but clientCert is")
+		return nil, errors.New("clientKey is not empty but clientCert is")
 	}
 
 	return &tls.Config{
@@ -75,13 +76,13 @@ func NewClientTLSConfig(caCert, clientCert, clientKey []byte) (*tls.Config, erro
 // The clientCACert parameter is required unless clientCerts is tls.NoClientCert.
 func NewServerTLSConfig(cert tls.Certificate, clientCertMode tls.ClientAuthType, clientCACert []byte) (*tls.Config, error) {
 	if clientCertMode != tls.NoClientCert && len(clientCACert) == 0 {
-		return nil, fmt.Errorf("clientCertMode indicates client certs supported but CACert is empty")
+		return nil, errors.New("clientCertMode indicates client certs supported but CACert is empty")
 	}
 	var caCertPool *x509.CertPool
 	if len(clientCACert) > 0 {
 		caCertPool = x509.NewCertPool()
 		if !caCertPool.AppendCertsFromPEM(clientCACert) {
-			return nil, fmt.Errorf("failed to parse client CA cert from given data")
+			return nil, errors.New("failed to parse client CA cert from given data")
 		}
 	}
 
@@ -96,10 +97,10 @@ func NewServerTLSConfig(cert tls.Certificate, clientCertMode tls.ClientAuthType,
 // ParseServerCert parses the given PEM-encoded cert and key.
 func ParseServerCert(cert, key []byte) (tls.Certificate, error) {
 	if len(cert) == 0 {
-		return tls.Certificate{}, fmt.Errorf("cert is empty")
+		return tls.Certificate{}, errors.New("cert is empty")
 	}
 	if len(key) == 0 {
-		return tls.Certificate{}, fmt.Errorf("key is empty")
+		return tls.Certificate{}, errors.New("key is empty")
 	}
 	certPair, err := tls.X509KeyPair(cert, key)
 	if err != nil {

--- a/internal/tracer/builder.go
+++ b/internal/tracer/builder.go
@@ -16,17 +16,17 @@ package tracer
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"net/http/httptrace"
 	"net/textproto"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 )
 
-const testCaseNameHeader = "x-test-case-name"
+const testCaseNameHeader = "X-Test-Case-Name"
 
 // builder accumulates events to build a trace.
 type builder struct {
@@ -76,7 +76,7 @@ func newBuilder(req *http.Request, client bool, collector Collector) (*builder, 
 		// from a header. So synthesize the header if it's not present.
 		headers := req.Header.Clone()
 		if len(headers.Get("Content-Length")) == 0 && req.ContentLength != -1 {
-			headers.Set("Content-Length", fmt.Sprintf("%d", req.ContentLength))
+			headers.Set("Content-Length", strconv.FormatInt(req.ContentLength, 10))
 		}
 		getHeaders = func() http.Header {
 			return headers

--- a/internal/tracer/middleware.go
+++ b/internal/tracer/middleware.go
@@ -51,7 +51,7 @@ func TracingRoundTripper(transport http.RoundTripper, collector Collector) http.
 // TracingHandler applies tracing middleware to the given handler. The returned
 // handler will record traces of all operations to the given tracer.
 func TracingHandler(handler http.Handler, collector Collector) http.Handler {
-	return http.HandlerFunc(func(respWriter http.ResponseWriter, req *http.Request) {
+	return http.HandlerFunc(func(respWriter http.ResponseWriter, req *http.Request) { //nolint:contextcheck // false positive
 		builder, ctx := newBuilder(req, false, collector)
 		defer builder.build() // make sure the trace is complete before returning
 		ctx, cancel := context.WithCancel(ctx)

--- a/internal/tracer/tracer.go
+++ b/internal/tracer/tracer.go
@@ -424,7 +424,7 @@ func printHeaders(prefix string, isHTTP1 bool, headers http.Header, printer inte
 }
 
 func isPrintableASCII(s string) bool {
-	for i := 0; i < len(s); i++ {
+	for i := range len(s) {
 		if s[i] < 0x20 || s[i] > 0x7E {
 			return false
 		}

--- a/internal/tracer/tracer_test.go
+++ b/internal/tracer/tracer_test.go
@@ -98,7 +98,6 @@ func TestTracer(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			var clientTracer, serverTracer Tracer
@@ -425,7 +424,6 @@ func TestTracer(t *testing.T) {
 				},
 			}
 			for _, testCall := range testCalls {
-				testCall := testCall
 				t.Run(testCall.name, func(t *testing.T) {
 					t.Parallel()
 					ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)


### PR DESCRIPTION
The minimum for this repo is now 1.22, not 1.21, due to upgrades in both grpc-go and quic-go.  We usually support the past _three_ versions of Go, instead of just past two. But this repo isn't a library for our users (some of which may use Go 1.21) and isn't a tool that our users need to build from source (possibly using Go 1.21). Instead, we provide release binaries that users should download if they are unable to build from source. So dropping 1.21 should be fine for this repo.

Much of the diff is due to a handful of new lint checks -- we had to update golangci-lint in order to support 1.23, and it includes several new checks, particularly one that wants string constants/literals used to query HTTP headers to use canonical case (it is more efficient -- _not_ using canonical case forces the `http.Header` value to build a new canonicalized string before querying the underlying map).

Also, moving to 1.22 means the default loop-variable behavior no longer captures the address, so we no longer need to make a copy (and there's a linter that catches this, so they've all been updated).