### PR TITLE
Add Connect client-stream test for missing EndStreamResponse

### DIFF
--- a/internal/app/connectconformance/testsuites/data/connect_client_unexpected.yaml
+++ b/internal/app/connectconformance/testsuites/data/connect_client_unexpected.yaml
@@ -100,15 +100,70 @@ testCases:
                     payload:
                       binary_message:
                         "@type": "type.googleapis.com/connectrpc.conformance.v1.ClientStreamResponse"
+    # Per the gRPC status-code guidance, "error parsing returned status" maps
+    # to UNKNOWN: the HTTP body completed cleanly but the protocol-level
+    # terminus is missing.
     otherAllowedErrorCodes:
-      # The spec doesn't mandate a code: connect-go reports `internal`
-      # (unexpected EOF); other implementations report `unavailable` (treats
-      # mid-body truncation as a transport-level condition) or `unknown`.
-      - CODE_UNKNOWN
-      - CODE_UNAVAILABLE
+      # TODO: connect-go currently reports INTERNAL via the unexpected-EOF
+      # path; once it returns UNKNOWN this allowance can be removed.
+      - CODE_INTERNAL
     expectedResponse:
       error:
-        code: CODE_INTERNAL
+        code: CODE_UNKNOWN
+  - request:
+      testName: server-stream/no-end-stream
+      streamType: STREAM_TYPE_SERVER_STREAM
+      requestMessages:
+        - "@type": type.googleapis.com/connectrpc.conformance.v1.ServerStreamRequest
+          responseDefinition:
+            rawResponse:
+              status_code: 200
+              headers:
+                - name: content-type
+                  value: [ "application/connect+proto" ]
+              stream:
+                items:
+                  - flags: 0
+                    payload:
+                      binary_message:
+                        "@type": "type.googleapis.com/connectrpc.conformance.v1.ServerStreamResponse"
+    otherAllowedErrorCodes:
+      # TODO: see client-stream/no-end-stream above.
+      - CODE_INTERNAL
+    expectedResponse:
+      # The data message is well-formed and is yielded to the application
+      # before the missing-end-stream error fires on the next receive.
+      payloads:
+        - { }
+      error:
+        code: CODE_UNKNOWN
+  - request:
+      # Note there is no 'full-duplex' test since that is logically
+      # equivalent to this test and is therefore covered here.
+      testName: bidi-stream/half-duplex/no-end-stream
+      streamType: STREAM_TYPE_HALF_DUPLEX_BIDI_STREAM
+      requestMessages:
+        - "@type": type.googleapis.com/connectrpc.conformance.v1.BidiStreamRequest
+          responseDefinition:
+            rawResponse:
+              status_code: 200
+              headers:
+                - name: content-type
+                  value: [ "application/connect+proto" ]
+              stream:
+                items:
+                  - flags: 0
+                    payload:
+                      binary_message:
+                        "@type": "type.googleapis.com/connectrpc.conformance.v1.BidiStreamResponse"
+    otherAllowedErrorCodes:
+      # TODO: see client-stream/no-end-stream above.
+      - CODE_INTERNAL
+    expectedResponse:
+      payloads:
+        - { }
+      error:
+        code: CODE_UNKNOWN
 
   - request:
       testName: unexpected-content-type

--- a/internal/app/connectconformance/testsuites/data/connect_client_unexpected.yaml
+++ b/internal/app/connectconformance/testsuites/data/connect_client_unexpected.yaml
@@ -79,6 +79,36 @@ testCases:
     expectedResponse:
       error:
         code: CODE_UNIMPLEMENTED
+  - request:
+      # Streaming responses must end with an EndStreamResponse envelope.
+      # A response that delivers the data message and then closes the body
+      # without one is truncated, not complete, and clients should not report
+      # it as success-with-empty-trailers.
+      testName: client-stream/no-end-stream
+      streamType: STREAM_TYPE_CLIENT_STREAM
+      requestMessages:
+        - "@type": type.googleapis.com/connectrpc.conformance.v1.ClientStreamRequest
+          responseDefinition:
+            rawResponse:
+              status_code: 200
+              headers:
+                - name: content-type
+                  value: [ "application/connect+proto" ]
+              stream:
+                items:
+                  - flags: 0
+                    payload:
+                      binary_message:
+                        "@type": "type.googleapis.com/connectrpc.conformance.v1.ClientStreamResponse"
+    otherAllowedErrorCodes:
+      # The spec doesn't mandate a code: connect-go reports `internal`
+      # (unexpected EOF); other implementations report `unavailable` (treats
+      # mid-body truncation as a transport-level condition) or `unknown`.
+      - CODE_UNKNOWN
+      - CODE_UNAVAILABLE
+    expectedResponse:
+      error:
+        code: CODE_INTERNAL
 
   - request:
       testName: unexpected-content-type

