### PR TITLE
Allow server to cancel when deadline expires

### DIFF
--- a/internal/app/connectconformance/connectconformance.go
+++ b/internal/app/connectconformance/connectconformance.go
@@ -312,7 +312,7 @@ func run( //nolint:gocyclo
 		}
 	}
 
-	results := newResults(filteredTestCount, knownFailing, knownFlaky, trace)
+	results := newResults(mode, filteredTestCount, knownFailing, knownFlaky, trace)
 
 	for _, clientInfo := range clients {
 		clientProcess, err := runClient(ctx, clientInfo.start)

--- a/internal/app/connectconformance/results_test.go
+++ b/internal/app/connectconformance/results_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestResults_SetOutcome(t *testing.T) {
 	t.Parallel()
-	results := newResults(0, makeKnownFailing(), makeKnownFlaky(), nil)
+	results := newResults(conformancev1.TestSuite_TEST_MODE_UNSPECIFIED, 0, makeKnownFailing(), makeKnownFlaky(), nil)
 	results.setOutcome("foo/bar/1", false, nil)
 	results.setOutcome("foo/bar/2", true, errors.New("fail"))
 	results.setOutcome("foo/bar/3", false, errors.New("fail"))
@@ -60,7 +60,7 @@ func TestResults_SetOutcome(t *testing.T) {
 
 func TestResults_FailedToStart(t *testing.T) {
 	t.Parallel()
-	results := newResults(0, makeKnownFailing(), makeKnownFlaky(), nil)
+	results := newResults(conformancev1.TestSuite_TEST_MODE_UNSPECIFIED, 0, makeKnownFailing(), makeKnownFlaky(), nil)
 	results.failedToStart([]*conformancev1.TestCase{
 		{Request: &conformancev1.ClientCompatRequest{TestName: "foo/bar/1"}},
 		{Request: &conformancev1.ClientCompatRequest{TestName: "known-to-fail/1"}},
@@ -80,7 +80,7 @@ func TestResults_FailedToStart(t *testing.T) {
 
 func TestResults_FailRemaining(t *testing.T) {
 	t.Parallel()
-	results := newResults(0, makeKnownFailing(), makeKnownFlaky(), nil)
+	results := newResults(conformancev1.TestSuite_TEST_MODE_UNSPECIFIED, 0, makeKnownFailing(), makeKnownFlaky(), nil)
 	results.setOutcome("foo/bar/1", false, nil)
 	results.setOutcome("known-to-fail/1", false, errors.New("fail"))
 	results.failRemaining([]*conformancev1.TestCase{
@@ -107,7 +107,7 @@ func TestResults_FailRemaining(t *testing.T) {
 
 func TestResults_Failed(t *testing.T) {
 	t.Parallel()
-	results := newResults(0, makeKnownFailing(), makeKnownFlaky(), nil)
+	results := newResults(conformancev1.TestSuite_TEST_MODE_UNSPECIFIED, 0, makeKnownFailing(), makeKnownFlaky(), nil)
 	results.failed("foo/bar/1", &conformancev1.ClientErrorResult{Message: "fail"})
 	results.failed("known-to-fail/1", &conformancev1.ClientErrorResult{Message: "fail"})
 
@@ -124,7 +124,7 @@ func TestResults_Failed(t *testing.T) {
 
 func TestResults_Assert(t *testing.T) {
 	t.Parallel()
-	results := newResults(0, makeKnownFailing(), makeKnownFlaky(), nil)
+	results := newResults(conformancev1.TestSuite_TEST_MODE_UNSPECIFIED, 0, makeKnownFailing(), makeKnownFlaky(), nil)
 	payload1 := &conformancev1.ClientResponseResult{
 		Payloads: []*conformancev1.ConformancePayload{
 			{Data: []byte{0, 1, 2, 3, 4}},
@@ -685,7 +685,7 @@ func TestResults_Assert_ReportsAllErrors(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
-			results := newResults(0, &testTrie{}, &testTrie{}, nil)
+			results := newResults(conformancev1.TestSuite_TEST_MODE_UNSPECIFIED, 0, &testTrie{}, &testTrie{}, nil)
 
 			expected := &conformancev1.TestCase{
 				Request:          &conformancev1.ClientCompatRequest{StreamType: conformancev1.StreamType_STREAM_TYPE_UNARY},
@@ -722,7 +722,7 @@ func TestResults_Assert_ReportsAllErrors(t *testing.T) {
 
 func TestResults_ServerSideband(t *testing.T) {
 	t.Parallel()
-	results := newResults(0, makeKnownFailing(), makeKnownFlaky(), nil)
+	results := newResults(conformancev1.TestSuite_TEST_MODE_UNSPECIFIED, 0, makeKnownFailing(), makeKnownFlaky(), nil)
 	results.setOutcome("foo/bar/1", false, nil)
 	results.setOutcome("foo/bar/2", false, errors.New("fail"))
 	results.setOutcome("foo/bar/3", false, nil)
@@ -747,7 +747,7 @@ func TestResults_ServerSideband(t *testing.T) {
 
 func TestResults_Report(t *testing.T) {
 	t.Parallel()
-	results := newResults(0, makeKnownFailing(), makeKnownFlaky(), nil)
+	results := newResults(conformancev1.TestSuite_TEST_MODE_UNSPECIFIED, 0, makeKnownFailing(), makeKnownFlaky(), nil)
 	logger := &internal.SimplePrinter{}
 
 	// No test cases? Report success.
@@ -755,42 +755,42 @@ func TestResults_Report(t *testing.T) {
 	require.True(t, success)
 
 	// Only successful outcomes? Report success.
-	results = newResults(0, makeKnownFailing(), makeKnownFlaky(), nil)
+	results = newResults(conformancev1.TestSuite_TEST_MODE_UNSPECIFIED, 0, makeKnownFailing(), makeKnownFlaky(), nil)
 	results.setOutcome("foo/bar/1", false, nil)
 	success = results.report(logger)
 	require.True(t, success)
 
 	// Unexpected failure? Report failure.
-	results = newResults(0, makeKnownFailing(), makeKnownFlaky(), nil)
+	results = newResults(conformancev1.TestSuite_TEST_MODE_UNSPECIFIED, 0, makeKnownFailing(), makeKnownFlaky(), nil)
 	results.setOutcome("foo/bar/1", false, errors.New("ruh roh"))
 	success = results.report(logger)
 	require.False(t, success)
 
 	// Unexpected failure during setup? Report failure.
-	results = newResults(0, makeKnownFailing(), makeKnownFlaky(), nil)
+	results = newResults(conformancev1.TestSuite_TEST_MODE_UNSPECIFIED, 0, makeKnownFailing(), makeKnownFlaky(), nil)
 	results.setOutcome("foo/bar/1", true, errors.New("ruh roh"))
 	success = results.report(logger)
 	require.False(t, success)
 
 	// Expected failure? Report success.
-	results = newResults(0, makeKnownFailing(), makeKnownFlaky(), nil)
+	results = newResults(conformancev1.TestSuite_TEST_MODE_UNSPECIFIED, 0, makeKnownFailing(), makeKnownFlaky(), nil)
 	results.setOutcome("known-to-fail/1", false, errors.New("ruh roh"))
 	success = results.report(logger)
 	require.True(t, success)
 
 	// Setup error from expected failure? Report failure (setup errors never acceptable).
-	results = newResults(0, makeKnownFailing(), makeKnownFlaky(), nil)
+	results = newResults(conformancev1.TestSuite_TEST_MODE_UNSPECIFIED, 0, makeKnownFailing(), makeKnownFlaky(), nil)
 	results.setOutcome("known-to-fail/1", true, errors.New("ruh roh"))
 	success = results.report(logger)
 	require.False(t, success)
 
 	// Flaky? Report success whether it passes or fails
-	results = newResults(0, makeKnownFailing(), makeKnownFlaky(), nil)
+	results = newResults(conformancev1.TestSuite_TEST_MODE_UNSPECIFIED, 0, makeKnownFailing(), makeKnownFlaky(), nil)
 	results.setOutcome("known-to-flake/1", false, nil) // succeeds
 	success = results.report(logger)
 	require.True(t, success)
 
-	results = newResults(0, makeKnownFailing(), makeKnownFlaky(), nil)
+	results = newResults(conformancev1.TestSuite_TEST_MODE_UNSPECIFIED, 0, makeKnownFailing(), makeKnownFlaky(), nil)
 	results.setOutcome("known-to-flake/1", false, errors.New("ruh roh"))
 	success = results.report(logger)
 	require.True(t, success)

--- a/internal/app/connectconformance/server_runner_test.go
+++ b/internal/app/connectconformance/server_runner_test.go
@@ -195,7 +195,7 @@ func TestRunTestCasesForServer(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
-			results := newResults(len(requests), &testTrie{}, &testTrie{}, nil)
+			results := newResults(conformancev1.TestSuite_TEST_MODE_UNSPECIFIED, len(requests), &testTrie{}, &testTrie{}, nil)
 
 			var procAddr atomic.Pointer[process] // populated when server process created
 			var actualSvrRequest bytes.Buffer


### PR DESCRIPTION
This makes some assertions for timeout cases a little more lenient. The tests previously asserted that a server would return a "deadline exceeded" error when the client's deadline expires. However, not all gRPC servers behave this way. The gRPC Go reference implementation was recently updated to sometimes just cancel the stream instead of sending back an error response. This doesn't seem unreasonable, so instead of updating the "known failing" list of cases for the grpc-go server, this PR makes this behavior allowed (which means it will be allowed in any other implementation-under-test, too).

The test case structure lets us define other acceptable error codes for test cases, however we don't actually want to add "canceled" as generally acceptable for these tests. It's really only acceptable for the server (clients should always report "deadline exceeded" for these cases). So we need to update the test assertions logic to get that level of nuance.

If you look at the latest commit on main as well as all open Depend-a-bot PRs, you'll see that CI is red on these commits because of this behavior -- it seems like one (out of five) of the timeout tests fails with each run. Interestingly, they normally pass (I've yet to even see a run where more than one failed; they seem to always pass when I run the suite locally). The actual failures observed so far have been in "unary", "client-stream", and "half-duplex/bidi-stream" tests (not yet observed for "server-stream" or "full-fuplex/bidi-stream" tests).

The behavior causing CI to be flaky/red was introduced in #993, which pulled in the latest grpc-go, v1.72.0, which included https://github.com/grpc/grpc-go/pull/8071 (which is the culprit for the new behavior).