--- a/internal/app/connectconformance/testsuites/data/connect_client_unexpected.yaml
+++ b/internal/app/connectconformance/testsuites/data/connect_client_unexpected.yaml
@@ -100,16 +100,16 @@ testCases:
                     payload:
                       binary_message:
                         "@type": "type.googleapis.com/connectrpc.conformance.v1.ClientStreamResponse"
-    # Per the gRPC status-code guidance, "error parsing returned status" maps
-    # to UNKNOWN: the HTTP body completed cleanly but the protocol-level
-    # terminus is missing.
+    # The HTTP body completed cleanly but the protocol-level terminus is
+    # missing. connect-go (and other gRPC implementations) classify this as
+    # a wire-level error and report INTERNAL, alongside cases such as a
+    # failed decompression or an unparseable response message. The spec does
+    # not mandate a code here, so UNKNOWN is also accepted.
     otherAllowedErrorCodes:
-      # TODO: connect-go currently reports INTERNAL via the unexpected-EOF
-      # path; once it returns UNKNOWN this allowance can be removed.
-      - CODE_INTERNAL
+      - CODE_UNKNOWN
     expectedResponse:
       error:
-        code: CODE_UNKNOWN
+        code: CODE_INTERNAL
   - request:
       testName: server-stream/no-end-stream
       streamType: STREAM_TYPE_SERVER_STREAM
@@ -128,15 +128,14 @@ testCases:
                       binary_message:
                         "@type": "type.googleapis.com/connectrpc.conformance.v1.ServerStreamResponse"
     otherAllowedErrorCodes:
-      # TODO: see client-stream/no-end-stream above.
-      - CODE_INTERNAL
+      - CODE_UNKNOWN
     expectedResponse:
       # The data message is well-formed and is yielded to the application
       # before the missing-end-stream error fires on the next receive.
       payloads:
         - { }
       error:
-        code: CODE_UNKNOWN
+        code: CODE_INTERNAL
   - request:
       # Note there is no 'full-duplex' test since that is logically
       # equivalent to this test and is therefore covered here.
@@ -157,13 +156,12 @@ testCases:
                       binary_message:
                         "@type": "type.googleapis.com/connectrpc.conformance.v1.BidiStreamResponse"
     otherAllowedErrorCodes:
-      # TODO: see client-stream/no-end-stream above.
-      - CODE_INTERNAL
+      - CODE_UNKNOWN
     expectedResponse:
       payloads:
         - { }
       error:
-        code: CODE_UNKNOWN
+        code: CODE_INTERNAL
 
   - request:
       testName: unexpected-content-type


### PR DESCRIPTION
A Connect streaming response must end with an `EndStreamResponse` envelope (the `flags & 0b10` frame). The Connect Unexpected Responses suite already covers a client-stream response with **no** data message (`client-stream/ok-but-no-response`) and with **multiple** data messages (`client-stream/multiple-responses`), and the gRPC suite covers the analogous "body present but trailers missing" case (`trailers-only/ignore-header-if-body-present`). There is no Connect-protocol case for a response that delivers the single data message and then closes the body without the end-stream envelope.

A client that doesn't check for the terminus will report such a truncated response as success-with-empty-trailers, which is indistinguishable from a complete response. (We hit this in `connect-rust` — anthropics/connect-rust#163 — and noticed the conformance suite didn't catch it.)

## Expected error code

`CODE_INTERNAL` is the primary expectation: it's what `connect-go` reports (the unexpected-EOF path in `connectStreamingClientConn.Receive` wraps `io.ErrUnexpectedEOF` as `CodeInternal`, which `receiveUnaryMessage` surfaces on the second receive). `CODE_UNKNOWN` and `CODE_UNAVAILABLE` are allowed as alternatives, for the same reason the gRPC analog allows `CODE_UNKNOWN` — the spec doesn't mandate a code, and at least one implementation classifies mid-body truncation as a transport-level (`unavailable`) condition. Happy to narrow this if you'd rather pin a single code.

## Verification

Built `connectconformance` and `referenceclient` from this branch and ran the new case:

```
$ connectconformance --conf ./testing/reference-impls-config.yaml --mode client \
    --run '**/client-stream/no-end-stream' -- referenceclient
Total cases: 5
5 passed, 0 failed
```

Full reference-client suite: 15701 cases, all pass (modulo two pre-existing `Duplicate Metadata/.../bidi-stream/half-duplex/error-with-responses` flakes against the `(grpc server impl)` config that pass on rerun and are unrelated to this change).

## Scope

This PR adds the **client-stream** case only. Server-stream and bidi-stream have the same gap, but the expected response there has to decide whether the data message is yielded to the application before the error fires (most implementations yield it; an implementation that requires the end-stream frame before surfacing anything would not). That's a separate discussion — happy to open it as a follow-up issue if this one lands.

Per CONTRIBUTING.md I'm happy to file an issue first if you'd prefer to discuss the shape before reviewing; opening as a draft so the diff is concrete.
